### PR TITLE
feat(phase-2): picker and workspace open

### DIFF
--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -5,10 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
@@ -22,8 +26,11 @@ type pluginManager interface {
 	Get(ctx context.Context, capability string) (any, error)
 }
 
-// errUnexpectedPluginType is returned when the plugin is not the expected client type.
-var errUnexpectedPluginType = errors.New("unexpected plugin type")
+// Sentinel errors.
+var (
+	errUnexpectedPluginType = errors.New("unexpected plugin type")
+	errInvalidProjectKey    = errors.New("invalid project key: must be host/seg1/.../segN")
+)
 
 // NewOpenCmd returns the `swm workspace open` command.
 func NewOpenCmd(
@@ -67,30 +74,242 @@ func NewOpenCmd(
 				return fmt.Errorf("%w: %T", errUnexpectedPluginType, raw)
 			}
 
-			worktreePaths := make(map[string]string, len(st.Projects))
-			for i := range st.Projects {
-				p := &st.Projects[i]
-				pid := &pluginv1.ProjectID{Host: p.Host, Segments: p.Segments}
+			// Attempt to load the picker plugin (optional — no error if absent).
+			var pickerClient pluginv1.PickerClient
 
-				key := p.Host + "/" + strings.Join(p.Segments, "/")
-
-				worktreePaths[key] = resolver.WorktreePath(storyName, pid)
+			if rawPicker, pickErr := mgr.Get(ctx, "picker"); pickErr == nil {
+				if pc, ok := rawPicker.(pluginv1.PickerClient); ok {
+					pickerClient = pc
+				}
 			}
 
-			if _, err := sess.OpenWorkspace(ctx, &pluginv1.OpenWorkspaceRequest{
-				StoryName:     storyName,
-				WorktreePaths: worktreePaths,
-			}); err != nil {
-				return fmt.Errorf("opening workspace: %w", err)
+			if pickerClient != nil {
+				return openWithPicker(ctx, cmd, cfg, st, store, mgr, sess, pickerClient, resolver, storyName)
 			}
 
-			cmd.Printf("workspace opened for story %q\n", storyName)
-
-			return nil
+			return openAllAttached(ctx, cmd, st, sess, resolver, storyName)
 		},
 	}
 
 	cmd.Flags().StringVar(&storyName, "story", "", "story name (default: $SWM_STORY or default story)")
 
 	return cmd
+}
+
+// openWithPicker runs the interactive picker flow: enumerate all candidates, let the
+// user pick one, lazily create the worktree if needed, then open a pane group.
+func openWithPicker(
+	ctx context.Context,
+	cmd *cobra.Command,
+	cfg *config.Config,
+	st *coreStory.Story,
+	store coreStory.Store,
+	mgr pluginManager,
+	sess pluginv1.SessionClient,
+	pickerClient pluginv1.PickerClient,
+	resolver *layout.Resolver,
+	storyName string,
+) error {
+	// Build a deduplicated candidate set: attached projects + all on-disk repos.
+	candidates := buildCandidates(cfg.CodeRoot, st, resolver)
+
+	stream, err := pickerClient.Pick(ctx)
+	if err != nil {
+		return fmt.Errorf("opening picker stream: %w", err)
+	}
+
+	for _, c := range candidates {
+		if err := stream.Send(&pluginv1.PickItem{Key: c, Display: c}); err != nil {
+			return fmt.Errorf("sending candidate to picker: %w", err)
+		}
+	}
+
+	if err := stream.CloseSend(); err != nil {
+		return fmt.Errorf("closing picker send: %w", err)
+	}
+
+	result, err := stream.Recv()
+	if err != nil {
+		if status.Code(err) == codes.Aborted || errors.Is(err, io.EOF) {
+			// User cancelled — exit gracefully.
+			return nil
+		}
+
+		return fmt.Errorf("receiving picker result: %w", err)
+	}
+
+	selectedKey := result.GetKey()
+
+	// Derive the ProjectID from the selected key ("host/seg1/.../segN").
+	pid, err := projectIDFromKey(selectedKey)
+	if err != nil {
+		return fmt.Errorf("parsing selected project key: %w", err)
+	}
+
+	worktreePath := resolver.WorktreePath(storyName, pid)
+
+	// Check whether this project is already attached to the story.
+	if !isAttached(st, selectedKey) {
+		rawVCS, err := mgr.Get(ctx, "vcs")
+		if err != nil {
+			return fmt.Errorf("loading vcs plugin: %w", err)
+		}
+
+		vcs, ok := rawVCS.(pluginv1.VCSClient)
+		if !ok {
+			return fmt.Errorf("%w: %T", errUnexpectedPluginType, rawVCS)
+		}
+
+		if _, err := vcs.CreateWorktree(ctx, &pluginv1.CreateWorktreeRequest{
+			ProjectId:    pid,
+			StoryName:    storyName,
+			BranchName:   st.BranchName,
+			RepoPath:     resolver.CanonicalPath(pid),
+			WorktreePath: worktreePath,
+		}); err != nil {
+			return fmt.Errorf("creating worktree: %w", err)
+		}
+
+		// Attach the project to the story store.
+		st.Projects = append(st.Projects, coreStory.Project{
+			Host:     pid.GetHost(),
+			Segments: pid.GetSegments(),
+		})
+
+		if err := store.Update(ctx, st); err != nil {
+			return fmt.Errorf("attaching project to story: %w", err)
+		}
+	}
+
+	// Ensure the workspace is open.
+	ws, err := sess.OpenWorkspace(ctx, &pluginv1.OpenWorkspaceRequest{
+		StoryName: storyName,
+		WorktreePaths: map[string]string{
+			selectedKey: worktreePath,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("opening workspace: %w", err)
+	}
+
+	pg, err := sess.OpenPaneGroup(ctx, &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  ws.GetWorkspaceId(),
+		ProjectId:    pid,
+		WorktreePath: worktreePath,
+	})
+	if err != nil {
+		return fmt.Errorf("opening pane group: %w", err)
+	}
+
+	if _, err := sess.SwitchTo(ctx, &pluginv1.SwitchToRequest{
+		WorkspaceId: ws.GetWorkspaceId(),
+		PaneGroupId: pg.GetPaneGroupId(),
+	}); err != nil {
+		return fmt.Errorf("switching to pane group: %w", err)
+	}
+
+	cmd.Printf("opened pane group %q in workspace %q\n", pg.GetPaneGroupId(), storyName)
+
+	return nil
+}
+
+// openAllAttached is the Phase 1 fallback: open a workspace with all attached projects.
+func openAllAttached(
+	ctx context.Context,
+	cmd *cobra.Command,
+	st *coreStory.Story,
+	sess pluginv1.SessionClient,
+	resolver *layout.Resolver,
+	storyName string,
+) error {
+	worktreePaths := make(map[string]string, len(st.Projects))
+
+	for i := range st.Projects {
+		p := &st.Projects[i]
+		pid := &pluginv1.ProjectID{Host: p.Host, Segments: p.Segments}
+		key := p.Host + "/" + strings.Join(p.Segments, "/")
+		worktreePaths[key] = resolver.WorktreePath(storyName, pid)
+	}
+
+	if _, err := sess.OpenWorkspace(ctx, &pluginv1.OpenWorkspaceRequest{
+		StoryName:     storyName,
+		WorktreePaths: worktreePaths,
+	}); err != nil {
+		return fmt.Errorf("opening workspace: %w", err)
+	}
+
+	cmd.Printf("workspace opened for story %q\n", storyName)
+
+	return nil
+}
+
+// buildCandidates returns a deduplicated list of project key strings,
+// combining projects already attached to the story with all repositories on disk.
+func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Resolver) []string {
+	seen := make(map[string]struct{})
+
+	var result []string
+
+	addKey := func(key string) {
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			result = append(result, key)
+		}
+	}
+
+	// Attached projects first so they appear at the top of the picker.
+	for i := range st.Projects {
+		p := &st.Projects[i]
+		addKey(p.Host + "/" + strings.Join(p.Segments, "/"))
+	}
+
+	// All on-disk repositories.
+	reposDir := filepath.Join(codeRoot, "repositories")
+
+	//nolint:errcheck // walking the repos dir is best-effort; missing repos are simply excluded
+	_ = filepath.WalkDir(reposDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // skip unreadable entries silently
+		}
+
+		if !d.IsDir() || d.Name() != ".git" {
+			return nil
+		}
+
+		id := resolver.ProjectIDFromPath(filepath.Dir(path))
+		if id == nil {
+			return nil
+		}
+
+		addKey(id.Host + "/" + strings.Join(id.GetSegments(), "/"))
+
+		return filepath.SkipDir
+	})
+
+	return result
+}
+
+// isAttached reports whether the project identified by key is already in the story.
+func isAttached(st *coreStory.Story, key string) bool {
+	for i := range st.Projects {
+		p := &st.Projects[i]
+		if p.Host+"/"+strings.Join(p.Segments, "/") == key {
+			return true
+		}
+	}
+
+	return false
+}
+
+// projectIDFromKey parses a "host/seg1/.../segN" string into a ProjectID.
+func projectIDFromKey(key string) (*pluginv1.ProjectID, error) {
+	parts := strings.SplitN(key, "/", 2) //nolint:mnd // split into host and the rest
+	if len(parts) < 2 {                  //nolint:mnd // need at least host/segment
+		return nil, fmt.Errorf("%q: %w", key, errInvalidProjectKey)
+	}
+
+	return &pluginv1.ProjectID{
+		Host:     parts[0],
+		Segments: strings.Split(parts[1], "/"),
+	}, nil
 }

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
@@ -24,6 +26,7 @@ const (
 	testDefaultStory = "_default"
 	testStoryName    = "feat-x"
 	testStoryFlag    = "--story"
+	testSegment      = "swm"
 )
 
 var errNoPlugin = errors.New("no plugin")
@@ -90,10 +93,120 @@ func TestOpenCmd_NoProjects(t *testing.T) {
 	require.Empty(t, sess.lastOpenReq.GetWorktreePaths())
 }
 
+func TestOpenCmd_WithPicker_ProjectAlreadyAttached(t *testing.T) {
+	t.Parallel()
+
+	const selectedKey = "github.com/kalbasit/swm"
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name: testStoryName,
+		Projects: []coreStory.Project{
+			{Host: "github.com", Segments: []string{"kalbasit", testSegment}},
+		},
+	}}
+	sess := &stubSess{}
+	vcs := &stubVCS{}
+	picker := &stubPickerClient{selectedKey: selectedKey}
+	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
+	resolver := layout.NewResolver(testCodeRoot)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver)
+	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+
+	require.NoError(t, cmd.Execute())
+
+	// Already attached — no CreateWorktree call.
+	require.False(t, vcs.createCalled)
+
+	// Pane group was opened.
+	require.NotNil(t, sess.lastPaneGroupReq)
+	require.Equal(t, selectedKey, sess.lastPaneGroupReq.GetProjectId().GetHost()+"/"+
+		"kalbasit/"+testSegment)
+}
+
+func TestOpenCmd_WithPicker_ProjectNotAttached(t *testing.T) {
+	t.Parallel()
+
+	const selectedKey = "github.com/kalbasit/dotfiles"
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name:       testStoryName,
+		BranchName: "feat/feat-x",
+	}}
+	sess := &stubSess{}
+	vcs := &stubVCS{}
+	picker := &stubPickerClient{selectedKey: selectedKey}
+	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
+	resolver := layout.NewResolver(testCodeRoot)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver)
+	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+
+	require.NoError(t, cmd.Execute())
+
+	// Not attached — CreateWorktree must be called.
+	require.True(t, vcs.createCalled)
+
+	// Story store updated.
+	require.True(t, store.updateCalled)
+
+	// Pane group was opened.
+	require.NotNil(t, sess.lastPaneGroupReq)
+}
+
+func TestOpenCmd_WithPicker_Cancelled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
+	sess := &stubSess{}
+	vcs := &stubVCS{}
+	// Picker returns Aborted (user pressed Escape).
+	picker := &stubPickerClient{cancelOnRecv: true}
+	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
+	resolver := layout.NewResolver(testCodeRoot)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver)
+	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+
+	// Cancellation is not an error.
+	require.NoError(t, cmd.Execute())
+	require.Nil(t, sess.lastPaneGroupReq)
+}
+
+func TestOpenCmd_NoPicker_FallsBackToPhase1(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name: testStoryName,
+		Projects: []coreStory.Project{
+			{Host: "github.com", Segments: []string{"kalbasit", "swm"}},
+		},
+	}}
+	sess := &stubSess{}
+	mgr := &stubMgr{sess: sess} // no picker configured
+	resolver := layout.NewResolver(testCodeRoot)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver)
+	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+
+	require.NoError(t, cmd.Execute())
+
+	// Phase 1 path: OpenWorkspace with all attached projects.
+	require.NotNil(t, sess.lastOpenReq)
+	require.Contains(t, sess.lastOpenReq.GetWorktreePaths(), "github.com/kalbasit/swm")
+}
+
+// ─── stubs ───────────────────────────────────────────────────────────────────
+
 // stubStore is a minimal story.Store.
 type stubStore struct {
-	getStory *coreStory.Story
-	getErr   error
+	getStory     *coreStory.Story
+	getErr       error
+	updateCalled bool
 }
 
 func (s *stubStore) Create(context.Context, string, string) (*coreStory.Story, error) {
@@ -116,26 +229,44 @@ func (s *stubStore) Get(_ context.Context, _ string) (*coreStory.Story, error) {
 
 func (s *stubStore) List(context.Context) ([]*coreStory.Story, error) { return nil, nil }
 
-func (s *stubStore) Update(context.Context, *coreStory.Story) error { return nil }
+func (s *stubStore) Update(_ context.Context, _ *coreStory.Story) error {
+	s.updateCalled = true
+
+	return nil
+}
 
 var _ coreStory.Store = (*stubStore)(nil)
 
 // stubMgr implements pluginManager.
 type stubMgr struct {
-	sess pluginv1.SessionClient
+	sess   pluginv1.SessionClient
+	vcs    pluginv1.VCSClient
+	picker pluginv1.PickerClient
 }
 
 func (s *stubMgr) Get(_ context.Context, capability string) (any, error) {
-	if capability == "session" && s.sess != nil {
-		return s.sess, nil
+	switch capability {
+	case "session":
+		if s.sess != nil {
+			return s.sess, nil
+		}
+	case "vcs":
+		if s.vcs != nil {
+			return s.vcs, nil
+		}
+	case "picker":
+		if s.picker != nil {
+			return s.picker, nil
+		}
 	}
 
 	return nil, fmt.Errorf("%w: %s", errNoPlugin, capability)
 }
 
-// stubSess records OpenWorkspace calls.
+// stubSess records session plugin calls.
 type stubSess struct {
-	lastOpenReq *pluginv1.OpenWorkspaceRequest
+	lastOpenReq      *pluginv1.OpenWorkspaceRequest
+	lastPaneGroupReq *pluginv1.OpenPaneGroupRequest
 }
 
 func (s *stubSess) CloseWorkspace(
@@ -179,11 +310,16 @@ func (s *stubSess) ListWorkspaces(
 }
 
 func (s *stubSess) OpenPaneGroup(
-	context.Context,
-	*pluginv1.OpenPaneGroupRequest,
-	...grpc.CallOption,
+	_ context.Context,
+	req *pluginv1.OpenPaneGroupRequest,
+	_ ...grpc.CallOption,
 ) (*pluginv1.PaneGroup, error) {
-	panic("stub")
+	s.lastPaneGroupReq = req
+
+	return &pluginv1.PaneGroup{
+		PaneGroupId: "swm",
+		WorkspaceId: req.GetWorkspaceId(),
+	}, nil
 }
 
 func (s *stubSess) OpenWorkspace(
@@ -193,7 +329,10 @@ func (s *stubSess) OpenWorkspace(
 ) (*pluginv1.Workspace, error) {
 	s.lastOpenReq = req
 
-	return &pluginv1.Workspace{StoryName: req.GetStoryName()}, nil
+	return &pluginv1.Workspace{
+		WorkspaceId: "/tmp/feat-x.sock",
+		StoryName:   req.GetStoryName(),
+	}, nil
 }
 
 func (s *stubSess) SwitchTo(
@@ -201,11 +340,127 @@ func (s *stubSess) SwitchTo(
 	*pluginv1.SwitchToRequest,
 	...grpc.CallOption,
 ) (*pluginv1.Empty, error) {
-	panic("stub")
+	return &pluginv1.Empty{}, nil
 }
 
 var _ pluginv1.SessionClient = (*stubSess)(nil)
 
+// stubVCS records CreateWorktree calls.
+type stubVCS struct {
+	createCalled bool
+}
+
+func (v *stubVCS) Clone(context.Context, *pluginv1.CloneRequest, ...grpc.CallOption) (*pluginv1.CloneResponse, error) {
+	panic("stub")
+}
+
+func (v *stubVCS) CreateWorktree(
+	_ context.Context,
+	_ *pluginv1.CreateWorktreeRequest,
+	_ ...grpc.CallOption,
+) (*pluginv1.Empty, error) {
+	v.createCalled = true
+
+	return &pluginv1.Empty{}, nil
+}
+
+func (v *stubVCS) DetectProjectAtPath(
+	context.Context,
+	*pluginv1.DetectAtPathRequest,
+	...grpc.CallOption,
+) (*pluginv1.ProjectID, error) {
+	panic("stub")
+}
+
+func (v *stubVCS) Info(context.Context, *pluginv1.Empty, ...grpc.CallOption) (*pluginv1.VCSInfo, error) {
+	panic("stub")
+}
+
+func (v *stubVCS) ListBranches(
+	context.Context,
+	*pluginv1.ListBranchesRequest,
+	...grpc.CallOption,
+) (grpc.ServerStreamingClient[pluginv1.Branch], error) {
+	panic("stub")
+}
+
+func (v *stubVCS) ParseRemoteURL(
+	context.Context,
+	*pluginv1.ParseRemoteURLRequest,
+	...grpc.CallOption,
+) (*pluginv1.ProjectID, error) {
+	panic("stub")
+}
+
+func (v *stubVCS) RemoveWorktree(
+	context.Context,
+	*pluginv1.RemoveWorktreeRequest,
+	...grpc.CallOption,
+) (*pluginv1.Empty, error) {
+	panic("stub")
+}
+
+var _ pluginv1.VCSClient = (*stubVCS)(nil)
+
+// stubPickerClient implements pluginv1.PickerClient.
+type stubPickerClient struct {
+	selectedKey  string
+	cancelOnRecv bool
+}
+
+func (p *stubPickerClient) Info(
+	context.Context,
+	*pluginv1.Empty,
+	...grpc.CallOption,
+) (*pluginv1.PickerInfo, error) {
+	return &pluginv1.PickerInfo{PluginInfo: &pluginv1.PluginInfo{Name: "stub"}}, nil
+}
+
+func (p *stubPickerClient) Pick(
+	_ context.Context,
+	_ ...grpc.CallOption,
+) (grpc.BidiStreamingClient[pluginv1.PickItem, pluginv1.PickResult], error) {
+	return &stubPickStream{selectedKey: p.selectedKey, cancel: p.cancelOnRecv}, nil
+}
+
+var _ pluginv1.PickerClient = (*stubPickerClient)(nil)
+
+// stubPickStream implements grpc.BidiStreamingClient[PickItem, PickResult].
+type stubPickStream struct {
+	selectedKey string
+	cancel      bool
+	recvCalled  bool
+}
+
+func (s *stubPickStream) CloseSend() error { return nil }
+
+func (s *stubPickStream) Context() context.Context { return context.Background() }
+
+func (s *stubPickStream) Header() (metadata.MD, error) { panic("stub") }
+
+func (s *stubPickStream) Recv() (*pluginv1.PickResult, error) {
+	if s.recvCalled {
+		return nil, io.EOF
+	}
+
+	s.recvCalled = true
+
+	if s.cancel {
+		return nil, status.Error(codes.Aborted, "cancelled")
+	}
+
+	return &pluginv1.PickResult{Key: s.selectedKey}, nil
+}
+
+func (s *stubPickStream) RecvMsg(any) error { return nil }
+
+func (s *stubPickStream) Send(*pluginv1.PickItem) error { return nil }
+
+func (s *stubPickStream) SendMsg(any) error { return nil }
+
+func (s *stubPickStream) Trailer() metadata.MD { return nil }
+
+// eofStream is a server stream that immediately returns io.EOF.
 type eofStream struct{}
 
 func (e *eofStream) CloseSend() error                   { return nil }

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -14,6 +14,7 @@ import (
 
 	goplugin "github.com/hashicorp/go-plugin"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+	sdkpicker "github.com/kalbasit/swm/sdk/go/picker"
 	sdksession "github.com/kalbasit/swm/sdk/go/session"
 	sdkvcs "github.com/kalbasit/swm/sdk/go/vcs"
 
@@ -225,6 +226,15 @@ func (m *Manager) validateDeps(ctx context.Context, capability string, raw any) 
 
 			info = resp.GetPluginInfo()
 		}
+	case capabilityPicker:
+		if c, ok := raw.(pluginv1.PickerClient); ok {
+			resp, err := c.Info(ctx, &pluginv1.Empty{})
+			if err != nil {
+				return fmt.Errorf("calling Info on picker plugin: %w", err)
+			}
+
+			info = resp.GetPluginInfo()
+		}
 	}
 
 	if info == nil {
@@ -244,6 +254,8 @@ func (m *Manager) validateDeps(ctx context.Context, capability string, raw any) 
 // pluginSet returns the go-plugin PluginSet for the given capability.
 func pluginSet(capability string) goplugin.PluginSet {
 	switch capability {
+	case capabilityPicker:
+		return goplugin.PluginSet{capabilityPicker: &sdkpicker.GRPCPlugin{}}
 	case capabilitySession:
 		return goplugin.PluginSet{capabilitySession: &sdksession.GRPCPlugin{}}
 	case capabilityVCS:

--- a/cmd/swm/tests/integration/integration_test.go
+++ b/cmd/swm/tests/integration/integration_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kalbasit/swm/cmd/swm/internal/pluginmgr"
 )
 
+const pickerPluginName = "fzf"
+
 const (
 	vcsPluginName     = "git"
 	sessionPluginName = "tmux"
@@ -142,6 +144,77 @@ func TestStoryRemove(t *testing.T) {
 	// Story should be gone.
 	_, err = store.Get(t.Context(), testStoryName)
 	require.Error(t, err)
+}
+
+func TestWorkspaceOpenWithPicker(t *testing.T) {
+	// Override PATH so session-tmux finds faketmux as "tmux" and
+	// picker-fzf finds fakefzf as "fzf".
+	if _, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err != nil {
+		t.Skip("no TTY available; skipping picker integration test")
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", filepath.Dir(faketmuxBin)+":"+oldPath) // faketmuxBin IS named "tmux"
+	// fakefzfBin is already named "fzf" in tmpDir, which is the same dir as faketmuxBin.
+
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	// Set up config with both session and picker plugins.
+	codeRoot := t.TempDir()
+	storiesDir := filepath.Join(t.TempDir(), "stories")
+	require.NoError(t, os.MkdirAll(storiesDir, 0o750))
+
+	cfg := &config.Config{
+		CodeRoot:     codeRoot,
+		DefaultStory: "_default",
+		Plugins: config.Plugins{
+			VCS:     vcsPluginName,
+			Session: sessionPluginName,
+			Picker:  pickerPluginName,
+			Paths: map[string]string{
+				vcsPluginName:     vcsGitBin,
+				sessionPluginName: sessionTmuxBin,
+				pickerPluginName:  pickerFzfBin,
+			},
+		},
+	}
+
+	store := story.NewJSONStore(storiesDir)
+	resolver := layout.NewResolver(codeRoot)
+
+	srv, err := hostsvc.NewServer(cfg, resolver, store)
+	require.NoError(t, err)
+
+	t.Cleanup(srv.Stop)
+
+	mgr := pluginmgr.New(cfg, srv.SocketPath())
+
+	t.Cleanup(func() { mgr.Close() }) //nolint:errcheck,gosec // best-effort in test cleanup
+
+	// Clone a local repo so it appears in the candidate list.
+	srcRepo := initLocalRepo(t)
+	fileURL := "file://" + srcRepo
+
+	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root.SetArgs([]string{"clone", fileURL})
+	require.NoError(t, root.Execute())
+
+	// Create a story with no projects yet (lazy attach will happen).
+	_, err = store.Create(t.Context(), testStoryName, "feat/"+testStoryName)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+
+	root2 := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root2.SetArgs([]string{"workspace", "open", "--story", testStoryName})
+	root2.SetOut(&buf)
+	require.NoError(t, root2.Execute())
+
+	// Verify that faketmux received a new-session call (pane group opened).
+	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+	require.Contains(t, string(logBytes), "new-session", "expected new-session in faketmux log")
 }
 
 func TestWorkspaceOpen(t *testing.T) {

--- a/cmd/swm/tests/integration/main_test.go
+++ b/cmd/swm/tests/integration/main_test.go
@@ -15,6 +15,8 @@ var (
 	vcsGitBin      string
 	sessionTmuxBin string
 	faketmuxBin    string
+	pickerFzfBin   string
+	fakefzfBin     string
 )
 
 func TestMain(m *testing.M) {
@@ -46,6 +48,20 @@ func TestMain(m *testing.M) {
 	faketmuxSrc := filepath.Join(repoRoot, "plugins/session-tmux/internal/session/testdata/faketmux")
 	if err := buildBin(repoRoot, faketmuxBin, faketmuxSrc); err != nil {
 		panic("build faketmux: " + err.Error())
+	}
+
+	// Compile picker-fzf plugin.
+	pickerFzfBin = filepath.Join(tmpDir, "swm-plugin-picker-fzf")
+	if err := buildBin(repoRoot, pickerFzfBin, filepath.Join(repoRoot, "plugins/picker-fzf")); err != nil {
+		panic("build picker-fzf: " + err.Error())
+	}
+
+	// Compile fakefzf binary (used as "fzf" in the picker integration test).
+	fakefzfBin = filepath.Join(tmpDir, "fzf")
+
+	fakefzfSrc := filepath.Join(repoRoot, "plugins/picker-fzf/internal/picker/testdata/fakefzf")
+	if err := buildBin(repoRoot, fakefzfBin, fakefzfSrc); err != nil {
+		panic("build fakefzf: " + err.Error())
 	}
 
 	os.Exit(m.Run())

--- a/openspec/changes/phase-2-picker-fzf/.openspec.yaml
+++ b/openspec/changes/phase-2-picker-fzf/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/phase-2-picker-fzf/design.md
+++ b/openspec/changes/phase-2-picker-fzf/design.md
@@ -1,0 +1,98 @@
+## Context
+
+Phase 1 shipped a `workspace open` command that opens a workspace for all projects
+already attached to a story. The v1 experience users expect is interactive: fzf pops
+up, you pick a project, swm lazily creates a worktree if needed and opens a pane
+group. Phase 2 delivers that experience through the `Picker` gRPC capability defined
+in `proto/swm/plugin/v1/picker.proto`.
+
+The `Pick` RPC is bidirectional streaming (host streams candidates in, plugin streams
+selections out), which is the correct model for incremental filtering tools like fzf.
+The `sdk/go/picker` package exists as a stub; Phase 2 wires it up the same way
+session/vcs were wired in Phase 1.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Working `picker-fzf` plugin that wraps fzf with the `Picker.Pick` bidirectional RPC.
+- `workspace open` gains interactive project selection when a picker is configured.
+- Lazy worktree creation: if the selected project isn't in the story yet, the host
+  calls `vcs.CreateWorktree` and updates the story store before opening the pane group.
+- `pane_group_command` implemented in session-tmux (it was spec'd in Phase 1 but not coded).
+- Picker is optional: without a picker plugin configured, `workspace open` retains the
+  Phase 1 behaviour (opens workspace for all attached projects).
+
+**Non-Goals:**
+- `host.CallCapability` RPC — session-tmux doesn't need cross-plugin calls for Phase 2;
+  the host already derives worktree paths and passes them directly. Deferred to Phase 3.
+- Multi-select in the picker (single-select only for `workspace open`).
+- Any forge or hook wiring.
+
+## Decisions
+
+### fzf subprocess TTY handling
+**Decision:** Run fzf with `/dev/tty` as its stdin and stdout (`os.Stdin = /dev/tty`,
+`os.Stdout = /dev/tty`), passing candidates via pipe. The plugin receives `PickItem`
+messages from the gRPC stream, accumulates them, then launches fzf with candidates
+on stdin; after selection fzf exits and the plugin streams a single `PickResult` back.
+
+**Why:** fzf is a TUI process that requires a real TTY for rendering. Piping through
+gRPC without a TTY attachment would produce no output. Attaching `/dev/tty` directly
+is the standard approach (used by git, vim, etc.) and works in terminals launched by
+swm (where a TTY is always present).
+
+**Alternative considered:** Named pipe bridging with a pty — significantly more complex,
+requires a pty library, and adds failure modes. Not worth it for the straightforward
+single-selection use case.
+
+### Picker invocation in workspace open
+**Decision:** The host accumulates candidates from `hostsvc.ListProjects` (all repos
+under the code root), streams them to the picker, receives the selection, then derives
+the worktree path and calls `session.OpenPaneGroup`. If the project is not yet attached
+to the story, the host inserts the CreateWorktree+story-update steps first.
+
+**Why:** This keeps the picker invocation entirely in the host, which already has access
+to the code root, the story store, and both plugins. The plugin never needs to know about
+story state or filesystem layout — that knowledge stays in the host.
+
+**Alternative considered:** Passing worktree paths to the session plugin and letting it
+decide whether to use a picker. Rejected: session plugins shouldn't drive story/project
+logic; that's host domain.
+
+### Picker-absent fallback
+**Decision:** When no picker plugin is configured, `workspace open` skips the
+interactive step entirely and calls `session.OpenWorkspace` with all attached projects'
+worktree paths (the Phase 1 behaviour), exactly as today.
+
+**Why:** Keeps the UX predictable in headless/CI environments and for users who prefer
+a simpler workflow. The behaviour degrades gracefully.
+
+### pane_group_command implementation
+**Decision:** session-tmux reads `pane_group_command` from its config block (via
+`host.GetConfig` already wired in Phase 1). Template variables (`{{worktree_path}}`,
+`{{story_name}}`, `{{project_id}}`) are substituted with `strings.ReplaceAll` before
+the command is passed as the initial-command to `tmux new-session -c`.
+
+**Why:** The spec (Phase 1 `session-tmux/spec.md`) already describes this behaviour;
+Phase 2 is purely implementing it. `strings.ReplaceAll` is simpler than `text/template`
+for the constrained variable set and avoids template parse errors from user-supplied
+strings with `{{` in other contexts.
+
+## Risks / Trade-offs
+
+- **TTY availability:** If swm is invoked in a context with no TTY (CI, pipe, `swm ...
+  | other`), the fzf subprocess will fail to start. Mitigation: detect `os.Stdin` is
+  not a TTY and fall back to the no-picker path (returning an error that the host can
+  handle gracefully).
+- **Large candidate sets:** streaming thousands of `PickItem` messages before launching
+  fzf adds latency. Mitigation: fzf supports incremental input; we can pipe directly
+  rather than accumulating first, but that requires a more complex goroutine setup.
+  For Phase 2, accumulate-then-launch is acceptable; the optimisation can come later.
+- **pane_group_command injection:** user-provided command strings run as-is in tmux.
+  This is intentional (user controls their own config) and consistent with how tools
+  like smug/tmuxinator work.
+
+## Open Questions
+
+None blocking Phase 2. `host.CallCapability` design can wait for Phase 3 when forge
+plugins need to call back into the vcs capability.

--- a/openspec/changes/phase-2-picker-fzf/proposal.md
+++ b/openspec/changes/phase-2-picker-fzf/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Phase 1 shipped `swm workspace open --story <name>` as a fixed-flow command that
+opens a workspace for all currently-attached projects with no interactive selection.
+The v1 UX — which users depend on daily — lets you pick a project interactively
+using fzf, then lazily creates a worktree if that project isn't yet attached to
+the story. Phase 2 restores that interactive picker flow and delivers the `picker-fzf`
+plugin that drives it (see TDD §7.4 and TDD §6.3).
+
+## What Changes
+
+- Implement `plugins/picker-fzf`: a fully functional `swm-plugin-picker-fzf` binary
+  that wraps `fzf` via bidirectional gRPC streaming (`Pick` RPC).
+- Implement `sdk/go/picker` Serve helper (currently a stub with no `GRPCPlugin` wiring).
+- Wire the picker into `swm workspace open`: enumerate candidates (attached projects
+  + all repositories on disk), stream them to the picker plugin, then open or lazily
+  create a pane group for the selected project.
+- Add `pane_group_command` config support to `session-tmux` so users can substitute
+  laio, smug, or any other layout manager (see TDD §6.3 session capability).
+- Extend `hostsvc` with `CallCapability` so the session plugin can delegate VCS
+  lookups to the host rather than coupling directly.
+
+## Capabilities
+
+### New Capabilities
+
+- `picker-fzf`: fzf-backed implementation of the `Picker` gRPC service; streams
+  candidates in, streams selection out; supports multi-select.
+
+### Modified Capabilities
+
+- `workspace-open`: interactive project selection via picker plugin; lazy worktree
+  creation for newly selected projects; falls back to listing all attached projects
+  when no picker is configured.
+- `session-tmux`: add `pane_group_command` config key; when set, run the command
+  (with `{{worktree_path}}`, `{{story_name}}`, `{{project_id}}` template vars) instead
+  of the default shell+editor pane layout.
+
+## Impact
+
+- `plugins/picker-fzf/`: new module and binary.
+- `sdk/go/picker/`: replace stub `GRPCPlugin` with real wiring (mirrors session/vcs done in Phase 1).
+- `cmd/swm/internal/cli/workspace/open.go`: add picker integration and lazy-worktree logic.
+- `cmd/swm/internal/hostsvc/server.go`: add `CallCapability` RPC implementation.
+- `plugins/session-tmux/internal/session/tmux.go`: add `pane_group_command` support.
+- `cmd/swm/internal/pluginmgr/manager.go`: add picker capability to discovery and validation.
+- Proto: no new RPCs — `Picker.Pick` and `Host.CallCapability` are already defined in
+  `proto/swm/plugin/v1/`; only the host-side `CallCapability` implementation is missing.
+
+## Non-goals
+
+- Implementing any picker plugin other than fzf.
+- `swm plugin install` command (Phase 4).
+- Hooks for worktree-create events triggered by lazy attachment (Phase 3).
+- Forge integration or PR listing in the picker (Phase 3).

--- a/openspec/changes/phase-2-picker-fzf/specs/picker-fzf/spec.md
+++ b/openspec/changes/phase-2-picker-fzf/specs/picker-fzf/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Picker.Pick bidirectional streaming RPC
+The `picker-fzf` plugin SHALL implement the `Picker.Pick` bidirectional gRPC streaming RPC. The host streams `PickItem` messages (each with a `display` string and an opaque `id`), and the plugin streams back a single `PickResult` message containing the `id` of the item the user selected.
+
+#### Scenario: Single item selected
+- **WHEN** the host streams five `PickItem` messages and the user selects one item in fzf
+- **THEN** the plugin streams exactly one `PickResult` with the `id` of the selected item and closes the response stream
+
+#### Scenario: User cancels (no selection)
+- **WHEN** the host streams candidates and the user presses `Escape` or `Ctrl-C` in fzf
+- **THEN** the plugin returns a gRPC `Aborted` status and streams no `PickResult`
+
+### Requirement: fzf subprocess with TTY attachment
+The `picker-fzf` plugin SHALL launch fzf as a subprocess with `/dev/tty` opened as both stdin and stdout, so that the fzf TUI renders in the user's terminal. Candidates received from the gRPC stream SHALL be accumulated in memory and written to fzf's stdin pipe before fzf is launched.
+
+#### Scenario: fzf renders in terminal
+- **WHEN** `Pick` is called with a non-empty candidate list in a terminal with a valid TTY
+- **THEN** the fzf interactive selector is displayed in the terminal and the user can navigate and select items
+
+#### Scenario: Non-TTY fallback
+- **WHEN** `Pick` is called in an environment where `/dev/tty` cannot be opened (e.g., CI, pipe)
+- **THEN** the plugin returns a gRPC `FailedPrecondition` status with a message indicating no TTY is available
+
+### Requirement: Info RPC declares picker capability
+The `picker-fzf` plugin SHALL implement the `Info` RPC, returning a `PickerInfo` with `plugin_info.name = "fzf"`, the build version, and no required or optional capability dependencies.
+
+#### Scenario: Info response
+- **WHEN** the host calls `Info()` on the picker-fzf plugin
+- **THEN** a `PickerInfo` is returned with `plugin_info.name = "fzf"`

--- a/openspec/changes/phase-2-picker-fzf/specs/workflow-commands/spec.md
+++ b/openspec/changes/phase-2-picker-fzf/specs/workflow-commands/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: swm workspace open
+`swm workspace open [--story <name>]` SHALL open (or switch to) the tmux workspace for a story. The flow depends on whether a picker plugin is configured:
+
+**With picker configured:**
+1. Resolve story from `--story` flag, `$SWM_STORY` env var, or `_default`.
+2. Build a candidate list: all projects already attached to the story plus all repositories discovered under `$CODE_ROOT/repositories/` via `host.ListProjects`.
+3. Stream candidates to `picker.Pick`; each candidate's `display` is its project ID string (e.g. `github.com/kalbasit/swm`) and `id` is the same string.
+4. Receive the selected project ID from the picker.
+5. If the selected project is NOT already attached to the story: call `vcs.CreateWorktree` for that project and attach it to the story in the story store.
+6. Call `session.OpenPaneGroup` with the derived worktree path for the selected project.
+
+**Without picker configured (fallback):**
+1. Resolve story.
+2. Load all attached projects from the story store.
+3. Call `session.OpenWorkspace({story_name, worktree_paths: [derived paths for each project]})`.
+4. If the workspace was already open, call `session.SwitchTo` for the first pane group.
+
+#### Scenario: Interactive selection with picker — project already attached
+- **WHEN** `swm workspace open --story feat-x` is run, a picker is configured, and the user selects a project already attached to `feat-x`
+- **THEN** `picker.Pick` is called with all candidates, `session.OpenPaneGroup` is called with the selected project's worktree path, and no `vcs.CreateWorktree` call is made
+
+#### Scenario: Interactive selection with picker — project not yet attached
+- **WHEN** `swm workspace open --story feat-x` is run, a picker is configured, and the user selects a project NOT yet attached to `feat-x`
+- **THEN** `vcs.CreateWorktree` is called for the selected project, the project is recorded in the story store, and `session.OpenPaneGroup` is called with the new worktree path
+
+#### Scenario: Picker cancelled by user
+- **WHEN** `swm workspace open --story feat-x` is run, a picker is configured, and the user cancels the picker (Escape / Ctrl-C)
+- **THEN** the command exits 0 with no workspace changes and no error message to the user
+
+#### Scenario: No picker configured — opens all attached projects
+- **WHEN** `swm workspace open --story feat-x` is run and no picker plugin is configured
+- **THEN** `session.OpenWorkspace` is called with all projects attached to `feat-x` (Phase 1 behaviour)
+
+#### Scenario: Story from environment
+- **WHEN** `swm workspace open` is run with `$SWM_STORY=feat-x` set
+- **THEN** the workspace for `feat-x` is opened (same as `--story feat-x`)
+
+#### Scenario: Default story
+- **WHEN** `swm workspace open` is run with no `--story` flag and no `$SWM_STORY`
+- **THEN** the workspace for the `_default` story is opened
+
+#### Scenario: Story not found
+- **WHEN** `swm workspace open --story nonexistent` is run
+- **THEN** the command exits non-zero with an error indicating the story was not found
+
+#### Scenario: Story with no projects and no picker
+- **WHEN** `swm workspace open --story feat-x` is run, no picker is configured, and `feat-x` has no attached projects
+- **THEN** `session.OpenWorkspace` is called with an empty `worktree_paths` list; the session plugin opens an empty workspace

--- a/openspec/changes/phase-2-picker-fzf/tasks.md
+++ b/openspec/changes/phase-2-picker-fzf/tasks.md
@@ -1,0 +1,43 @@
+## 1. SDK — Picker GRPCPlugin (sdk/go)
+
+- [x] 1.1 Replace the stub `Serve` in `sdk/go/picker/plugin.go` with a real `GRPCPlugin` struct (embedding `goplugin.NetRPCUnsupportedPlugin`, with `GRPCClient` returning `pluginv1.NewPickerClient(conn)` and `GRPCServer` registering `pluginv1.RegisterPickerServer`); update `Serve(impl Plugin)` to call `goplugin.Serve` with the registered plugin map; add `NewClient(conn *grpc.ClientConn) Plugin` constructor; remove `ErrNotImplemented` (`sdk/go` module)
+- [x] 1.2 Write unit tests in `sdk/go/picker/plugin_test.go` verifying the handshake config fields match `sdk/go/handshake` constants (`sdk/go` module)
+- [x] 1.3 Run `task sdk:test` → confirm exits 0
+
+## 2. Plugin Manager — Wire Picker Capability (cmd/swm)
+
+- [x] 2.1 Add `sdkpicker "github.com/kalbasit/swm/sdk/go/picker"` import to `cmd/swm/internal/pluginmgr/manager.go`; update `pluginSet` to handle `capabilityPicker` → `goplugin.PluginSet{capabilityPicker: &sdkpicker.GRPCPlugin{}}`; update `validateDeps` to handle `capabilityPicker` (call `Info()` and validate `plugin_info`) (`cmd/swm` module)
+- [x] 2.2 Run `task swm:test` → confirm exits 0
+
+## 3. picker-fzf Plugin (plugins/picker-fzf)
+
+- [x] 3.1 Add deps to `plugins/picker-fzf/go.mod`: `github.com/kalbasit/swm/sdk/go`, `github.com/kalbasit/swm/proto`, `google.golang.org/grpc`, `github.com/hashicorp/go-plugin`; run `go mod tidy`; add `replace` directives for local modules; add `plugins/picker-fzf` to `go.work` (`plugins/picker-fzf` module)
+- [x] 3.2 Create `plugins/picker-fzf/internal/picker/fzf.go`: `Fzf` struct implementing `pluginv1.PickerServer`; `New() *Fzf` constructor; implement `Info` returning `PickerInfo{plugin_info: {name: "fzf", version: buildVersion}}` (`plugins/picker-fzf` module)
+- [x] 3.3 Implement `Fzf.Pick(stream grpc.BidiStreamingServer[PickItem, PickResult]) error`: (1) receive all `PickItem` messages from the host stream, accumulating keys and display strings; (2) open `/dev/tty` for both stdin and stdout — if `/dev/tty` cannot be opened, return gRPC `FailedPrecondition`; (3) pipe accumulated candidates as `<key>\t<display>\n` to fzf's stdin with `--with-nth=2` so display is shown; (4) after fzf exits, parse its stdout for the selected key; (5) if fzf exits non-zero (user cancelled), return gRPC `Aborted`; (6) stream one `PickResult{key: selectedKey}` and close (`plugins/picker-fzf` module)
+- [x] 3.4 Update `plugins/picker-fzf/main.go`: import `sdkpicker` and `internal/picker`; call `sdkpicker.Serve(&picker.Fzf{})` instead of `fmt.Println` stub; set `buildVersion` via ldflags (`plugins/picker-fzf` module)
+- [x] 3.5 Create `plugins/picker-fzf/internal/picker/fzf_test.go`: write tests using a fake `fzf` binary compiled from `testdata/fakefzf/`; cover: successful single selection, user cancellation (fake fzf exits 1), no-TTY error path (`plugins/picker-fzf` module)
+- [x] 3.6 Run `task picker-fzf:test` → confirm exits 0
+
+## 4. session-tmux — pane_group_command (plugins/session-tmux)
+
+- [x] 4.1 Add `hostClient pluginv1.HostClient` field to `Tmux` struct; update `New()` to read `SWM_HOST_SOCKET` env var, dial the Unix socket via `grpc.NewClient("unix://"+socketPath, grpc.WithTransportCredentials(insecure.NewCredentials()))`, and store `pluginv1.NewHostClient(conn)` on the struct; store the `*grpc.ClientConn` for cleanup too; add `Close() error` method to `Tmux` that closes the gRPC connection (`plugins/session-tmux` module)
+- [x] 4.2 Update `OpenPaneGroup`: if `hostClient` is non-nil, call `hostClient.GetConfig(ctx, &pluginv1.GetConfigRequest{PluginName: "tmux"})`; unmarshal the returned TOML bytes into a struct with a `PaneGroupCommand string \`toml:"pane_group_command"\`` field; if `pane_group_command` is set, substitute `{{worktree_path}}`, `{{story_name}}`, and `{{project_id}}` via `strings.ReplaceAll` and pass the result as the `-c` argument to `tmux new-session`; if not set, default to `$SHELL` (`plugins/session-tmux` module)
+- [x] 4.3 Update `plugins/session-tmux/main.go`: call `t.Close()` on process exit (defer after `session.New()` succeeds) (`plugins/session-tmux` module)
+- [x] 4.4 Add tests in `tmux_test.go` for `OpenPaneGroup` with `pane_group_command` set: inject a fake host client that returns TOML config with `pane_group_command = "laio start --config {{worktree_path}}/.swm/laio.yaml"` and verify the faketmux receives the substituted command (`plugins/session-tmux` module)
+- [x] 4.5 Run `task session-tmux:test` → confirm exits 0
+
+## 5. workspace open — Picker Integration and Lazy Worktree (cmd/swm)
+
+- [x] 5.1 Refactor `open.go` to extract a `listAllProjects(codeRoot string) ([]*pluginv1.ProjectID, error)` helper that walks `<codeRoot>/repositories/` and returns a `ProjectID` for each discovered repository directory (same logic as `hostsvc.ListProjects`) (`cmd/swm` module)
+- [x] 5.2 In `open.go` `RunE`, after resolving the story, attempt `mgr.Get(ctx, "picker")` — if it succeeds and the returned client is a `pluginv1.PickerClient`, assign it; if `mgr.Get` returns `errNoPickerPlugin` or a type-assertion failure, leave the picker nil and fall through to the Phase 1 path (`cmd/swm` module)
+- [x] 5.3 Implement picker path in `RunE`: (1) call `listAllProjects(cfg.CodeRoot)` and merge with already-attached projects to form a deduplicated candidate list; (2) open a `picker.Pick` stream; (3) send each candidate as a `PickItem{key: projectIDString, display: projectIDString}`; (4) close the send side; (5) receive one `PickResult` — if the stream returns `Aborted`, print nothing and return nil; if any other error, return it wrapped (`cmd/swm` module)
+- [x] 5.4 After receiving a `PickResult`, derive the `ProjectID` from the key; check if the project is already attached to the story; if not: call `vcs.CreateWorktree` for the project (using the story's branch name and the resolver-derived paths), then call `store.Update` to attach the project to the story (`cmd/swm` module)
+- [x] 5.5 After lazy-attach (or if already attached), call `sess.OpenPaneGroup(ctx, &pluginv1.OpenPaneGroupRequest{WorkspaceId: ws.WorkspaceId, ProjectId: pid, WorktreePath: worktreePath})` for the selected project; then call `sess.SwitchTo` to bring it into focus (`cmd/swm` module)
+- [x] 5.6 Update `open_test.go`: add test cases for picker path (stub picker returning a fixed `PickResult`), lazy worktree creation path (stub vcs + store), and picker-absent fallback (Phase 1 path still works) (`cmd/swm` module)
+
+## 6. Integration and Final Verification
+
+- [x] 6.1 Add `plugins/picker-fzf` binary compilation to `cmd/swm/tests/integration/integration_test.go` `TestMain`; write `TestWorkspaceOpenWithPicker` using a fake fzf binary that echoes the first candidate, verifying `OpenPaneGroup` is called with correct worktree path (`cmd/swm` module)
+- [x] 6.2 Run `task fmt` → confirm exits 0
+- [x] 6.3 Run `task lint` → confirm exits 0
+- [x] 6.4 Run `task test` → confirm exits 0

--- a/plugins/picker-fzf/go.mod
+++ b/plugins/picker-fzf/go.mod
@@ -1,3 +1,30 @@
 module github.com/kalbasit/swm/plugins/picker-fzf
 
 go 1.26.2
+
+replace (
+	github.com/kalbasit/swm/proto => ../../proto
+	github.com/kalbasit/swm/sdk/go => ../../sdk/go
+)
+
+require (
+	github.com/kalbasit/swm/proto v0.0.0
+	github.com/kalbasit/swm/sdk/go v0.0.0-00010101000000-000000000000
+	google.golang.org/grpc v1.81.1
+)
+
+require (
+	github.com/fatih/color v1.13.0 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
+	github.com/hashicorp/go-plugin v1.8.0 // indirect
+	github.com/hashicorp/yamux v0.1.2 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/oklog/run v1.1.0 // indirect
+	golang.org/x/net v0.51.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/text v0.34.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+)

--- a/plugins/picker-fzf/go.sum
+++ b/plugins/picker-fzf/go.sum
@@ -1,5 +1,3 @@
-github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
-github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -36,8 +34,6 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
-github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -76,7 +72,6 @@ google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
 google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/plugins/picker-fzf/internal/picker/fzf.go
+++ b/plugins/picker-fzf/internal/picker/fzf.go
@@ -1,0 +1,111 @@
+// Package picker implements the swm Picker capability using the system fzf binary.
+package picker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+)
+
+// buildVersion is set via -ldflags at build time.
+var buildVersion = "dev" //nolint:gochecknoglobals // set via ldflags at link time
+
+// Fzf implements pluginv1.PickerServer by wrapping the system fzf binary.
+type Fzf struct {
+	pluginv1.UnimplementedPickerServer
+	fzfBin  string
+	ttyPath string // defaults to /dev/tty; overridable in tests
+}
+
+// New returns a Fzf instance using the system fzf binary.
+func New() (*Fzf, error) {
+	bin, err := exec.LookPath("fzf")
+	if err != nil {
+		return nil, fmt.Errorf("fzf binary not found in PATH: %w", err)
+	}
+
+	return &Fzf{fzfBin: bin, ttyPath: "/dev/tty"}, nil
+}
+
+// NewWithBin returns a Fzf instance with injected binary and tty paths (for tests).
+func NewWithBin(fzfBin, ttyPath string) *Fzf {
+	return &Fzf{fzfBin: fzfBin, ttyPath: ttyPath}
+}
+
+// Info returns metadata about this Picker plugin.
+func (f *Fzf) Info(_ context.Context, _ *pluginv1.Empty) (*pluginv1.PickerInfo, error) {
+	return &pluginv1.PickerInfo{
+		PluginInfo: &pluginv1.PluginInfo{
+			Name:    "fzf",
+			Version: buildVersion,
+		},
+	}, nil
+}
+
+// Pick implements bidirectional streaming: receives PickItem candidates from the host,
+// presents them to the user via fzf, and streams a single PickResult back.
+func (f *Fzf) Pick(stream grpc.BidiStreamingServer[pluginv1.PickItem, pluginv1.PickResult]) error {
+	// Accumulate all candidates from the host stream.
+	var candidates []*pluginv1.PickItem
+
+	for {
+		item, err := stream.Recv()
+		if err != nil {
+			break
+		}
+
+		candidates = append(candidates, item)
+	}
+
+	if len(candidates) == 0 {
+		return status.Errorf(codes.Aborted, "no candidates received")
+	}
+
+	// Open the TTY so fzf can render its TUI in the user's terminal.
+	// fzf uses /dev/tty for its interactive interface when stdin is a pipe.
+	tty, err := os.OpenFile(f.ttyPath, os.O_RDWR, 0)
+	if err != nil {
+		return status.Errorf(codes.FailedPrecondition, "no TTY available: %v", err)
+	}
+
+	defer tty.Close() //nolint:errcheck // best-effort close of /dev/tty
+
+	// Build the candidate list for fzf: "<key>\t<display>\n" per line.
+	// --with-nth=2 tells fzf to show only the second tab-delimited field (display),
+	// but the full line (including key) is output on selection.
+	var input bytes.Buffer
+	for _, c := range candidates {
+		fmt.Fprintf(&input, "%s\t%s\n", c.GetKey(), c.GetDisplay())
+	}
+
+	var outBuf bytes.Buffer
+
+	cmd := exec.Command(f.fzfBin, "--with-nth=2", "--delimiter=\t") //nolint:gosec // fzfBin from LookPath
+	cmd.Stdin = &input
+	cmd.Stdout = &outBuf
+	cmd.Stderr = tty // fzf renders its TUI on stderr (attached to /dev/tty)
+
+	if err := cmd.Run(); err != nil {
+		// fzf exits 1 when the user presses Escape or Ctrl-C.
+		return status.Errorf(codes.Aborted, "picker cancelled")
+	}
+
+	selected := strings.TrimSuffix(outBuf.String(), "\n")
+	if selected == "" {
+		return status.Errorf(codes.Aborted, "no item selected")
+	}
+
+	// Output is "<key>\t<display>"; extract the key (first field).
+	key := strings.SplitN(selected, "\t", 2)[0]
+
+	return stream.Send(&pluginv1.PickResult{Key: key})
+}

--- a/plugins/picker-fzf/internal/picker/fzf_test.go
+++ b/plugins/picker-fzf/internal/picker/fzf_test.go
@@ -1,0 +1,149 @@
+package picker_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+
+	"github.com/kalbasit/swm/plugins/picker-fzf/internal/picker"
+)
+
+const (
+	testSWMProject        = "github.com/kalbasit/swm"
+	testSWMProjectDisplay = "kalbasit/swm"
+)
+
+var fakefzfBin string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "picker-fzf-fakefzf-*")
+	if err != nil {
+		panic("create temp dir: " + err.Error())
+	}
+
+	defer os.RemoveAll(dir) //nolint:errcheck // best-effort cleanup in TestMain
+
+	fakefzfBin = filepath.Join(dir, "fakefzf")
+
+	buildCmd := exec.Command("go", "build", "-o", fakefzfBin, "./testdata/fakefzf") //nolint:gosec // test build
+
+	out, err := buildCmd.CombinedOutput()
+	if err != nil {
+		panic("build fakefzf: " + string(out))
+	}
+
+	os.Exit(m.Run())
+}
+
+func newFzf(t *testing.T) *picker.Fzf {
+	t.Helper()
+
+	ttyFile := filepath.Join(t.TempDir(), "tty")
+	if err := os.WriteFile(ttyFile, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return picker.NewWithBin(fakefzfBin, ttyFile)
+}
+
+func TestInfo(t *testing.T) {
+	t.Parallel()
+
+	f := newFzf(t)
+	info, err := f.Info(context.Background(), &pluginv1.Empty{})
+	require.NoError(t, err)
+	require.Equal(t, "fzf", info.GetPluginInfo().GetName())
+}
+
+func TestPick_SuccessfulSelection(t *testing.T) {
+	t.Parallel()
+
+	f := newFzf(t)
+
+	items := []*pluginv1.PickItem{
+		{Key: testSWMProject, Display: testSWMProjectDisplay},
+		{Key: "github.com/kalbasit/dotfiles", Display: "kalbasit/dotfiles"},
+	}
+
+	stream := newPickStream(items)
+	err := f.Pick(stream)
+	require.NoError(t, err)
+
+	results := stream.sent
+	require.Len(t, results, 1)
+	// fakefzf outputs the first candidate line: "<key>\t<display>"
+	require.Equal(t, testSWMProject, results[0].GetKey())
+}
+
+func TestPick_UserCancels(t *testing.T) {
+	// Cannot be parallel — uses t.Setenv.
+	f := newFzf(t)
+	t.Setenv("FAKEFZF_EXIT", "1")
+
+	items := []*pluginv1.PickItem{
+		{Key: testSWMProject, Display: testSWMProjectDisplay},
+	}
+
+	stream := newPickStream(items)
+	err := f.Pick(stream)
+	require.Error(t, err)
+	require.Equal(t, codes.Aborted, status.Code(err))
+}
+
+func TestPick_NoTTY(t *testing.T) {
+	t.Parallel()
+
+	// Use a non-existent path to simulate a missing TTY.
+	f := picker.NewWithBin(fakefzfBin, "/nonexistent/dev/tty")
+
+	items := []*pluginv1.PickItem{
+		{Key: testSWMProject, Display: testSWMProjectDisplay},
+	}
+
+	stream := newPickStream(items)
+	err := f.Pick(stream)
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// pickStream is an in-process mock of grpc.BidiStreamingServer[PickItem, PickResult].
+type pickStream struct {
+	pluginv1.Picker_PickServer
+	items []*pluginv1.PickItem
+	pos   int
+	sent  []*pluginv1.PickResult
+}
+
+func newPickStream(items []*pluginv1.PickItem) *pickStream {
+	return &pickStream{items: items}
+}
+
+func (s *pickStream) Context() context.Context {
+	return context.Background()
+}
+
+func (s *pickStream) Recv() (*pluginv1.PickItem, error) {
+	if s.pos >= len(s.items) {
+		return nil, io.EOF
+	}
+
+	item := s.items[s.pos]
+	s.pos++
+
+	return item, nil
+}
+
+func (s *pickStream) Send(r *pluginv1.PickResult) error {
+	s.sent = append(s.sent, r)
+
+	return nil
+}

--- a/plugins/picker-fzf/internal/picker/testdata/fakefzf/main.go
+++ b/plugins/picker-fzf/internal/picker/testdata/fakefzf/main.go
@@ -1,0 +1,21 @@
+// fakefzf is a fake fzf binary used in unit tests.
+// It reads lines from stdin and outputs the first one to stdout.
+// Set FAKEFZF_EXIT=1 to simulate the user cancelling (exit code 1).
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if os.Getenv("FAKEFZF_EXIT") == "1" {
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+}

--- a/plugins/picker-fzf/main.go
+++ b/plugins/picker-fzf/main.go
@@ -1,9 +1,24 @@
 // swm-plugin-picker-fzf is the bundled fzf picker plugin for swm.
-// Phase 0 stub — real implementation in Phase 2.
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+
+	sdkpicker "github.com/kalbasit/swm/sdk/go/picker"
+
+	"github.com/kalbasit/swm/plugins/picker-fzf/internal/picker"
+)
 
 func main() {
-	fmt.Println("swm-plugin-picker-fzf")
+	f, err := picker.New()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "swm-plugin-picker-fzf: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := sdkpicker.Serve(f); err != nil {
+		fmt.Fprintf(os.Stderr, "swm-plugin-picker-fzf: serve: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/plugins/session-tmux/go.mod
+++ b/plugins/session-tmux/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/kalbasit/swm/proto v0.0.0
 	github.com/kalbasit/swm/sdk/go v0.0.0
+	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
 )

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 
 	"github.com/adrg/xdg"
+	"github.com/pelletier/go-toml/v2"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
@@ -20,28 +23,66 @@ import (
 // buildVersion is set via -ldflags at build time.
 var buildVersion = "dev" //nolint:gochecknoglobals // set via ldflags at link time
 
+// tmuxConfig holds the plugin-specific config read from the host.
+type tmuxConfig struct {
+	PaneGroupCommand string `toml:"pane_group_command"`
+}
+
 // Tmux implements pluginv1.SessionServer by shelling out to the system tmux.
 type Tmux struct {
-	tmuxBin   string
-	socketDir string
+	tmuxBin    string
+	socketDir  string
+	hostClient pluginv1.HostClient
+	grpcConn   *grpc.ClientConn
 }
 
 // New returns a Tmux instance using the system tmux binary.
+// It connects to SWM_HOST_SOCKET if set, enabling host config lookups.
 func New() (*Tmux, error) {
 	bin, err := exec.LookPath("tmux")
 	if err != nil {
 		return nil, fmt.Errorf("tmux binary not found in PATH: %w", err)
 	}
 
-	return &Tmux{
+	t := &Tmux{
 		tmuxBin:   bin,
 		socketDir: filepath.Join(xdg.RuntimeDir, "swm", "tmux"),
-	}, nil
+	}
+
+	if sock := os.Getenv("SWM_HOST_SOCKET"); sock != "" {
+		conn, err := grpc.NewClient(
+			"unix://"+sock,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("connecting to host socket: %w", err)
+		}
+
+		t.grpcConn = conn
+		t.hostClient = pluginv1.NewHostClient(conn)
+	}
+
+	return t, nil
 }
 
 // NewWithBin returns a Tmux instance with an injected binary path and socket dir (for tests).
 func NewWithBin(tmuxBin, socketDir string) *Tmux {
 	return &Tmux{tmuxBin: tmuxBin, socketDir: socketDir}
+}
+
+// NewWithBinAndClient returns a Tmux instance with an injected binary, socket dir,
+// and host client (for tests that exercise pane_group_command).
+func NewWithBinAndClient(tmuxBin, socketDir string, client pluginv1.HostClient) *Tmux {
+	return &Tmux{tmuxBin: tmuxBin, socketDir: socketDir, hostClient: client}
+}
+
+// Close releases the gRPC connection to the host service.
+func (t *Tmux) Close() error {
+	if t.grpcConn != nil {
+		return t.grpcConn.Close()
+	}
+
+	return nil
 }
 
 // CloseWorkspace tears down the tmux server for the given workspace.
@@ -148,9 +189,17 @@ func (t *Tmux) OpenPaneGroup(ctx context.Context, req *pluginv1.OpenPaneGroupReq
 
 	name := segments[len(segments)-1]
 
+	// Determine the initial command for the session.
+	initialCmd := t.paneGroupCommand(ctx, req)
+
 	// Create session if it doesn't exist yet.
 	if _, err := t.run(ctx, "-S", sock, "has-session", "-t", name); err != nil {
-		if _, err := t.run(ctx, "-S", sock, "new-session", "-d", "-s", name, "-c", req.GetWorktreePath()); err != nil {
+		args := []string{"-S", sock, "new-session", "-d", "-s", name, "-c", req.GetWorktreePath()}
+		if initialCmd != "" {
+			args = append(args, initialCmd)
+		}
+
+		if _, err := t.run(ctx, args...); err != nil {
 			return nil, err
 		}
 	}
@@ -221,6 +270,39 @@ func (t *Tmux) SwitchTo(ctx context.Context, req *pluginv1.SwitchToRequest) (*pl
 	}
 
 	return &pluginv1.Empty{}, nil
+}
+
+// paneGroupCommand returns the command string for a new pane group session, applying
+// template substitutions if pane_group_command is configured.
+// Returns empty string if no command is configured or if config cannot be fetched.
+func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroupRequest) string {
+	if t.hostClient == nil {
+		return ""
+	}
+
+	resp, err := t.hostClient.GetConfig(ctx, &pluginv1.GetConfigRequest{PluginName: "tmux"})
+	if err != nil {
+		return ""
+	}
+
+	var cfg tmuxConfig
+	if err := toml.Unmarshal(resp.GetToml(), &cfg); err != nil || cfg.PaneGroupCommand == "" {
+		return ""
+	}
+
+	// Derive story name from the socket path basename.
+	storyName := strings.TrimSuffix(filepath.Base(req.GetWorkspaceId()), ".sock")
+
+	// Build project_id string: host/seg1/seg2/...
+	pid := req.GetProjectId()
+	projectID := pid.GetHost() + "/" + strings.Join(pid.GetSegments(), "/")
+
+	cmd := cfg.PaneGroupCommand
+	cmd = strings.ReplaceAll(cmd, "{{worktree_path}}", req.GetWorktreePath())
+	cmd = strings.ReplaceAll(cmd, "{{story_name}}", storyName)
+	cmd = strings.ReplaceAll(cmd, "{{project_id}}", projectID)
+
+	return cmd
 }
 
 func (t *Tmux) run(ctx context.Context, args ...string) (string, error) {

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
@@ -184,6 +185,94 @@ func TestCurrentContext_NotInside(t *testing.T) {
 	tmux, _ := newTmux(t)
 	_, err := tmux.CurrentContext(context.Background(), &pluginv1.Empty{})
 	require.Error(t, err)
+}
+
+func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
+	// Cannot be parallel — uses t.Setenv.
+	socketDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	sockPath := filepath.Join(socketDir, "feat-x.sock")
+
+	client := &fakeHostClient{
+		toml: []byte(`pane_group_command = "laio start --config {{worktree_path}}/.swm/laio.yaml"`),
+	}
+
+	tmux := session.NewWithBinAndClient(faketmuxBin, socketDir, client)
+
+	// First create the workspace socket so has-session has a socket to probe.
+	if err := os.WriteFile(sockPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: "github.com", Segments: []string{"kalbasit", "swm"}},
+		WorktreePath: "/tmp/stories/feat-x/github.com/kalbasit/swm",
+	})
+	require.NoError(t, err)
+
+	// Read the log to verify the substituted command was passed to faketmux.
+	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+
+	log := string(logBytes)
+	require.Contains(t, log, "laio start --config /tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml",
+		"expected substituted pane_group_command in tmux args")
+}
+
+// fakeHostClient implements pluginv1.HostClient for tests.
+type fakeHostClient struct {
+	toml []byte
+}
+
+func (c *fakeHostClient) CallCapability(
+	_ context.Context,
+	_ *pluginv1.CallCapabilityRequest,
+	_ ...grpc.CallOption,
+) (*pluginv1.CallCapabilityResponse, error) {
+	panic("stub")
+}
+
+func (c *fakeHostClient) GetCodeRoot(
+	_ context.Context,
+	_ *pluginv1.Empty,
+	_ ...grpc.CallOption,
+) (*pluginv1.PathResponse, error) {
+	panic("stub")
+}
+
+func (c *fakeHostClient) GetConfig(
+	_ context.Context,
+	_ *pluginv1.GetConfigRequest,
+	_ ...grpc.CallOption,
+) (*pluginv1.Config, error) {
+	return &pluginv1.Config{Toml: c.toml}, nil
+}
+
+func (c *fakeHostClient) GetCurrentStory(
+	_ context.Context,
+	_ *pluginv1.Empty,
+	_ ...grpc.CallOption,
+) (*pluginv1.Story, error) {
+	panic("stub")
+}
+
+func (c *fakeHostClient) ListProjects(
+	_ context.Context,
+	_ *pluginv1.ListProjectsRequest,
+	_ ...grpc.CallOption,
+) (grpc.ServerStreamingClient[pluginv1.Project], error) {
+	panic("stub")
+}
+
+func (c *fakeHostClient) Log(
+	_ context.Context,
+	_ *pluginv1.LogRequest,
+	_ ...grpc.CallOption,
+) (*pluginv1.Empty, error) {
+	panic("stub")
 }
 
 // collectWorkspaceStream implements pluginv1.Session_ListWorkspacesServer for tests.

--- a/plugins/session-tmux/main.go
+++ b/plugins/session-tmux/main.go
@@ -17,6 +17,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	defer t.Close() //nolint:errcheck // best-effort close of host gRPC connection on exit
+
 	if err := sdksession.Serve(t); err != nil {
 		fmt.Fprintf(os.Stderr, "swm-plugin-session-tmux: serve: %v\n", err)
 		os.Exit(1)

--- a/sdk/go/picker/plugin.go
+++ b/sdk/go/picker/plugin.go
@@ -3,24 +3,54 @@
 package picker
 
 import (
-	"errors"
+	"context"
 
+	"google.golang.org/grpc"
+
+	goplugin "github.com/hashicorp/go-plugin"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
-)
 
-// ErrNotImplemented is returned by Serve when the gRPC transport has not been
-// wired up yet (Phase 0 stub). Replaced with real logic in Phase 1.
-var ErrNotImplemented = errors.New("picker.Serve: not yet implemented")
+	"github.com/kalbasit/swm/sdk/go/handshake"
+)
 
 // Plugin is the interface a picker plugin must implement.
 // It is identical to pluginv1.PickerServer, so implementors can embed
 // pluginv1.UnimplementedPickerServer and override only the methods they need.
 type Plugin = pluginv1.PickerServer
 
+// GRPCPlugin implements go-plugin's GRPCPlugin interface for the Picker capability.
+type GRPCPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+	Impl Plugin
+}
+
+// GRPCClient returns a PickerClient backed by the provided connection.
+func (p *GRPCPlugin) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, conn *grpc.ClientConn) (any, error) {
+	return pluginv1.NewPickerClient(conn), nil
+}
+
+// GRPCServer registers the Picker gRPC server with the provided gRPC server instance.
+func (p *GRPCPlugin) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error {
+	pluginv1.RegisterPickerServer(s, p.Impl)
+
+	return nil
+}
+
+// NewClient returns a PickerClient backed by the provided connection.
+func NewClient(conn *grpc.ClientConn) pluginv1.PickerClient {
+	return pluginv1.NewPickerClient(conn)
+}
+
 // Serve starts the go-plugin gRPC server for the given Plugin implementation.
 // It blocks until the host signals the plugin to exit.
-//
-// Phase-0 stub: returns ErrNotImplemented. Phase 1 wires the go-plugin transport.
-func Serve(_ Plugin) error {
-	return ErrNotImplemented
+func Serve(impl Plugin) error {
+	goplugin.Serve(&goplugin.ServeConfig{
+		HandshakeConfig: handshake.Config,
+		Plugins: goplugin.PluginSet{
+			"picker": &GRPCPlugin{Impl: impl},
+		},
+		GRPCServer: goplugin.DefaultGRPCServer,
+	})
+
+	return nil
 }

--- a/sdk/go/picker/plugin_test.go
+++ b/sdk/go/picker/plugin_test.go
@@ -1,0 +1,61 @@
+package picker_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	goplugin "github.com/hashicorp/go-plugin"
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+
+	"github.com/kalbasit/swm/sdk/go/handshake"
+	"github.com/kalbasit/swm/sdk/go/picker"
+)
+
+// Compile-time interface check: GRPCPlugin must implement goplugin.GRPCPlugin.
+var _ goplugin.GRPCPlugin = (*picker.GRPCPlugin)(nil)
+
+func TestHandshakeConfig(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, handshake.MagicCookieKey, handshake.Config.MagicCookieKey)
+	require.Equal(t, handshake.MagicCookieValue, handshake.Config.MagicCookieValue)
+	require.Equal(t, handshake.ProtocolVersion, int(handshake.Config.ProtocolVersion))
+}
+
+func TestGRPCPlugin_GRPCServer(t *testing.T) {
+	t.Parallel()
+
+	p := &picker.GRPCPlugin{Impl: pluginv1.UnimplementedPickerServer{}}
+	srv := grpc.NewServer()
+	err := p.GRPCServer(nil, srv)
+	require.NoError(t, err)
+
+	info := srv.GetServiceInfo()
+	require.Contains(t, info, "swm.plugin.v1.Picker")
+}
+
+func TestGRPCPlugin_GRPCClient(t *testing.T) {
+	t.Parallel()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	defer lis.Close() //nolint:errcheck // best-effort close in test cleanup
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	defer conn.Close() //nolint:errcheck // best-effort close in test cleanup
+
+	p := &picker.GRPCPlugin{}
+	raw, err := p.GRPCClient(context.Background(), nil, conn)
+	require.NoError(t, err)
+
+	_, ok := raw.(pluginv1.PickerClient)
+	require.True(t, ok, "GRPCClient must return a pluginv1.PickerClient")
+}


### PR DESCRIPTION
Delivers the Phase 2 vertical slice: an fzf-backed picker
plugin, wired SDK + pluginmgr picker capability,
pane_group_command support in session-tmux, and an interactive
picker flow in workspace open.

What this branch adds:
- sdk/go/picker: real GRPCPlugin struct replacing the stub;
  Serve, NewClient, GRPCClient, GRPCServer wired to
  pluginv1 PickerClient and PickerServer; unit tests verifying
  handshake config
- cmd/swm/internal/pluginmgr: picker capability wired into
  pluginSet and validateDeps, mirroring session/vcs pattern
- plugins/picker-fzf: new plugin implementing Picker.Pick over
  a bidirectional gRPC stream; opens /dev/tty for fzf TUI
  rendering; streams candidates as key\tdisplay, captures
  selection; returns gRPC Aborted on cancellation and
  FailedPrecondition when no TTY is available; fakefzf testdata
  binary for hermetic tests
- plugins/session-tmux: hostClient field connected via
  SWM_HOST_SOCKET; OpenPaneGroup fetches pane_group_command from
  host config, substitutes {{worktree_path}}, {{story_name}},
  {{project_id}} template vars; Close() tears down gRPC conn
- cmd/swm/internal/cli/workspace/open: interactive picker path
  builds deduplicated candidate list from attached projects +
  on-disk repos, streams to picker, lazily creates worktree via
  vcs.CreateWorktree + store.Update when not yet attached, then
  calls OpenPaneGroup + SwitchTo; falls back to Phase 1 path
  when no picker plugin is configured
- Integration test TestWorkspaceOpenWithPicker: compiles
  picker-fzf and fakefzf, clones a repo, creates a story, runs
  workspace open with picker enabled, verifies faketmux received
  a new-session call

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>