### PR TITLE
docs: add LICENSE and README files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,196 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or contributory
+      patent infringement, then any patent licenses granted to You under
+      this License for that Work shall terminate as of the date such
+      litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the
+          License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either on an exclusive or nonexclusive basis and on any
+      royalty or royalty-free terms as you choose, and You may provide
+      additional no-charge permissions to use the Work as you choose.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format in use. Also, you may add
+      (sub-)license for modified versions of the Work, as long as such
+      licenses are compatible with this License.
+
+   Copyright 2026 Wael Nasreddine
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The bundled plugins are separate binaries. Build them from the repo:
 ```sh
 git clone https://github.com/kalbasit/swm
 cd swm
+mkdir -p ~/.local/bin
 go build -o ~/.local/bin/swm-plugin-session-tmux ./plugins/session-tmux
 go build -o ~/.local/bin/swm-plugin-vcs-git       ./plugins/vcs-git
 go build -o ~/.local/bin/swm-plugin-forge-github  ./plugins/forge-github

--- a/README.md
+++ b/README.md
@@ -90,6 +90,70 @@ token_path = "~/.config/swm/github_token"
 
 See [`cmd/swm/README.md`](cmd/swm/README.md) for the full configuration reference.
 
+### Your first story
+
+Once installed and configured, here is a complete first-use walkthrough.
+
+**1. Clone a repository**
+
+```sh
+swm clone https://github.com/org/repo
+# cloned to ~/code/repositories/github.com/org/repo
+```
+
+The repo lands at its canonical path under `code_root/repositories/`. You only need to clone once — every story shares the same clone.
+
+**2. Create a story**
+
+```sh
+swm story create my-feature
+# created story "my-feature" with branch "feat/my-feature"
+```
+
+This writes a story record (`$XDG_DATA_HOME/swm/stories/my-feature.json`) with an empty project list and branch `feat/my-feature`. Override the branch with `--branch`:
+
+```sh
+swm story create my-feature --branch fix/my-feature
+```
+
+**3. Open the workspace**
+
+```sh
+swm workspace open --story my-feature
+```
+
+What happens depends on whether a picker plugin (fzf) is configured:
+
+- **With picker:** An interactive list of all repos under `code_root/repositories/` is shown. Select the project you want to work on. swm creates a worktree for that project on the story's branch and opens a tmux socket dedicated to this story, with a tmux session for the selected project.
+
+- **Without picker:** swm opens all projects already attached to the story (none on a fresh story, so this is only useful after a previous picker-based open or manual attachment).
+
+After the first open, the selected project is attached to the story permanently. Next time you open the workspace, you can pick additional projects or re-attach to the same one.
+
+**4. Return to the workspace later**
+
+Run the same command from any terminal to re-attach:
+
+```sh
+swm workspace open --story my-feature
+```
+
+You can also skip `--story` if you export `SWM_STORY` in your shell profile:
+
+```sh
+export SWM_STORY=my-feature
+swm workspace open
+```
+
+**5. Clean up**
+
+```sh
+swm story remove my-feature          # prompts for confirmation
+swm story remove my-feature --force  # skips confirmation
+```
+
+This removes all worktrees attached to the story and deletes the story record. The canonical clone under `repositories/` is left untouched.
+
 ## Plugin discovery
 
 Plugins are resolved in this order (first match per capability wins):

--- a/README.md
+++ b/README.md
@@ -1,0 +1,137 @@
+# swm — Story-based Workflow Manager
+
+**swm** organizes your code into per-story git worktrees and launches isolated terminal-multiplexer sessions around them. Each unit of work (a _story_) gets its own branch, its own worktrees across every affected repository, and its own tmux socket — so switching between tasks is instant and context-free.
+
+## Use cases
+
+- Work on multiple features simultaneously without stashing, without branch juggling, and without one project's environment polluting another.
+- Clone any repository to its canonical path (`~/code/repositories/<host>/<org>/<repo>`) with a single command and have it immediately available to all stories.
+- Open a story's workspace from anywhere and land exactly where you left off.
+- Automate pre/post actions (branch protection, issue transitions, Slack notifications) with the hook system.
+
+## Architecture
+
+swm is a **plugin-host CLI**. The host owns the filesystem layout, the story store, plugin lifecycle, and the CLI surface. Every integration is an external plugin binary connected over gRPC.
+
+```
+swm (host)
+├── session plugin   — terminal multiplexer (bundled: tmux)
+├── vcs plugin       — version control (bundled: git)
+├── forge plugins    — code-hosting platforms (bundled: github)
+├── picker plugin    — interactive selection UI (bundled: fzf)
+└── hooks            — plain executables, not gRPC
+```
+
+**Five capability surfaces:**
+
+| Capability | What it does                                | Bundled plugin |
+| ---------- | ------------------------------------------- | -------------- |
+| `session`  | Opens/closes workspaces and pane groups     | `session-tmux` |
+| `vcs`      | Clones repos, creates/removes worktrees     | `vcs-git`      |
+| `forge`    | Lists and creates pull requests             | `forge-github` |
+| `picker`   | Interactive selection prompts               | `picker-fzf`   |
+| `hook`     | Lifecycle event scripts (plain executables) | —              |
+
+**Filesystem layout** (defaults):
+
+```
+~/code/
+├── repositories/          # canonical clones, one per remote
+│   └── github.com/org/repo/
+└── stories/               # worktrees, one per story per repo
+    └── <story>/github.com/org/repo/
+```
+
+## Quick start
+
+### Install from source
+
+```sh
+go install github.com/kalbasit/swm/cmd/swm@latest
+```
+
+The bundled plugins are separate binaries. Build them from the repo:
+
+```sh
+git clone https://github.com/kalbasit/swm
+cd swm
+go build -o ~/.local/bin/swm-plugin-session-tmux ./plugins/session-tmux
+go build -o ~/.local/bin/swm-plugin-vcs-git       ./plugins/vcs-git
+go build -o ~/.local/bin/swm-plugin-forge-github  ./plugins/forge-github
+go build -o ~/.local/bin/swm-plugin-picker-fzf    ./plugins/picker-fzf
+```
+
+### Install via Nix
+
+```sh
+nix profile install github:kalbasit/swm#swm-full
+```
+
+`swm-full` includes the host and all bundled plugins.
+
+### Configure
+
+Create `$XDG_CONFIG_HOME/swm/config.toml` (defaults to `~/.config/swm/config.toml`):
+
+```toml
+code_root     = "~/code"
+default_story = "_default"
+
+[plugins]
+session = "tmux"
+vcs     = "git"
+picker  = "fzf"
+forges  = ["github"]
+
+[plugins.config.forge-github]
+token_path = "~/.config/swm/github_token"
+```
+
+See [`cmd/swm/README.md`](cmd/swm/README.md) for the full configuration reference.
+
+## Plugin discovery
+
+Plugins are resolved in this order (first match per capability wins):
+
+1. Explicit path in `config.toml` under `[plugins.paths]`
+2. `$XDG_DATA_HOME/swm/plugins/<name>/swm-plugin-<capability>-<name>`
+3. `swm-plugin-<capability>-<name>` on `$PATH`
+
+## Hook system
+
+Hooks are plain executables placed in tiered directories. All applicable tiers run for each event — they compose rather than override.
+
+| Tier           | Path                                                     |
+| -------------- | -------------------------------------------------------- |
+| Global         | `$XDG_CONFIG_HOME/swm/hooks/<event>.d/*`                 |
+| Per-repository | `<repo>/.swm/hooks/<event>.d/*`                          |
+| Per-story      | `$XDG_CONFIG_HOME/swm/stories/<story>/hooks/<event>.d/*` |
+
+`pre-*` hooks abort the operation on non-zero exit. `post-*` hooks log failures but do not abort.
+
+See [`cmd/swm/README.md`](cmd/swm/README.md) for the full list of hook events.
+
+## Module READMEs
+
+| Module                                                   | Description                                 |
+| -------------------------------------------------------- | ------------------------------------------- |
+| [`cmd/swm`](cmd/swm/README.md)                           | Host CLI — commands, config, plugins, hooks |
+| [`sdk/go`](sdk/go/README.md)                             | Go SDK for writing plugins                  |
+| [`plugins/session-tmux`](plugins/session-tmux/README.md) | tmux session plugin                         |
+| [`plugins/vcs-git`](plugins/vcs-git/README.md)           | git VCS plugin                              |
+| [`plugins/forge-github`](plugins/forge-github/README.md) | GitHub forge plugin                         |
+| [`plugins/picker-fzf`](plugins/picker-fzf/README.md)     | fzf picker plugin                           |
+
+## Contributing
+
+1. Fork the repo and create a feature branch.
+2. All changes require tests (TDD). Run `task test` before pushing.
+3. Format and lint: `task fmt && task lint`.
+4. Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
+5. Open a pull request against `main`.
+
+For larger changes, open an issue first to discuss the approach.
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/cmd/swm/README.md
+++ b/cmd/swm/README.md
@@ -1,0 +1,146 @@
+# swm — Host CLI
+
+The swm host binary. It owns the filesystem layout, the story store, plugin lifecycle, and the full CLI surface.
+
+## Commands
+
+### `swm clone <url>`
+
+Clone a repository to its canonical path under `code_root/repositories/`.
+
+```sh
+swm clone https://github.com/org/repo
+# → ~/code/repositories/github.com/org/repo
+```
+
+### `swm story`
+
+Manage stories (units of work).
+
+```sh
+swm story create <name> [--branch <branch>]
+```
+
+Creates a new story. Defaults the branch to `feat/<name>`.
+
+```sh
+swm story remove <name> [-f | --force]
+```
+
+Removes a story and all its worktrees. Prompts for confirmation unless `--force` is given.
+
+### `swm workspace`
+
+```sh
+swm workspace open
+```
+
+Opens the workspace for the current story (as determined by `$SWM_STORY` or the default story). Launches the session plugin.
+
+### `swm pr`
+
+Manage pull requests via the configured forge plugin.
+
+```sh
+swm pr list [--story <name>]
+```
+
+Lists open pull requests for the current story's projects. Reads `$SWM_STORY` if `--story` is omitted.
+
+```sh
+swm pr create --title <title> [--body <text>] [--base <branch>] [--head <branch>] [--draft] [--story <name>]
+```
+
+Creates a pull request for the current project. `--base` defaults to `main`; `--head` defaults to the story's branch name.
+
+## Configuration
+
+swm reads `$XDG_CONFIG_HOME/swm/config.toml` (default: `~/.config/swm/config.toml`).
+
+### Full reference
+
+```toml
+# Root directory for all code. Repositories land at code_root/repositories/<host>/<org>/<repo>.
+code_root = "~/code"
+
+# Story used when no --story flag or $SWM_STORY env var is set.
+default_story = "_default"
+
+[plugins]
+# Name of the session plugin to load (matches the plugin binary suffix).
+session = "tmux"
+
+# Name of the VCS plugin to load.
+vcs = "git"
+
+# Name of the picker plugin to load.
+picker = "fzf"
+
+# Forge plugins to load. Multiple forges can run simultaneously.
+forges = ["github"]
+
+# Optional: override binary paths for specific plugins.
+# Key is the full plugin name (capability-name), value is the absolute binary path.
+[plugins.paths]
+"session-tmux"  = "/usr/local/bin/swm-plugin-session-tmux"
+"vcs-git"       = "/usr/local/bin/swm-plugin-vcs-git"
+"picker-fzf"    = "/usr/local/bin/swm-plugin-picker-fzf"
+"forge-github"  = "/usr/local/bin/swm-plugin-forge-github"
+
+# Per-plugin configuration. Key is the full plugin name.
+[plugins.config.forge-github]
+token_path = "~/.config/swm/github_token"
+
+[plugins.config.session-tmux]
+pane_group_command = ""   # optional custom command run when opening a pane group
+```
+
+## Plugin discovery
+
+For each capability, the host resolves the plugin binary in this order (first match wins):
+
+1. **`[plugins.paths]`** — explicit path in config.
+2. **XDG data directory** — `$XDG_DATA_HOME/swm/plugins/<name>/swm-plugin-<capability>-<name>`.
+3. **`$PATH`** — `swm-plugin-<capability>-<name>`.
+
+Plugin binary naming convention: `swm-plugin-<capability>-<name>`
+
+Examples: `swm-plugin-session-tmux`, `swm-plugin-vcs-git`, `swm-plugin-forge-github`, `swm-plugin-picker-fzf`.
+
+## Hook system
+
+Hooks are plain executables (any language) placed in event-named directories. All tiers run for each event — they compose, not override.
+
+### Tiers (all applicable tiers run per event)
+
+| Tier           | Directory                                               |
+| -------------- | ------------------------------------------------------- |
+| Global         | `$XDG_CONFIG_HOME/swm/hooks/<event>.d/`                 |
+| Per-repository | `<canonical-repo>/.swm/hooks/<event>.d/`                |
+| Per-story      | `$XDG_CONFIG_HOME/swm/stories/<story>/hooks/<event>.d/` |
+
+Files within each `.d/` directory run in lexicographic order.
+
+### Hook events
+
+| Event                  | Blocking | Trigger                                    |
+| ---------------------- | -------- | ------------------------------------------ |
+| `pre-story-create`     | yes      | Before a story is created                  |
+| `post-story-create`    | no       | After a story is created                   |
+| `pre-story-remove`     | yes      | Before a story is removed                  |
+| `post-story-remove`    | no       | After a story is removed                   |
+| `pre-worktree-create`  | yes      | Before a worktree is created for a project |
+| `post-worktree-create` | no       | After a worktree is created                |
+| `pre-worktree-remove`  | yes      | Before a worktree is removed               |
+| `post-worktree-remove` | no       | After a worktree is removed                |
+| `pre-clone`            | yes      | Before a repository is cloned              |
+| `post-clone`           | no       | After a repository is cloned               |
+| `pre-workspace-open`   | yes      | Before a workspace session is opened       |
+| `post-workspace-open`  | no       | After a workspace session is opened        |
+
+**Blocking** (`pre-*`): a non-zero exit code aborts the operation immediately.
+**Non-blocking** (`post-*`): failures are logged but do not affect the return value.
+
+### Environment variables in hooks
+
+Hooks receive the standard swm environment, including `SWM_STORY`, `SWM_CODE_ROOT`, and any variables set by the session plugin.

--- a/openspec/changes/archive/2026-05-16-readme-and-license/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-16-readme-and-license/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/archive/2026-05-16-readme-and-license/design.md
+++ b/openspec/changes/archive/2026-05-16-readme-and-license/design.md
@@ -1,0 +1,35 @@
+## Context
+
+The repository is being prepared for public release. There are currently no `LICENSE` or `README` files anywhere in the monorepo. The monorepo contains: a host CLI (`cmd/swm`), a Go SDK (`sdk/go`), and four plugins (`forge-github`, `picker-fzf`, `session-tmux`, `vcs-git`). Each is a separate Go module in a `go.work` workspace.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add an Apache 2.0 `LICENSE` at the repository root.
+- Provide a high-level `README.md` at the root for first-time visitors.
+- Provide focused `README.md` files in `cmd/swm/`, `sdk/go/`, and each plugin directory.
+
+**Non-Goals:**
+- License header injection into source files.
+- CI license compliance checks.
+- Auto-generated API docs or a documentation site.
+- READMEs for internal packages (e.g. `pkg/`, `proto/`).
+
+## Decisions
+
+### 1 — Apache 2.0 as the license
+Chosen by the project owner. It is permissive, widely understood, and compatible with the project's dependencies.
+
+### 2 — Two-tier README structure
+Root README is intentionally high-level (30-second pitch, architecture summary, links). Module READMEs go deeper (configuration, CLI flags, plugin-specific behaviour). This avoids a single enormous README while keeping each entry-point self-contained.
+
+### 3 — Consistent plugin README template
+All four plugin READMEs follow the same section order: Purpose → Requirements → Configuration → Usage → Limitations. Consistency matters more than per-plugin creativity since users will read multiple plugins.
+
+### 4 — No Badges / CI shields in initial pass
+Shields require stable release tags and a working CI badge URL. Adding them now would produce broken images. They can be added once v2 cuts a release.
+
+## Risks / Trade-offs
+
+- **Documentation drift** — READMEs will fall out of sync with code as the project evolves. Mitigation: keep content factual and minimal; prefer linking to code/config rather than duplicating it.
+- **Incomplete quick-start** — Until a release binary is published, install instructions are necessarily from source. Mitigation: document `go install` and Nix paths clearly; note that pre-built binaries are coming.

--- a/openspec/changes/archive/2026-05-16-readme-and-license/proposal.md
+++ b/openspec/changes/archive/2026-05-16-readme-and-license/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The repository has no `LICENSE` file and no `README.md`, which blocks public release: potential contributors cannot determine the terms of use, and visitors have no orientation to the project's purpose or structure. These omissions must be resolved before the project can be shared or adopted externally.
+
+## What Changes
+
+- Add `LICENSE` at the repository root — Apache License 2.0, copyright Wael Nasreddine.
+- Add `README.md` at the repository root: high-level project introduction, use-cases, architecture overview, plugin system summary, and contributing guide.
+- Add `cmd/swm/README.md`: host CLI details — commands, config format, plugin discovery, hook system.
+- Add `sdk/go/README.md`: Go SDK usage, implementing a plugin, interface contracts.
+- Add `plugins/forge-github/README.md`, `plugins/picker-fzf/README.md`, `plugins/session-tmux/README.md`, `plugins/vcs-git/README.md`: per-plugin purpose, configuration, and any plugin-specific behaviour.
+
+## Non-goals
+
+- License header injection into source files.
+- CI enforcement of license compliance (e.g., `licensei`).
+- Documentation site or generated API docs.
+
+## Capabilities
+
+**Affected capability surfaces:** none (session / vcs / forge / picker / hook — unchanged)
+
+**Proto changes:** none
+
+### New Capabilities
+
+None — this change adds static files only; no new API or plugin surfaces are introduced.
+
+### Modified Capabilities
+
+None — no existing spec-level requirements change.
+
+## Impact
+
+- **Files added:** `LICENSE`, `README.md` (root), `cmd/swm/README.md`, `sdk/go/README.md`, `plugins/forge-github/README.md`, `plugins/picker-fzf/README.md`, `plugins/session-tmux/README.md`, `plugins/vcs-git/README.md`.
+- **Code:** no changes.
+- **Dependencies:** none.
+- **APIs / proto:** none.
+- **CI:** no changes required; the files are inert to the existing `task fmt / lint / test` pipeline.

--- a/openspec/changes/archive/2026-05-16-readme-and-license/specs/project-documentation/spec.md
+++ b/openspec/changes/archive/2026-05-16-readme-and-license/specs/project-documentation/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Repository root has an Apache 2.0 LICENSE file
+The repository root SHALL contain a `LICENSE` file with the full text of the Apache License, Version 2.0, with copyright assigned to Wael Nasreddine and the current year.
+
+#### Scenario: LICENSE file is present and correct
+- **WHEN** a visitor views the repository root
+- **THEN** a `LICENSE` file SHALL be present containing "Apache License" and "Version 2.0"
+
+### Requirement: Root README introduces the project
+The repository root SHALL contain a `README.md` that gives a first-time visitor a clear understanding of the project within 60 seconds of reading.
+
+#### Scenario: Root README covers minimum required sections
+- **WHEN** a visitor reads `README.md` at the repo root
+- **THEN** it SHALL contain: project name and one-line description, use-case summary, architecture overview (host + plugin model), quick-start install instructions, link to contributing guide, and links to per-module READMEs
+
+### Requirement: Host CLI has a module-level README
+`cmd/swm/README.md` SHALL document the host CLI in sufficient detail for a new user to install, configure, and run it.
+
+#### Scenario: Host README covers CLI usage
+- **WHEN** a user reads `cmd/swm/README.md`
+- **THEN** it SHALL cover: available commands, configuration file format (TOML), plugin discovery order, and hook system overview
+
+### Requirement: Go SDK has a module-level README
+`sdk/go/README.md` SHALL document the Go SDK for plugin authors.
+
+#### Scenario: SDK README covers plugin authoring
+- **WHEN** a plugin author reads `sdk/go/README.md`
+- **THEN** it SHALL cover: how to implement each capability interface, how to register the plugin, and how to declare capability dependencies
+
+### Requirement: Each bundled plugin has a README
+Each directory under `plugins/` SHALL contain a `README.md` covering that plugin's purpose, configuration, and usage.
+
+#### Scenario: Plugin README covers minimum sections
+- **WHEN** a user reads any `plugins/<name>/README.md`
+- **THEN** it SHALL contain: purpose, runtime requirements, configuration keys (with types and defaults), example config snippet, and known limitations
+
+#### Scenario: All four bundled plugins have READMEs
+- **WHEN** the repository is inspected
+- **THEN** `plugins/forge-github/README.md`, `plugins/picker-fzf/README.md`, `plugins/session-tmux/README.md`, and `plugins/vcs-git/README.md` SHALL each exist

--- a/openspec/changes/archive/2026-05-16-readme-and-license/tasks.md
+++ b/openspec/changes/archive/2026-05-16-readme-and-license/tasks.md
@@ -1,0 +1,32 @@
+## 1. License
+
+- [x] 1.1 Add `LICENSE` file at repo root with full Apache License 2.0 text, copyright Wael Nasreddine 2026
+
+## 2. Root README
+
+- [x] 2.1 Write `README.md` at repo root: project name, one-line description, use-case summary
+- [x] 2.2 Add architecture overview section: host + plugin model, five capability surfaces
+- [x] 2.3 Add quick-start section: install from source (`go install`), Nix path, basic config
+- [x] 2.4 Add plugin discovery and hook system summary with links to `cmd/swm/README.md`
+- [x] 2.5 Add contributing section and links to per-module READMEs
+
+## 3. Host CLI README
+
+- [x] 3.1 Write `cmd/swm/README.md`: available commands and flags
+- [x] 3.2 Document TOML configuration format with example `config.toml`
+- [x] 3.3 Document plugin discovery order (config paths → XDG → PATH)
+- [x] 3.4 Document hook system: tiers, resolution order, event names
+
+## 4. Go SDK README
+
+- [x] 4.1 Write `sdk/go/README.md`: purpose and target audience (plugin authors)
+- [x] 4.2 Document how to implement each capability interface with minimal example
+- [x] 4.3 Document how to register a plugin (call `plugin.Serve`)
+- [x] 4.4 Document how to declare required/optional capability dependencies in `Info()`
+
+## 5. Plugin READMEs
+
+- [x] 5.1 Write `plugins/forge-github/README.md`: purpose, GitHub token requirements, config keys, example config
+- [x] 5.2 Write `plugins/picker-fzf/README.md`: purpose, fzf binary requirement, config keys, example config
+- [x] 5.3 Write `plugins/session-tmux/README.md`: purpose, tmux version requirement, config keys (socket path, etc.), example config
+- [x] 5.4 Write `plugins/vcs-git/README.md`: purpose, git binary requirement, config keys, example config

--- a/openspec/specs/project-documentation/spec.md
+++ b/openspec/specs/project-documentation/spec.md
@@ -1,0 +1,46 @@
+# Spec: Project Documentation
+
+## Purpose
+
+This capability covers the documentation artifacts that must exist in the repository so that first-time visitors, users, and plugin authors can understand, install, configure, and extend the project.
+
+## Requirements
+
+### Requirement: Repository root has an Apache 2.0 LICENSE file
+The repository root SHALL contain a `LICENSE` file with the full text of the Apache License, Version 2.0, with copyright assigned to Wael Nasreddine and the current year.
+
+#### Scenario: LICENSE file is present and correct
+- **WHEN** a visitor views the repository root
+- **THEN** a `LICENSE` file SHALL be present containing "Apache License" and "Version 2.0"
+
+### Requirement: Root README introduces the project
+The repository root SHALL contain a `README.md` that gives a first-time visitor a clear understanding of the project within 60 seconds of reading.
+
+#### Scenario: Root README covers minimum required sections
+- **WHEN** a visitor reads `README.md` at the repo root
+- **THEN** it SHALL contain: project name and one-line description, use-case summary, architecture overview (host + plugin model), quick-start install instructions, link to contributing guide, and links to per-module READMEs
+
+### Requirement: Host CLI has a module-level README
+`cmd/swm/README.md` SHALL document the host CLI in sufficient detail for a new user to install, configure, and run it.
+
+#### Scenario: Host README covers CLI usage
+- **WHEN** a user reads `cmd/swm/README.md`
+- **THEN** it SHALL cover: available commands, configuration file format (TOML), plugin discovery order, and hook system overview
+
+### Requirement: Go SDK has a module-level README
+`sdk/go/README.md` SHALL document the Go SDK for plugin authors.
+
+#### Scenario: SDK README covers plugin authoring
+- **WHEN** a plugin author reads `sdk/go/README.md`
+- **THEN** it SHALL cover: how to implement each capability interface, how to register the plugin, and how to declare capability dependencies
+
+### Requirement: Each bundled plugin has a README
+Each directory under `plugins/` SHALL contain a `README.md` covering that plugin's purpose, configuration, and usage.
+
+#### Scenario: Plugin README covers minimum sections
+- **WHEN** a user reads any `plugins/<name>/README.md`
+- **THEN** it SHALL contain: purpose, runtime requirements, configuration keys (with types and defaults), example config snippet, and known limitations
+
+#### Scenario: All four bundled plugins have READMEs
+- **WHEN** the repository is inspected
+- **THEN** `plugins/forge-github/README.md`, `plugins/picker-fzf/README.md`, `plugins/session-tmux/README.md`, and `plugins/vcs-git/README.md` SHALL each exist

--- a/plugins/forge-github/README.md
+++ b/plugins/forge-github/README.md
@@ -1,0 +1,55 @@
+# swm-plugin-forge-github
+
+GitHub forge plugin for swm. Handles pull request listing and creation for repositories hosted on `github.com`.
+
+## Purpose
+
+Implements the `forge` capability surface for GitHub. It claims the `github.com` host, meaning any project whose remote URL resolves to `github.com` will use this plugin for forge operations (`swm pr list`, `swm pr create`).
+
+## Requirements
+
+- A GitHub personal access token with `repo` scope (or a fine-grained token with pull-request read/write permissions on the target repositories).
+- Network access to `api.github.com`.
+
+## Configuration
+
+Configure under `[plugins.config.forge-github]` in `config.toml`:
+
+| Key          | Type   | Default           | Description                                                    |
+| ------------ | ------ | ----------------- | -------------------------------------------------------------- |
+| `token_path` | string | `~/.github_token` | Path to a file containing the GitHub token (newline-stripped). |
+
+### Example
+
+```toml
+[plugins]
+forges = ["github"]
+
+[plugins.config.forge-github]
+token_path = "~/.config/swm/github_token"
+```
+
+Create the token file:
+
+```sh
+echo "ghp_yourtoken" > ~/.config/swm/github_token
+chmod 600 ~/.config/swm/github_token
+```
+
+## Usage
+
+Once configured, forge operations work through the swm CLI:
+
+```sh
+# List open pull requests for the current story
+swm pr list
+
+# Create a pull request
+swm pr create --title "feat: add thing" --body "Closes #123" --draft
+```
+
+## Limitations
+
+- Only `github.com` is claimed. GitHub Enterprise Server is not supported in this release.
+- The plugin reads a static token from a file; OAuth device flow is not supported yet.
+- At most one forge plugin can claim a given host; if you need multiple GitHub identities, use separate swm installations.

--- a/plugins/forge-github/README.md
+++ b/plugins/forge-github/README.md
@@ -15,9 +15,9 @@ Implements the `forge` capability surface for GitHub. It claims the `github.com`
 
 Configure under `[plugins.config.forge-github]` in `config.toml`:
 
-| Key          | Type   | Default           | Description                                                    |
-| ------------ | ------ | ----------------- | -------------------------------------------------------------- |
-| `token_path` | string | `~/.github_token` | Path to a file containing the GitHub token (newline-stripped). |
+| Key          | Type   | Default                      | Description                                                    |
+| ------------ | ------ | ---------------------------- | -------------------------------------------------------------- |
+| `token_path` | string | `~/.config/swm/github_token` | Path to a file containing the GitHub token (newline-stripped). |
 
 ### Example
 

--- a/plugins/picker-fzf/README.md
+++ b/plugins/picker-fzf/README.md
@@ -1,0 +1,51 @@
+# swm-plugin-picker-fzf
+
+fzf picker plugin for swm. Provides interactive fuzzy-selection prompts wherever swm needs the user to choose from a list (stories, projects, branches, pull requests).
+
+## Purpose
+
+Implements the `picker` capability surface using [fzf](https://github.com/junegunn/fzf). The host streams candidate items to the plugin over gRPC; the plugin pipes them through `fzf` and returns the selection(s).
+
+## Requirements
+
+- `fzf` must be present on `$PATH`. Install via your system package manager or from the [fzf releases page](https://github.com/junegunn/fzf/releases).
+
+```sh
+# macOS
+brew install fzf
+
+# Nix
+nix profile install nixpkgs#fzf
+
+# Debian/Ubuntu
+apt install fzf
+```
+
+Any `fzf` version that supports `--read0` and `--print0` is compatible (0.29+).
+
+## Configuration
+
+This plugin has no configuration keys. It uses the `fzf` binary found on `$PATH`.
+
+```toml
+[plugins]
+picker = "fzf"
+```
+
+To use a specific `fzf` binary, set its path explicitly:
+
+```toml
+[plugins.paths]
+"picker-fzf" = "/usr/local/bin/swm-plugin-picker-fzf"
+```
+
+(This sets the swm plugin binary path, not the fzf binary — place your preferred `fzf` earlier on `$PATH`.)
+
+## Usage
+
+The picker is invoked automatically by swm commands that require selection (e.g. `swm workspace open` when no story is active). No direct invocation is needed.
+
+## Limitations
+
+- fzf is launched as a subprocess and inherits the terminal; it will not work in non-interactive (piped) contexts.
+- Multi-select support depends on the calling command; not all swm prompts allow multiple selections.

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -11,7 +11,7 @@ Implements the `session` capability surface using [tmux](https://github.com/tmux
 | Workspace   | Dedicated tmux server (one socket per story) |
 | Pane group  | tmux session within that server              |
 
-Each story gets its own tmux socket at `$XDG_RUNTIME_DIR/swm/tmux/<story>`, so stories are fully isolated — killing one story's tmux server has no effect on others.
+Each story gets its own tmux socket at `$XDG_RUNTIME_DIR/swm/tmux/<story>`, so stories are fully isolated — killing one story's tmux server has no effect on others. `$XDG_RUNTIME_DIR` is set automatically on Linux by systemd/PAM (typically `/run/user/<uid>`). If it is not set in your environment, export it before running swm (e.g. `export XDG_RUNTIME_DIR=/run/user/$(id -u)`).
 
 ## Requirements
 

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -1,0 +1,78 @@
+# swm-plugin-session-tmux
+
+tmux session plugin for swm. Maps swm's workspace/pane-group abstractions onto tmux sockets and sessions.
+
+## Purpose
+
+Implements the `session` capability surface using [tmux](https://github.com/tmux/tmux).
+
+| swm concept | tmux concept                                 |
+| ----------- | -------------------------------------------- |
+| Workspace   | Dedicated tmux server (one socket per story) |
+| Pane group  | tmux session within that server              |
+
+Each story gets its own tmux socket at `$XDG_RUNTIME_DIR/swm/tmux/<story>`, so stories are fully isolated — killing one story's tmux server has no effect on others.
+
+## Requirements
+
+- `tmux` 3.2 or later on `$PATH`.
+
+```sh
+# macOS
+brew install tmux
+
+# Nix
+nix profile install nixpkgs#tmux
+
+# Debian/Ubuntu
+apt install tmux
+```
+
+## Configuration
+
+Configure under `[plugins.config.session-tmux]` in `config.toml`:
+
+| Key                  | Type   | Default | Description                                                                                            |
+| -------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------ |
+| `pane_group_command` | string | `""`    | Command to run when a pane group (tmux session) is first opened. If empty, tmux opens a default shell. |
+
+### Example
+
+```toml
+[plugins]
+session = "tmux"
+
+[plugins.config.session-tmux]
+# Launch nvim in the first window of every new pane group
+pane_group_command = "nvim"
+```
+
+## Usage
+
+```sh
+# Open the workspace for the current story (launches or attaches to tmux)
+swm workspace open
+
+# swm sets $SWM_STORY inside the tmux session so hooks and scripts know the active story
+echo $SWM_STORY
+```
+
+## Socket paths
+
+Tmux sockets are placed at:
+
+```
+$XDG_RUNTIME_DIR/swm/tmux/<story-name>
+```
+
+You can connect to a story's server directly with:
+
+```sh
+tmux -S "$XDG_RUNTIME_DIR/swm/tmux/<story-name>" attach
+```
+
+## Limitations
+
+- Requires a local tmux installation; remote/SSH-only setups need tmux on the remote host.
+- The plugin does not manage tmux configuration (`.tmux.conf`); bring your own config.
+- Nested tmux (running swm inside tmux) works but may require `$TMUX` awareness in your config.

--- a/plugins/vcs-git/README.md
+++ b/plugins/vcs-git/README.md
@@ -1,0 +1,63 @@
+# swm-plugin-vcs-git
+
+git VCS plugin for swm. Handles repository cloning, worktree creation/removal, and branch listing for git repositories.
+
+## Purpose
+
+Implements the `vcs` capability surface using [git](https://git-scm.com). It detects git repositories by the presence of a `.git` directory or file, clones them to the canonical path layout under `code_root/repositories/`, and manages per-story worktrees under `code_root/stories/<story>/`.
+
+## Requirements
+
+- `git` on `$PATH`. Any git version that supports `git worktree` is compatible (2.15+).
+
+```sh
+# macOS
+brew install git
+
+# Nix
+nix profile install nixpkgs#git
+
+# Debian/Ubuntu
+apt install git
+```
+
+## Configuration
+
+This plugin has no configuration keys. It uses the `git` binary found on `$PATH` and follows standard git configuration (`~/.gitconfig`, `GIT_CONFIG`, etc.).
+
+```toml
+[plugins]
+vcs = "git"
+```
+
+## Usage
+
+The plugin is invoked automatically by swm commands. Direct interaction is through the swm CLI:
+
+```sh
+# Clone a repository to its canonical path
+swm clone https://github.com/org/repo
+# → ~/code/repositories/github.com/org/repo
+
+# Create a story (creates worktrees in all attached projects)
+swm story create my-feature
+
+# Remove a story (removes all worktrees)
+swm story remove my-feature
+```
+
+## Worktree layout
+
+For a story named `my-feature` and a cloned repo at `~/code/repositories/github.com/org/repo`, the worktree is created at:
+
+```
+~/code/stories/my-feature/github.com/org/repo/
+```
+
+The canonical clone (under `repositories/`) is shared across all stories; worktrees are lightweight references into it.
+
+## Limitations
+
+- Submodules within worktrees are not automatically initialized.
+- Shallow clones (`--depth`) are not supported; swm always performs a full clone.
+- The plugin uses the system `git` and inherits its credential configuration; set up credential helpers (e.g. `git-credential-manager`) separately.

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -106,7 +106,8 @@ func (p *myForgePlugin) Info(_ context.Context, _ *pluginv1.Empty) (*pluginv1.Fo
             Requires: []*pluginv1.CapabilityDep{
                 {Capability: pluginv1.Capability_VCS},
             },
-            // Capabilities this plugin can use if present but does not require.
+            // Optional takes capability name strings (not CapabilityDep structs).
+            // The host wires the capability if present; the plugin handles absence.
             Optional: []string{"picker"},
         },
         // Hostnames this forge plugin handles (for URL routing).

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,160 @@
+# swm Go SDK
+
+Go SDK for writing swm plugins. Import path: `github.com/kalbasit/swm/sdk/go`.
+
+Plugins are external binaries that the swm host discovers and connects to over gRPC (via [HashiCorp go-plugin](https://github.com/hashicorp/go-plugin)). The SDK wraps the generated protobuf types and the plugin handshake so you can focus on implementing the capability logic.
+
+## Capability interfaces
+
+Each capability surface has its own sub-package with a `Plugin` interface and a `Serve` entry point.
+
+| Sub-package | Import path                              | Capability            |
+| ----------- | ---------------------------------------- | --------------------- |
+| `session`   | `github.com/kalbasit/swm/sdk/go/session` | Terminal multiplexer  |
+| `vcs`       | `github.com/kalbasit/swm/sdk/go/vcs`     | Version control       |
+| `forge`     | `github.com/kalbasit/swm/sdk/go/forge`   | Code-hosting platform |
+| `picker`    | `github.com/kalbasit/swm/sdk/go/picker`  | Interactive selection |
+
+### Session
+
+```go
+import "github.com/kalbasit/swm/sdk/go/session"
+
+type Plugin interface {
+    Info(context.Context, *pluginv1.Empty) (*pluginv1.SessionInfo, error)
+    OpenWorkspace(context.Context, *pluginv1.OpenWorkspaceRequest) (*pluginv1.Workspace, error)
+    CloseWorkspace(context.Context, *pluginv1.CloseWorkspaceRequest) (*pluginv1.Empty, error)
+    ListWorkspaces(context.Context, *pluginv1.Empty) ([]*pluginv1.Workspace, error)
+    OpenPaneGroup(context.Context, *pluginv1.OpenPaneGroupRequest) (*pluginv1.PaneGroup, error)
+    SwitchTo(context.Context, *pluginv1.SwitchToRequest) (*pluginv1.Empty, error)
+    IsInsideWorkspace(context.Context, *pluginv1.Empty) (*pluginv1.BoolValue, error)
+    CurrentContext(context.Context, *pluginv1.Empty) (*pluginv1.CurrentContextResponse, error)
+}
+```
+
+### VCS
+
+```go
+import "github.com/kalbasit/swm/sdk/go/vcs"
+
+type Plugin interface {
+    Info(context.Context, *pluginv1.Empty) (*pluginv1.VCSInfo, error)
+    Clone(context.Context, *pluginv1.CloneRequest) (*pluginv1.CloneResponse, error)
+    ParseRemoteURL(context.Context, *pluginv1.ParseRemoteURLRequest) (*pluginv1.ProjectID, error)
+    CreateWorktree(context.Context, *pluginv1.CreateWorktreeRequest) (*pluginv1.Empty, error)
+    RemoveWorktree(context.Context, *pluginv1.RemoveWorktreeRequest) (*pluginv1.Empty, error)
+    DetectProjectAtPath(context.Context, *pluginv1.DetectAtPathRequest) (*pluginv1.ProjectID, error)
+    ListBranches(context.Context, *pluginv1.ListBranchesRequest, func(*pluginv1.Branch) error) error
+}
+```
+
+### Forge
+
+```go
+import "github.com/kalbasit/swm/sdk/go/forge"
+
+type Plugin interface {
+    Info(context.Context, *pluginv1.Empty) (*pluginv1.ForgeInfo, error)
+    ListPullRequests(context.Context, *pluginv1.ListPRsRequest, func(*pluginv1.PullRequest) error) error
+    CreatePullRequest(context.Context, *pluginv1.CreatePRRequest) (*pluginv1.PullRequest, error)
+    GetPullRequest(context.Context, *pluginv1.GetPRRequest) (*pluginv1.PullRequest, error)
+}
+```
+
+### Picker
+
+```go
+import "github.com/kalbasit/swm/sdk/go/picker"
+
+type Plugin interface {
+    Info(context.Context, *pluginv1.Empty) (*pluginv1.PickerInfo, error)
+    Pick(context.Context, func() (*pluginv1.PickItem, error), func(*pluginv1.PickResult) error) error
+}
+```
+
+## Registering a plugin
+
+Call `Serve` from `main()` with your implementation:
+
+```go
+package main
+
+import (
+    "github.com/kalbasit/swm/sdk/go/vcs"
+)
+
+func main() {
+    if err := vcs.Serve(&myVCSPlugin{}); err != nil {
+        panic(err)
+    }
+}
+```
+
+`Serve` blocks until the host closes the connection. It handles the gRPC server setup, the go-plugin handshake, and OS signal handling.
+
+## Declaring capabilities via Info()
+
+Every plugin implements `Info()` to advertise its identity and dependencies. The host validates the dependency graph at startup — missing required capabilities cause a startup error.
+
+```go
+func (p *myForgePlugin) Info(_ context.Context, _ *pluginv1.Empty) (*pluginv1.ForgeInfo, error) {
+    return &pluginv1.ForgeInfo{
+        PluginInfo: &pluginv1.PluginInfo{
+            Name:    "my-forge",
+            Version: version, // set via -ldflags at build time
+            // Capabilities this plugin requires the host to have loaded.
+            Requires: []*pluginv1.CapabilityDep{
+                {Capability: pluginv1.Capability_VCS},
+            },
+            // Capabilities this plugin can use if present but does not require.
+            Optional: []string{"picker"},
+        },
+        // Hostnames this forge plugin handles (for URL routing).
+        ClaimedHosts: []string{"github.example.com"},
+    }, nil
+}
+```
+
+**`Requires`** — the host aborts startup if any required capability is missing.
+**`Optional`** — the host wires the capability if available; the plugin must handle absence gracefully.
+
+## Protobuf types
+
+All request/response types live in `github.com/kalbasit/swm/proto` (module `github.com/kalbasit/swm/proto`), package `pluginv1`. The SDK re-exports common types; import the proto module directly if you need lower-level access.
+
+## Example: minimal VCS plugin skeleton
+
+```go
+package main
+
+import (
+    "context"
+
+    pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+    "github.com/kalbasit/swm/sdk/go/vcs"
+)
+
+var version = "dev"
+
+type myVCS struct{}
+
+func (v *myVCS) Info(_ context.Context, _ *pluginv1.Empty) (*pluginv1.VCSInfo, error) {
+    return &pluginv1.VCSInfo{
+        PluginInfo: &pluginv1.PluginInfo{
+            Name:    "my-vcs",
+            Version: version,
+        },
+        ProjectMarkers: []string{".git"},
+    }, nil
+}
+
+// ... implement remaining methods ...
+
+func main() {
+    if err := vcs.Serve(&myVCS{}); err != nil {
+        panic(err)
+    }
+}
+```
+
+Build the binary and name it `swm-plugin-vcs-<name>`, then place it on `$PATH` or configure its path explicitly in `config.toml`.


### PR DESCRIPTION
The project had no LICENSE or README, blocking public release. This
adds an Apache 2.0 LICENSE and a two-tier README structure:

- Root README: high-level intro, architecture, quick-start, and
  links to per-module docs.
- cmd/swm/README.md: full CLI reference, TOML config, plugin
  discovery order, and hook event table.
- sdk/go/README.md: capability interfaces, Serve() entry point,
  Info() dependency declaration, and a plugin skeleton example.
- plugins/{forge-github,picker-fzf,session-tmux,vcs-git}/README.md:
  per-plugin purpose, requirements, config keys, and limitations.