### PR TITLE
feat: add swm story list command

### DIFF
--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -46,6 +46,7 @@ func NewRootCmd(
 
 	storyGroup := &cobra.Command{Use: "story", Short: "Manage stories"}
 	storyGroup.AddCommand(story.NewCreateCmd(store, cfg.CodeRoot, hooks))
+	storyGroup.AddCommand(story.NewListCmd(store, cfg.DefaultStory))
 	storyGroup.AddCommand(story.NewRemoveCmd(store, mgr, resolver, hooks))
 	root.AddCommand(storyGroup)
 

--- a/cmd/swm/internal/cli/story/list.go
+++ b/cmd/swm/internal/cli/story/list.go
@@ -1,0 +1,34 @@
+package story
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
+)
+
+// NewListCmd returns the `swm story list` command.
+func NewListCmd(store coreStory.Store, defaultStory string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all stories",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			stories, err := store.List(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("listing stories: %w", err)
+			}
+
+			for _, s := range stories {
+				if s.Name == defaultStory {
+					continue
+				}
+
+				cmd.Println(s.Name)
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/swm/internal/cli/story/list_test.go
+++ b/cmd/swm/internal/cli/story/list_test.go
@@ -1,0 +1,61 @@
+package story_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/cli/story"
+)
+
+func TestListCmd_DefaultOnlyIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{
+		listStories: []*coreStory.Story{
+			{Name: "_default"},
+		},
+	}
+
+	cmd := story.NewListCmd(store, "_default")
+
+	var out bytes.Buffer
+
+	cmd.SetOut(&out)
+
+	require.NoError(t, cmd.Execute())
+	require.Empty(t, out.String())
+}
+
+func TestListCmd_MultipleStoriesExcludesDefault(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{
+		listStories: []*coreStory.Story{
+			{Name: "_default"},
+			{Name: "alpha"},
+			{Name: "beta"},
+		},
+	}
+
+	cmd := story.NewListCmd(store, "_default")
+
+	var out bytes.Buffer
+
+	cmd.SetOut(&out)
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, "alpha\nbeta\n", out.String())
+}
+
+func TestListCmd_StoreError(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{listErr: errHookFailed}
+
+	cmd := story.NewListCmd(store, "_default")
+	require.Error(t, cmd.Execute())
+}

--- a/cmd/swm/internal/cli/story/testhelpers_test.go
+++ b/cmd/swm/internal/cli/story/testhelpers_test.go
@@ -32,6 +32,8 @@ type stubStore struct {
 	getErr            error
 	deleteErr         error
 	deleted           bool
+	listStories       []*coreStory.Story
+	listErr           error
 }
 
 func (s *stubStore) Create(_ context.Context, name, branch string) (*coreStory.Story, error) {
@@ -63,7 +65,9 @@ func (s *stubStore) Get(_ context.Context, _ string) (*coreStory.Story, error) {
 	return &coreStory.Story{}, nil
 }
 
-func (s *stubStore) List(_ context.Context) ([]*coreStory.Story, error) { return nil, nil }
+func (s *stubStore) List(_ context.Context) ([]*coreStory.Story, error) {
+	return s.listStories, s.listErr
+}
 
 func (s *stubStore) Update(_ context.Context, _ *coreStory.Story) error { return nil }
 

--- a/openspec/changes/archive/2026-05-16-story-list/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-16-story-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-16-story-list/design.md
+++ b/openspec/changes/archive/2026-05-16-story-list/design.md
@@ -1,0 +1,65 @@
+# Design: swm story list
+
+## Context
+
+`swm story create` and `swm story remove` are implemented. `Store.List(ctx)`
+already exists in the `JSONStore` and returns all stories sorted lexically. The
+CLI has no command to surface that data. Users must inspect
+`$XDG_DATA_HOME/swm/stories/` directly.
+
+## Goals / Non-Goals
+
+**Goals**
+- Expose `Store.List` as `swm story list`.
+- Print story names to stdout, one per line, in lexical order.
+
+**Non-Goals**
+- Formatting flags (`--json`, `--table`).
+- Metadata columns (branch, created-at, attached projects).
+- Filtering or sorting flags.
+- Hooks — listing is a pure read; no side-effects warrant hook points.
+
+## Decisions
+
+### One name per line, no header
+
+**Decision**: Print bare story names, one per line.
+
+**Alternatives considered**:
+- Tabular output (name + branch + date) — deferred to non-goals; adds output
+  coupling before users have expressed a need.
+- JSON output — same deferral rationale.
+
+**Rationale**: Matches the shell-friendly output style of `swm pr list` and
+keeps the implementation trivial. Future flags can add formatting without
+breaking existing consumers.
+
+### No hooks
+
+**Decision**: No `pre-story-list` / `post-story-list` hook events.
+
+**Rationale**: Hook events exist for operations with side-effects (file
+creation, worktree manipulation, workspace transitions). A read-only list
+command has no meaningful pre/post contract to offer hook scripts.
+
+### Store wires in via existing constructor pattern
+
+**Decision**: `NewListCmd(store coreStory.Store) *cobra.Command` — same
+signature pattern as `NewCreateCmd`.
+
+**Rationale**: Keeps dependency injection consistent across story sub-commands.
+No new interfaces needed; `Store.List` is already part of `coreStory.Store`.
+
+## Risks / Trade-offs
+
+- `Store.List` always bootstraps `_default` on first call — users will always
+  see at least one story. This is existing behaviour and acceptable.
+
+## Migration Plan
+
+No data-model changes. The new binary is a strict superset of the old one.
+Rollback is replacing the binary.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-05-16-story-list/proposal.md
+++ b/openspec/changes/archive/2026-05-16-story-list/proposal.md
@@ -1,0 +1,42 @@
+# Proposal: swm story list
+
+## Why
+
+Users can create and remove stories but have no way to enumerate them from the
+CLI — they must inspect the JSON store directly. A `swm story list` command
+closes this gap and makes the story lifecycle fully introspectable from the
+terminal.
+
+## What Changes
+
+- Add `swm story list` sub-command under `swm story`.
+- The command calls `Store.List` (already implemented in `story-store`) and
+  prints each story name, one per line, to stdout.
+- No flags required for the initial implementation.
+- No proto changes; no new plugins involved.
+
+## Non-goals
+
+- Filtering, sorting, or formatting flags (e.g. `--json`, `--active`).
+- Displaying story metadata beyond the name (projects, branch, timestamps).
+- Interactive/picker mode.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — `Store.List` already exists; only the CLI surface is new)_
+
+### Modified Capabilities
+
+- **workflow-commands** — add `swm story list` requirement. The delta spec
+  will document the command contract, output format, and scenarios (empty
+  store, single story, multiple stories).
+
+## Impact
+
+- New file: `cmd/swm/internal/cli/story/list.go` (and `list_test.go`).
+- `cmd/swm/internal/cli/root.go`: register the new sub-command.
+- `openspec/specs/workflow-commands/spec.md`: delta with `swm story list`
+  requirement.
+- No dependency changes.

--- a/openspec/changes/archive/2026-05-16-story-list/specs/workflow-commands/spec.md
+++ b/openspec/changes/archive/2026-05-16-story-list/specs/workflow-commands/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: swm story list
+`swm story list` SHALL print all story names to stdout, one per line, in
+lexical order. The command takes no arguments and no flags. On success it exits
+zero. If the store cannot be read it exits non-zero and prints an error to
+stderr.
+
+#### Scenario: Single story (default only)
+- **WHEN** `swm story list` is run and only the `_default` story exists
+- **THEN** the command exits zero and prints exactly `_default` to stdout
+
+#### Scenario: Multiple stories
+- **WHEN** `swm story list` is run and stories `alpha`, `beta`, and `_default` exist
+- **THEN** the command exits zero and prints the names in lexical order, one per line
+
+#### Scenario: Store error
+- **WHEN** `swm story list` is run and `Store.List` returns an error
+- **THEN** the command exits non-zero and prints a human-readable error message

--- a/openspec/changes/archive/2026-05-16-story-list/tasks.md
+++ b/openspec/changes/archive/2026-05-16-story-list/tasks.md
@@ -1,0 +1,18 @@
+## 1. Spec delta
+
+- [x] 1.1 Apply `openspec/changes/story-list/specs/workflow-commands/spec.md` delta to `openspec/specs/workflow-commands/spec.md` (cmd/swm)
+
+## 2. Tests (TDD — write first)
+
+- [x] 2.1 Add table-driven tests for `NewListCmd` in `cmd/swm/internal/cli/story/list_test.go` covering: single story (_default only), multiple stories in lexical order, store error
+
+## 3. Implementation
+
+- [x] 3.1 Create `cmd/swm/internal/cli/story/list.go` implementing `NewListCmd(store coreStory.Store) *cobra.Command` (cmd/swm)
+- [x] 3.2 Register `story.NewListCmd(store)` in `storyGroup` inside `cmd/swm/internal/cli/root.go` (cmd/swm)
+
+## 4. Verification
+
+- [x] 4.1 Run `task fmt` and confirm exit 0 (cmd/swm)
+- [x] 4.2 Run `task lint` and confirm exit 0 (cmd/swm)
+- [x] 4.3 Run `task test` and confirm exit 0 (cmd/swm)

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -139,3 +139,21 @@ Before opening the workspace the command SHALL run `hookexec.Run` for event `pre
 #### Scenario: pre-workspace-open hook aborts open
 - **WHEN** a `pre-workspace-open` hook exits non-zero
 - **THEN** no workspace is opened and the command exits non-zero
+
+### Requirement: swm story list
+`swm story list` SHALL print all story names to stdout, one per line, in
+lexical order. The command takes no arguments and no flags. On success it exits
+zero. If the store cannot be read it exits non-zero and prints an error to
+stderr.
+
+#### Scenario: Single story (default only)
+- **WHEN** `swm story list` is run and only the `_default` story exists
+- **THEN** the command exits zero and prints exactly `_default` to stdout
+
+#### Scenario: Multiple stories
+- **WHEN** `swm story list` is run and stories `alpha`, `beta`, and `_default` exist
+- **THEN** the command exits zero and prints the names in lexical order, one per line
+
+#### Scenario: Store error
+- **WHEN** `swm story list` is run and `Store.List` returns an error
+- **THEN** the command exits non-zero and prints a human-readable error message


### PR DESCRIPTION
List all user-created stories via `swm story list`. The command
calls the existing Store.List, prints each story name one per line
in lexical order, and suppresses the built-in default story using
cfg.DefaultStory rather than a hardcoded literal so user-configured
defaults are respected.