### PR TITLE
fix: default config path to XDG when SWM_CONFIG unset

### DIFF
--- a/cmd/swm/internal/config/config_test.go
+++ b/cmd/swm/internal/config/config_test.go
@@ -76,6 +76,20 @@ func TestLoad_MissingOptionalFields(t *testing.T) {
 	require.Empty(t, cfg.Plugins.Session)
 }
 
+func TestResolveConfigPath_EnvVarSet(t *testing.T) {
+	t.Parallel()
+
+	got := config.ResolveConfigPath("/explicit/config.toml", "/home/user/.config")
+	require.Equal(t, "/explicit/config.toml", got)
+}
+
+func TestResolveConfigPath_EnvVarEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := config.ResolveConfigPath("", "/home/user/.config")
+	require.Equal(t, "/home/user/.config/swm/config.toml", got)
+}
+
 func TestLoad_BadTOML(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/config/load.go
+++ b/cmd/swm/internal/config/load.go
@@ -4,12 +4,24 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
 // ErrConfigNotFound is returned by Load when the config file does not exist.
 var ErrConfigNotFound = errors.New("config file not found")
+
+// ResolveConfigPath returns the effective config file path.
+// When swmConfig (the value of $SWM_CONFIG) is non-empty it is returned as-is.
+// Otherwise the XDG default <xdgConfigHome>/swm/config.toml is returned.
+func ResolveConfigPath(swmConfig, xdgConfigHome string) string {
+	if swmConfig != "" {
+		return swmConfig
+	}
+
+	return filepath.Join(xdgConfigHome, "swm", "config.toml")
+}
 
 // Load reads the TOML config file at path and returns a Config with defaults applied.
 // Returns ErrConfigNotFound if the file does not exist.

--- a/cmd/swm/main.go
+++ b/cmd/swm/main.go
@@ -20,7 +20,7 @@ import (
 var version = "v2.0.0-dev"
 
 func main() {
-	cfg, err := config.Load(os.Getenv("SWM_CONFIG"))
+	cfg, err := config.Load(config.ResolveConfigPath(os.Getenv("SWM_CONFIG"), xdg.ConfigHome))
 	if err != nil && !errors.Is(err, config.ErrConfigNotFound) {
 		fmt.Fprintf(os.Stderr, "swm: loading config: %v\n", err)
 		os.Exit(1)

--- a/openspec/changes/archive/2026-05-16-fix-workspace-open/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-16-fix-workspace-open/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-16-fix-workspace-open/design.md
+++ b/openspec/changes/archive/2026-05-16-fix-workspace-open/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`cmd/swm/main.go` loads the config by calling `config.Load(os.Getenv("SWM_CONFIG"))`. When `$SWM_CONFIG` is unset the empty string is passed to `os.ReadFile("")`, which fails immediately; the error satisfies `os.IsNotExist`, so `ErrConfigNotFound` is returned and `main` falls back to `config.Defaults()` — a bare struct with no plugin names set. The user's `$XDG_CONFIG_HOME/swm/config.toml` is never consulted.
+
+`config.Load` itself is correct; the gap is that `main` doesn't supply the XDG default path when `$SWM_CONFIG` is empty.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `swm` read `$XDG_CONFIG_HOME/swm/config.toml` automatically when `$SWM_CONFIG` is unset.
+- Preserve the existing override behaviour: `$SWM_CONFIG` takes full precedence when set.
+- Keep "file not found" a non-fatal condition (fall back to defaults), consistent with today.
+
+**Non-Goals:**
+- Config file merging or layered config (global + user + project).
+- Detecting or auto-configuring any plugin (separate concern).
+- Changes to `config.Load`, `config.Config`, or any plugin code.
+
+## Decisions
+
+### D1 — Resolve path in `main`, not in `config.Load`
+
+`config.Load` takes an explicit path and is already unit-tested that way. Changing its signature to "use XDG when path is empty" would push environment-awareness into a package that is intentionally pure. Instead, `main` computes the effective path before calling `Load`:
+
+```go
+configPath := os.Getenv("SWM_CONFIG")
+if configPath == "" {
+    configPath = filepath.Join(xdg.ConfigHome, "swm", "config.toml")
+}
+cfg, err := config.Load(configPath)
+```
+
+Alternative considered: add an `AutoLoad()` function in the `config` package that does the XDG lookup. Rejected — it would add surface area and make `config` depend on XDG for a concern that belongs in the entry point.
+
+### D2 — Preserve `ErrConfigNotFound` semantics
+
+If the XDG default file doesn't exist, `config.Load` returns `ErrConfigNotFound` and `main` falls back to `config.Defaults()`. This is unchanged behaviour: users without any config file continue to get sensible defaults.
+
+## Risks / Trade-offs
+
+- **Behaviour change for users who rely on no-config defaults**: Any user who intentionally runs without a config file but happens to have an unrelated `~/.config/swm/config.toml` will now have it loaded. Low risk in practice (the directory name is swm-specific).
+- **`xdg.ConfigHome` respects `$XDG_CONFIG_HOME`**: If the env var is set to a non-standard path, `swm` will look there. This is correct XDG behaviour.
+
+## Migration Plan
+
+No migration needed. The change is backward-compatible:
+- Users without a config file: no change (still uses defaults).
+- Users with `$SWM_CONFIG` set: no change (env var still wins).
+- Users with `~/.config/swm/config.toml` and no env var: now works correctly.

--- a/openspec/changes/archive/2026-05-16-fix-workspace-open/proposal.md
+++ b/openspec/changes/archive/2026-05-16-fix-workspace-open/proposal.md
@@ -1,0 +1,32 @@
+# Proposal: fix-workspace-open
+
+## Why
+
+`swm workspace open` (and all plugin-dependent commands) fail with "no session plugin configured" even when `~/.config/swm/config.toml` is properly populated. The root cause is that `main.go` loads the config exclusively from the `$SWM_CONFIG` environment variable and silently falls back to bare defaults when the variable is unset — it never tries the XDG standard path (`$XDG_CONFIG_HOME/swm/config.toml`).
+
+## What Changes
+
+- `cmd/swm/main.go`: when `$SWM_CONFIG` is empty, default the config path to `filepath.Join(xdg.ConfigHome, "swm", "config.toml")` before calling `config.Load`. `ErrConfigNotFound` is still handled gracefully (defaults applied) so a missing config file is not an error.
+
+**Non-goals**
+
+- Changing the `config.Load` API.
+- Supporting multiple config file locations or config merging.
+- Any changes to plugin resolution logic.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `workflow-commands` — the implicit contract that commands respect `~/.config/swm/config.toml` was already assumed by users but not enforced by the code. A new scenario documents that `$SWM_CONFIG` overrides the XDG default and that the XDG default is used when the variable is unset.
+
+## Impact
+
+- `cmd/swm/main.go`: 2-line change — compute default config path from `xdg.ConfigHome` before calling `config.Load`.
+- `openspec/specs/workflow-commands/spec.md`: add a requirement describing config file resolution order (`$SWM_CONFIG` → XDG default → built-in defaults).
+- Capability surface affected: **none** (this is startup/bootstrapping, not a plugin capability).
+- No proto changes required.

--- a/openspec/changes/archive/2026-05-16-fix-workspace-open/specs/workflow-commands/spec.md
+++ b/openspec/changes/archive/2026-05-16-fix-workspace-open/specs/workflow-commands/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Config file resolution order
+When `swm` starts it SHALL resolve the configuration file path using the following precedence (first match wins):
+1. `$SWM_CONFIG` environment variable, if set and non-empty.
+2. `$XDG_CONFIG_HOME/swm/config.toml` (where `$XDG_CONFIG_HOME` defaults to `~/.config` per the XDG Base Directory Specification).
+
+If the resolved file does not exist, `swm` SHALL start with built-in defaults and SHALL NOT treat a missing file as an error.
+
+#### Scenario: SWM_CONFIG env var overrides XDG default
+- **WHEN** `$SWM_CONFIG` is set to `/custom/path/config.toml` and that file exists
+- **THEN** `swm` loads config from `/custom/path/config.toml`, ignoring `$XDG_CONFIG_HOME/swm/config.toml`
+
+#### Scenario: XDG default used when SWM_CONFIG is unset
+- **WHEN** `$SWM_CONFIG` is unset and `$XDG_CONFIG_HOME/swm/config.toml` exists with `[plugins] session = "tmux"`
+- **THEN** `swm` loads config from the XDG path and plugin commands succeed
+
+#### Scenario: Missing config file falls back to defaults
+- **WHEN** `$SWM_CONFIG` is unset and `$XDG_CONFIG_HOME/swm/config.toml` does not exist
+- **THEN** `swm` starts with built-in defaults (code_root=~/code, default_story=_default, no plugins) and exits zero

--- a/openspec/changes/archive/2026-05-16-fix-workspace-open/tasks.md
+++ b/openspec/changes/archive/2026-05-16-fix-workspace-open/tasks.md
@@ -1,0 +1,8 @@
+## 1. Fix config path resolution (cmd/swm)
+
+- [x] 1.1 In `cmd/swm/main.go`, compute the effective config path: use `$SWM_CONFIG` when set, otherwise `filepath.Join(xdg.ConfigHome, "swm", "config.toml")`
+- [x] 1.2 Add a unit test in `cmd/swm/internal/config/` (or an integration test) covering the three scenarios: `$SWM_CONFIG` override, XDG default found, XDG default missing → falls back to defaults
+
+## 2. Spec update (openspec)
+
+- [x] 2.1 Merge the delta spec (`specs/workflow-commands/spec.md`) into `openspec/specs/workflow-commands/spec.md` — add the "Config file resolution order" requirement and its three scenarios

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -157,3 +157,22 @@ stderr.
 #### Scenario: Store error
 - **WHEN** `swm story list` is run and `Store.List` returns an error
 - **THEN** the command exits non-zero and prints a human-readable error message
+
+### Requirement: Config file resolution order
+When `swm` starts it SHALL resolve the configuration file path using the following precedence (first match wins):
+1. `$SWM_CONFIG` environment variable, if set and non-empty.
+2. `$XDG_CONFIG_HOME/swm/config.toml` (where `$XDG_CONFIG_HOME` defaults to `~/.config` per the XDG Base Directory Specification).
+
+If the resolved file does not exist, `swm` SHALL start with built-in defaults and SHALL NOT treat a missing file as an error.
+
+#### Scenario: SWM_CONFIG env var overrides XDG default
+- **WHEN** `$SWM_CONFIG` is set to `/custom/path/config.toml` and that file exists
+- **THEN** `swm` loads config from `/custom/path/config.toml`, ignoring `$XDG_CONFIG_HOME/swm/config.toml`
+
+#### Scenario: XDG default used when SWM_CONFIG is unset
+- **WHEN** `$SWM_CONFIG` is unset and `$XDG_CONFIG_HOME/swm/config.toml` exists with `[plugins] session = "tmux"`
+- **THEN** `swm` loads config from the XDG path and plugin commands succeed
+
+#### Scenario: Missing config file falls back to defaults
+- **WHEN** `$SWM_CONFIG` is unset and `$XDG_CONFIG_HOME/swm/config.toml` does not exist
+- **THEN** `swm` starts with built-in defaults (code_root=~/code, default_story=_default, no plugins) and exits zero


### PR DESCRIPTION
Without this fix, swm silently falls back to bare defaults when
$SWM_CONFIG is not set, ignoring the user's config at
$XDG_CONFIG_HOME/swm/config.toml. Commands like 'workspace open'
would then fail with 'no session plugin configured' even though
the config file was correctly populated.

Fix: add config.ResolveConfigPath to choose $SWM_CONFIG when set,
or $XDG_CONFIG_HOME/swm/config.toml as the default. main.go is
updated to use this function, and unit tests cover all three
resolution scenarios.