### PR TITLE
fix: forward plugin stderr to host process

### DIFF
--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -206,6 +206,34 @@ func TestOpenCmd_WithPicker_FailedPrecondition_FallsBack(t *testing.T) {
 	require.Nil(t, sess.lastPaneGroupReq, "expected OpenPaneGroup NOT to be called")
 }
 
+// TestOpenCmd_WithPicker_RecvFailedPrecondition_FallsBack covers the case where the
+// picker's stream.Recv() returns FailedPrecondition (e.g. /dev/tty unavailable inside
+// the handler, after all candidates have been received). The host must still fall back
+// to openAllAttached, not surface the gRPC error to the caller.
+func TestOpenCmd_WithPicker_RecvFailedPrecondition_FallsBack(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name: testStoryName,
+		Projects: []coreStory.Project{
+			{Host: testHost, Segments: []string{testOwner, testSegment}},
+		},
+	}}
+	sess := &stubSess{}
+	// Picker stream opens fine but Recv() returns FailedPrecondition (no TTY).
+	picker := &stubPickerClient{recvErr: status.Error(codes.FailedPrecondition, "no tty")}
+	mgr := &stubMgr{sess: sess, picker: picker}
+	resolver := layout.NewResolver(testCodeRoot)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.NotNil(t, sess.lastOpenReq, "expected OpenWorkspace to be called as fallback")
+	require.Nil(t, sess.lastPaneGroupReq, "expected OpenPaneGroup NOT to be called")
+}
+
 func TestOpenCmd_WithPicker_InvalidKey_EmptyHost(t *testing.T) {
 	t.Parallel()
 
@@ -491,6 +519,7 @@ type stubPickerClient struct {
 	selectedKey  string
 	cancelOnRecv bool
 	pickErr      error
+	recvErr      error // returned from stream.Recv() instead of a normal result
 }
 
 func (p *stubPickerClient) Info(
@@ -509,7 +538,7 @@ func (p *stubPickerClient) Pick(
 		return nil, p.pickErr
 	}
 
-	return &stubPickStream{selectedKey: p.selectedKey, cancel: p.cancelOnRecv}, nil
+	return &stubPickStream{selectedKey: p.selectedKey, cancel: p.cancelOnRecv, recvErr: p.recvErr}, nil
 }
 
 var _ pluginv1.PickerClient = (*stubPickerClient)(nil)
@@ -519,6 +548,7 @@ type stubPickStream struct {
 	selectedKey string
 	cancel      bool
 	recvCalled  bool
+	recvErr     error // returned from Recv() when set, before checking cancel/selectedKey
 }
 
 func (s *stubPickStream) CloseSend() error { return nil }
@@ -533,6 +563,10 @@ func (s *stubPickStream) Recv() (*pluginv1.PickResult, error) {
 	}
 
 	s.recvCalled = true
+
+	if s.recvErr != nil {
+		return nil, s.recvErr
+	}
 
 	if s.cancel {
 		return nil, status.Error(codes.Aborted, "cancelled")

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,10 +62,22 @@ type forgeEntry struct {
 	hostnames []string
 }
 
+// Option configures a Manager.
+type Option func(*Manager)
+
+// WithStderr sets the writer that receives the raw stderr output of plugin processes.
+// Defaults to os.Stderr when not specified.
+func WithStderr(w io.Writer) Option {
+	return func(m *Manager) {
+		m.syncStderr = w
+	}
+}
+
 // Manager discovers, launches, and provides typed access to swm plugins.
 type Manager struct {
 	cfg        *config.Config
 	hostSocket string
+	syncStderr io.Writer
 
 	mu           sync.Mutex
 	launched     map[string]*entry
@@ -73,12 +86,19 @@ type Manager struct {
 }
 
 // New returns a Manager. Plugins are not launched until Get is called.
-func New(cfg *config.Config, hostSocket string) *Manager {
-	return &Manager{
+func New(cfg *config.Config, hostSocket string, opts ...Option) *Manager {
+	m := &Manager{
 		cfg:        cfg,
 		hostSocket: hostSocket,
+		syncStderr: os.Stderr,
 		launched:   make(map[string]*entry),
 	}
+
+	for _, o := range opts {
+		o(m)
+	}
+
+	return m
 }
 
 // Close terminates all launched plugin processes.
@@ -141,6 +161,7 @@ func (m *Manager) Get(ctx context.Context, capability string) (any, error) {
 		HandshakeConfig: handshake.Config,
 		Plugins:         set,
 		Cmd:             pluginCmd,
+		Stderr:          m.syncStderr,
 		AllowedProtocols: []goplugin.Protocol{
 			goplugin.ProtocolGRPC,
 		},
@@ -266,6 +287,7 @@ func (m *Manager) loadForges(ctx context.Context) error {
 			HandshakeConfig: handshake.Config,
 			Plugins:         set,
 			Cmd:             pluginCmd,
+			Stderr:          m.syncStderr,
 			AllowedProtocols: []goplugin.Protocol{
 				goplugin.ProtocolGRPC,
 			},

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -1,11 +1,14 @@
 package pluginmgr_test
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -17,7 +20,30 @@ import (
 
 const fakePluginName = "fake"
 
-var fakeVCSBin string
+var (
+	fakeVCSBin    string
+	fakeStderrBin string
+)
+
+// syncBuffer is a thread-safe bytes.Buffer for use as a SyncStderr target.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.String()
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.Write(p)
+}
 
 func TestMain(m *testing.M) {
 	dir, err := os.MkdirTemp("", "pluginmgr-test-*")
@@ -36,6 +62,17 @@ func TestMain(m *testing.M) {
 
 	if err := cmd.Run(); err != nil {
 		panic("building fake plugin: " + err.Error())
+	}
+
+	fakeStderrBin = filepath.Join(dir, "swm-plugin-vcs-fakestderr")
+
+	cmd = exec.Command("go", "build", "-o", fakeStderrBin, //nolint:gosec // building from trusted test paths
+		"./testdata/fakestderr/")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		panic("building fakestderr plugin: " + err.Error())
 	}
 
 	os.Exit(m.Run())
@@ -170,4 +207,29 @@ func TestClose_Cleanup(t *testing.T) {
 	require.NotNil(t, raw)
 
 	require.NoError(t, mgr.Close())
+}
+
+func TestGet_PluginStderrForwarded(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Plugins: config.Plugins{
+			VCS: "fakestderr",
+			Paths: map[string]string{
+				"fakestderr": fakeStderrBin,
+			},
+		},
+	}
+
+	var sink syncBuffer
+
+	mgr := pluginmgr.New(cfg, "", pluginmgr.WithStderr(&sink))
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	_, err := mgr.Get(context.Background(), "vcs")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return bytes.Contains([]byte(sink.String()), []byte("FAKESTDERR_MARKER"))
+	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/cmd/swm/internal/pluginmgr/testdata/fakestderr/main.go
+++ b/cmd/swm/internal/pluginmgr/testdata/fakestderr/main.go
@@ -1,0 +1,56 @@
+// fakestderr is a minimal swm-plugin-vcs-* binary used to test stderr forwarding.
+// It writes a known marker to stderr before serving, then behaves like a normal VCS plugin.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	goplugin "github.com/hashicorp/go-plugin"
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+	"github.com/kalbasit/swm/sdk/go/handshake"
+	"google.golang.org/grpc"
+)
+
+const stderrMarker = "FAKESTDERR_MARKER: hello from fakestderr"
+
+type fakeVCS struct {
+	pluginv1.UnimplementedVCSServer
+}
+
+func (f *fakeVCS) Info(_ context.Context, _ *pluginv1.Empty) (*pluginv1.VCSInfo, error) {
+	return &pluginv1.VCSInfo{
+		PluginInfo: &pluginv1.PluginInfo{
+			Name:    "fakestderr",
+			Version: "0.0.1",
+		},
+		ProjectMarkers: []string{".git"},
+	}, nil
+}
+
+type grpcPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+}
+
+func (g *grpcPlugin) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error {
+	pluginv1.RegisterVCSServer(s, &fakeVCS{})
+
+	return nil
+}
+
+func (g *grpcPlugin) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, conn *grpc.ClientConn) (interface{}, error) {
+	return pluginv1.NewVCSClient(conn), nil
+}
+
+func main() {
+	fmt.Fprintln(os.Stderr, stderrMarker)
+
+	goplugin.Serve(&goplugin.ServeConfig{
+		HandshakeConfig: handshake.Config,
+		Plugins: goplugin.PluginSet{
+			"vcs": &grpcPlugin{},
+		},
+		GRPCServer: goplugin.DefaultGRPCServer,
+	})
+}


### PR DESCRIPTION
fix: forward plugin stderr to host process

Plugin crashes were silent because go-plugin's ClientConfig.Stderr
defaults to io.Discard. Any panic, os.Exit message, or runtime error
written by a plugin binary was discarded without appearing anywhere
visible to the operator.

Add a WithStderr functional option to Manager so the destination is
injectable (defaulting to os.Stderr). Set Stderr: m.syncStderr in
both Get() (regular capabilities) and loadForges() (forge plugins)
so all plugin subprocess stderr is forwarded to the host.

Add a fakestderr test plugin and TestGet_PluginStderrForwarded to
verify the forwarding end-to-end.

Note: SyncStderr (the gRPC-multiplexed channel) was investigated but
found to be the wrong field; go-plugin's Stderr field is for the raw
subprocess stderr pipe, which is what we need here.

test(pluginmgr): add fakestderr plugin testdata

Missing from previous commit — testdata/fakestderr/main.go was
an untracked new file and was not staged by gs branch create -am.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

test(workspace): cover picker Recv FailedPrecondition fallback

Add TestOpenCmd_WithPicker_RecvFailedPrecondition_FallsBack and
supporting stub fields (recvErr on stubPickerClient/stubPickStream)
to document the correct behavior when the picker's bidirectional-
stream Recv() call returns FailedPrecondition (e.g. /dev/tty
unavailable inside the handler after candidates are received).

gRPC-go v1.56+ propagates the code through wrapped errors via
errors.As, so status.Code detects the FailedPrecondition code
even after fmt.Errorf wrapping, and the openAllAttached fallback
fires as expected.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>