### PR TITLE
feat: add --log-level flag and debug logging

### DIFF
--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -3,6 +3,9 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -30,11 +33,25 @@ func NewRootCmd(
 	store coreStory.Store,
 	resolver *layout.Resolver,
 ) *cobra.Command {
+	var logLevel string
+
 	root := &cobra.Command{
 		Use:          "swm",
 		Short:        "Story-based Workflow Manager",
 		SilenceUsage: true,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			var level slog.Level
+			if err := level.UnmarshalText([]byte(logLevel)); err != nil {
+				return fmt.Errorf("invalid --log-level %q: %w", logLevel, err)
+			}
+
+			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+
+			return nil
+		},
 	}
+
+	root.PersistentFlags().StringVar(&logLevel, "log-level", "warn", "log level (debug, info, warn, error)")
 
 	hooks := hookexec.RunnerFunc(func(ctx context.Context, rc hookexec.RunConfig) error {
 		if rc.ConfigHome == "" {

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -68,6 +68,13 @@ func NewOpenCmd(
 				return fmt.Errorf("loading story %q: %w", storyName, err)
 			}
 
+			slog.DebugContext(
+				ctx, "workspace open",
+				"story", storyName,
+				"projects", len(st.Projects),
+				"code_root", cfg.CodeRoot,
+			)
+
 			raw, err := mgr.Get(ctx, "session")
 			if err != nil {
 				return fmt.Errorf("loading session plugin: %w", err)
@@ -92,14 +99,27 @@ func NewOpenCmd(
 			if rawPicker, pickErr := mgr.Get(ctx, "picker"); pickErr == nil {
 				if pc, ok := rawPicker.(pluginv1.PickerClient); ok {
 					pickerClient = pc
+
+					slog.DebugContext(ctx, "picker plugin loaded")
 				}
+			} else {
+				slog.DebugContext(ctx, "picker plugin unavailable", "err", pickErr)
 			}
 
 			var openErr error
 			if pickerClient != nil {
 				openErr = openWithPicker(ctx, cmd, cfg, st, store, mgr, sess, pickerClient, resolver, storyName)
-				if openErr != nil && status.Code(openErr) == codes.FailedPrecondition {
-					openErr = openAllAttached(ctx, cmd, st, sess, resolver, storyName)
+				if openErr != nil {
+					slog.DebugContext(
+						ctx, "picker returned error, checking fallback",
+						"code", status.Code(openErr).String(),
+						"err", openErr,
+					)
+
+					if status.Code(openErr) == codes.FailedPrecondition {
+						slog.DebugContext(ctx, "falling back to openAllAttached (no TTY)")
+						openErr = openAllAttached(ctx, cmd, st, sess, resolver, storyName)
+					}
 				}
 			} else {
 				openErr = openAllAttached(ctx, cmd, st, sess, resolver, storyName)
@@ -143,6 +163,13 @@ func openWithPicker(
 	// Build a deduplicated candidate set: attached projects + all on-disk repos.
 	candidates := buildCandidates(cfg.CodeRoot, st, resolver)
 
+	slog.DebugContext(
+		ctx, "picker candidates built",
+		"count", len(candidates),
+		"code_root", cfg.CodeRoot,
+		"story_projects", len(st.Projects),
+	)
+
 	stream, err := pickerClient.Pick(ctx)
 	if err != nil {
 		// Return unwrapped so the caller can inspect the gRPC status code.
@@ -161,8 +188,10 @@ func openWithPicker(
 
 	result, err := stream.Recv()
 	if err != nil {
+		slog.DebugContext(ctx, "picker recv", "code", status.Code(err).String(), "err", err)
+
 		if status.Code(err) == codes.Aborted || errors.Is(err, io.EOF) {
-			// User cancelled — exit gracefully.
+			// User cancelled or no candidates — exit gracefully.
 			return nil
 		}
 
@@ -296,6 +325,8 @@ func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Reso
 
 	// All on-disk repositories.
 	reposDir := filepath.Join(codeRoot, "repositories")
+
+	slog.Default().Debug("scanning repos dir", "path", reposDir)
 
 	//nolint:errcheck // walking the repos dir is best-effort; missing repos are simply excluded
 	_ = filepath.WalkDir(reposDir, func(path string, d os.DirEntry, err error) error {


### PR DESCRIPTION
Add a persistent --log-level flag (default: warn) to the root
command so callers can pass --log-level debug to trace exactly
what happens during workspace open.

Add slog.DebugContext calls at every key decision point in the
workspace open flow:
- story load: story name, project count, code_root
- picker plugin: loaded or unavailable (with error)
- candidate build: count, code_root, story_projects
- repos dir scan path (in buildCandidates)
- picker recv error code and value
- FailedPrecondition fallback detection

This makes silent failures (e.g. 0 candidates → Aborted →
exit 0) visible without changing behaviour at the default
warn level.