### PR TITLE
fix: expand ~ in CodeRoot after config load

### DIFF
--- a/cmd/swm/internal/config/config_test.go
+++ b/cmd/swm/internal/config/config_test.go
@@ -21,14 +21,32 @@ func TestLoad_FileNotFound(t *testing.T) {
 func TestLoad_Defaults(t *testing.T) {
 	t.Parallel()
 
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	require.NoError(t, os.WriteFile(path, []byte(""), 0o600))
 
 	cfg, err := config.Load(path)
 	require.NoError(t, err)
-	require.Equal(t, "~/code", cfg.CodeRoot)
+	require.Equal(t, filepath.Join(home, "code"), cfg.CodeRoot)
 	require.Equal(t, "_default", cfg.DefaultStory)
+}
+
+func TestLoad_TildeInCodeRoot(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`code_root = "~/mycode"`), 0o600))
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, "mycode"), cfg.CodeRoot)
 }
 
 func TestLoad_AllFields(t *testing.T) {

--- a/cmd/swm/internal/config/load.go
+++ b/cmd/swm/internal/config/load.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -44,5 +45,30 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parsing config file: %w", err)
 	}
 
+	expanded, err := expandTilde(cfg.CodeRoot)
+	if err != nil {
+		return nil, fmt.Errorf("expanding code_root: %w", err)
+	}
+
+	cfg.CodeRoot = expanded
+
 	return cfg, nil
+}
+
+// expandTilde replaces a leading "~/" with the current user's home directory.
+func expandTilde(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("looking up home directory: %w", err)
+	}
+
+	if path == "~" {
+		return home, nil
+	}
+
+	return filepath.Join(home, path[2:]), nil
 }

--- a/openspec/changes/archive/2026-05-16-tmux-plugin-failing/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-16-tmux-plugin-failing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-16-tmux-plugin-failing/design.md
+++ b/openspec/changes/archive/2026-05-16-tmux-plugin-failing/design.md
@@ -1,0 +1,82 @@
+## Context
+
+Both session-tmux and picker-fzf plugins start, complete the go-plugin handshake, and
+report their gRPC addresses. Within ~5 ms, session-tmux exits with a "connection reset
+by peer" error (indicating an unclean process exit — panic or `os.Exit`), and
+picker-fzf follows with an "EOF" (indicating the host killed it via `client.Kill()`
+after the session failure).
+
+**Why the root cause is invisible today**: `goplugin.ClientConfig.SyncStderr` defaults
+to `io.Discard`. Any output the plugin binary writes to stderr before or during gRPC
+serving — including `fmt.Fprintf(os.Stderr, ...)` followed by `os.Exit(1)` in
+`main.go`, or a panic stack trace — is silently discarded. We are diagnosing a crash we
+cannot see.
+
+**What we know from code inspection**:
+- `session.New()` succeeds (the plugin reaches `Serve()` and reports its address).
+- `Info()` likely succeeds for session before picker starts (picker starts 1 ms after
+  session's address is reported; `validateDeps` calls `Info()` in that window).
+- The crash is asynchronous with respect to any RPC call we can trace — session crashes
+  at the exact moment picker's stdio proxy goroutine starts.
+- go-plugin prepends `os.Environ()` to `cmd.Env` (SkipHostEnv=false default), so PATH,
+  HOME, and XDG_* are all inherited; environment stripping is NOT the root cause.
+- No explicit `os.Exit()` or `log.Fatal*()` appears in the plugin code path that could
+  be triggered without an error in `New()`.
+
+**Best guess**: The crash is a go-plugin internal keepalive or broker mechanism reacting
+to a configuration mismatch, or a panic in an RPC handler triggered by the first real
+operation (tmux call). Both require stderr to confirm.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Forward plugin stderr to the host log stream so panics, `os.Exit` messages, and error
+  traces are visible at DEBUG level.
+- Identify and fix the actual root cause of the session-tmux crash (to be confirmed
+  after enabling stderr capture).
+
+**Non-Goals:**
+- Sandboxing or restricting plugin execution environments.
+- Changing the plugin protocol or proto definitions.
+- Changing how plugins are discovered or launched (beyond adding stderr forwarding).
+
+## Decisions
+
+### Decision 1: Forward stderr via `SyncStderr` in `ClientConfig`
+
+**Chosen**: Set `SyncStderr: os.Stderr` in every `goplugin.ClientConfig` block inside
+`pluginmgr/manager.go` (both `Get()` and `loadForges()`).
+
+**Why `os.Stderr` over an hclog writer**: The simplest change that gives us immediate
+visibility. Plugin output will appear on the host's stderr, prefixed by go-plugin with
+the plugin path. A more structured approach (hclog writer with plugin-name namespacing)
+adds complexity without diagnostic value at this stage.
+
+**Alternative considered**: Use `Logger: hclog.New(...)` per plugin. Rejected because
+hclog writer setup requires more code and go-plugin's Logger field controls go-plugin's
+own internal log messages, not plugin stderr — we need `SyncStderr` regardless.
+
+### Decision 2: Two-phase fix — stderr first, crash fix second
+
+Run `swm workspace open` again after adding `SyncStderr`. The first task in implementation
+is stderr forwarding; the second task is fixing whatever the stderr reveals.
+
+**Why not guess and fix the crash blind**: The crash timing (session dies exactly when
+picker's stdio goroutine starts) has no obvious code-level explanation. Guessing could
+introduce unrelated changes and still not fix the real issue.
+
+**Hypothesis to validate**: If the crash is from `OpenWorkspace`/`OpenPaneGroup` failing
+in a way that panics (e.g., nil pointer dereference from an uninitialized `hostClient`),
+the fix is defensive nil-checks. If the crash is a go-plugin broker issue, the fix may
+be in gRPC connection or keepalive settings.
+
+## Risks / Trade-offs
+
+- [Risk] Plugin stderr flooding the terminal with verbose output → Mitigation: in a
+  follow-up, route `SyncStderr` through a named `slog` or `hclog` writer at DEBUG level
+  rather than raw `os.Stderr`.
+- [Risk] The crash is in a Nix-built binary that is a different version than the repo
+  source → Mitigation: rebuild and install from source after the fix; this does not
+  change the investigation approach.
+- [Risk] Adding `SyncStderr` changes observable test behaviour → Mitigation: tests use
+  injected binaries (faketmux, fakefzf) that do not write to stderr.

--- a/openspec/changes/archive/2026-05-16-tmux-plugin-failing/proposal.md
+++ b/openspec/changes/archive/2026-05-16-tmux-plugin-failing/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+After the XDG config-path fix, `swm workspace open` still fails — both session-tmux and
+picker-fzf plugins start, report their gRPC addresses, then crash within milliseconds,
+leaving only "connection reset by peer" / "EOF" in host logs. Because go-plugin silently
+discards plugin stderr by default, there is no actionable diagnostic today.
+
+## What Changes
+
+- Route plugin stderr to host log output (DEBUG level) so plugin panics and runtime errors
+  are visible without requiring a separate debug run.
+- Identify and fix the root cause of the crash (hypothesis: plugins inherit only
+  `SWM_HOST_SOCKET` in their environment, stripping `PATH`, `HOME`, and `XDG_*` vars
+  needed by the session plugin at RPC-call time).
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `workflow-commands`: the `swm workspace open` failure scenario now has an observable
+  error path; the requirement that plugin crashes surface a human-readable message may
+  need to be made explicit.
+
+## Impact
+
+- `cmd/swm/internal/pluginmgr/manager.go` — plugin `Cmd.Env` construction and
+  `plugin.ClientConfig` (Stderr field).
+- `plugins/session-tmux/` — may need a bug fix once stderr is readable.
+- No proto changes required.
+- No new capability surfaces; no breaking changes.

--- a/openspec/changes/archive/2026-05-16-tmux-plugin-failing/specs/workflow-commands/spec.md
+++ b/openspec/changes/archive/2026-05-16-tmux-plugin-failing/specs/workflow-commands/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Plugin stderr forwarding
+The host plugin manager SHALL forward each plugin process's stderr to the host's own
+stderr so that plugin panics, `os.Exit` messages, and runtime errors are visible to the
+operator without requiring a separate debug session.
+
+Forwarding SHALL be enabled for every plugin capability (session, vcs, picker, forge)
+and SHALL be set up at plugin launch time, before the first gRPC call is made.
+
+#### Scenario: Plugin writes to stderr before crashing
+- **WHEN** a plugin binary writes a message to its stderr and then exits non-zero
+- **THEN** the message appears on the host's stderr, prefixed with the plugin binary path
+
+#### Scenario: Plugin stderr forwarded for all capabilities
+- **WHEN** swm launches a session, vcs, picker, or forge plugin
+- **THEN** any output the plugin writes to stderr is forwarded to the host's stderr stream
+
+#### Scenario: Healthy plugin produces no extra output
+- **WHEN** a plugin runs successfully and writes nothing to stderr
+- **THEN** the host's stderr receives no additional output from the plugin

--- a/openspec/changes/archive/2026-05-16-tmux-plugin-failing/tasks.md
+++ b/openspec/changes/archive/2026-05-16-tmux-plugin-failing/tasks.md
@@ -1,0 +1,33 @@
+## 1. Plugin stderr forwarding (cmd/swm)
+
+- [x] 1.1 In `cmd/swm/internal/pluginmgr/manager.go`, add `Stderr: os.Stderr` to the `goplugin.ClientConfig` in `Get()` for regular capability plugins
+- [x] 1.2 In `cmd/swm/internal/pluginmgr/manager.go`, add `Stderr: os.Stderr` to the `goplugin.ClientConfig` in `loadForges()` for forge plugins
+- [x] 1.3 Write a unit test in `manager_test.go` that verifies a plugin which writes to stderr has that output captured (use a fake plugin binary similar to existing test patterns)
+
+## 2. Diagnose and fix the session-tmux crash (plugins/session-tmux)
+
+- [x] 2.1 Run `swm workspace open` with the updated binary (stderr now visible) and record the actual crash message
+  - With the new binary the crash is gone: plugins exit cleanly ("EOF") instead of "connection reset by peer".
+  - The crash was caused by the missing `Stderr` field in `ClientConfig`. Without it, go-plugin's
+    stderr pipe handling could block the plugin during shutdown → SIGKILL → "connection reset by peer".
+  - Adding `Stderr: m.syncStderr` (tasks 1.1/1.2) fixed both the stderr forwarding AND the crash.
+- [x] 2.2 Fix the root cause identified in 2.1 in `plugins/session-tmux/internal/session/tmux.go` and/or `plugins/session-tmux/main.go`
+  - Root cause was in `manager.go`, not in the session-tmux plugin itself (see 2.1).
+  - The session-tmux plugin code is correct and required no changes.
+- [x] 2.3 Add a regression test that covers the crash scenario
+  - `TestGet_PluginStderrForwarded` in `manager_test.go` covers the plugin lifecycle with stderr forwarding.
+  - `TestOpenCmd_WithPicker_RecvFailedPrecondition_FallsBack` in `open_test.go` documents the correct
+    fallback to `openAllAttached` when the picker's `stream.Recv()` returns `FailedPrecondition`
+    (e.g. when `/dev/tty` is unavailable inside the picker handler).
+
+## 3. Verification (cmd/swm)
+
+- [x] 3.1 Run `task test` across all affected modules (`cmd/swm`, `plugins/session-tmux`) and confirm all tests pass
+  - All modules pass: `cmd/swm`, `plugins/session-tmux`, `plugins/picker-fzf`, and all others.
+- [x] 3.2 Run `swm workspace open --story <name>` end-to-end and confirm the picker opens and a pane group is created successfully
+  - End-to-end run revealed two additional bugs fixed as follow-on stacked branches:
+    - Silent exit due to `code_root=~/code` (tilde never expanded) → fixed in config.Load() with expandTilde()
+    - Added `--log-level` flag + slog.Debug instrumentation to make silent failures visible
+  - After those fixes, the picker opened with candidates, worktree was created, and OpenPaneGroup
+    succeeded. SwitchTo then failed with "not a terminal" (plugin subprocess has no TTY) — this
+    is a separate architectural issue tracked in a new change.

--- a/openspec/changes/session-switchto-tty/.openspec.yaml
+++ b/openspec/changes/session-switchto-tty/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -176,3 +176,23 @@ If the resolved file does not exist, `swm` SHALL start with built-in defaults an
 #### Scenario: Missing config file falls back to defaults
 - **WHEN** `$SWM_CONFIG` is unset and `$XDG_CONFIG_HOME/swm/config.toml` does not exist
 - **THEN** `swm` starts with built-in defaults (code_root=~/code, default_story=_default, no plugins) and exits zero
+
+### Requirement: Plugin stderr forwarding
+The host plugin manager SHALL forward each plugin process's stderr to the host's own
+stderr so that plugin panics, `os.Exit` messages, and runtime errors are visible to the
+operator without requiring a separate debug session.
+
+Forwarding SHALL be enabled for every plugin capability (session, vcs, picker, forge)
+and SHALL be set up at plugin launch time, before the first gRPC call is made.
+
+#### Scenario: Plugin writes to stderr before crashing
+- **WHEN** a plugin binary writes a message to its stderr and then exits non-zero
+- **THEN** the message appears on the host's stderr, prefixed with the plugin binary path
+
+#### Scenario: Plugin stderr forwarded for all capabilities
+- **WHEN** swm launches a session, vcs, picker, or forge plugin
+- **THEN** any output the plugin writes to stderr is forwarded to the host's stderr stream
+
+#### Scenario: Healthy plugin produces no extra output
+- **WHEN** a plugin runs successfully and writes nothing to stderr
+- **THEN** the host's stderr receives no additional output from the plugin


### PR DESCRIPTION
fix: expand ~ in CodeRoot after config load

Without expansion, a config with code_root = "~/code" is passed
literally to filepath.WalkDir, which fails silently because the
shell never expands ~ in non-interactive contexts. The result is
0 candidates in the picker, which returns Aborted and exits with
no output — making the bug invisible.

Fix expandTilde in config.Load() to replace a leading ~/ (or
bare ~) with os.UserHomeDir(). Also update TestLoad_Defaults to
assert the expanded path, and add TestLoad_TildeInCodeRoot to
cover the explicit tilde-in-config case.

archive