### PR TITLE
feat: use positional arg for workspace open

### DIFF
--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -43,13 +43,18 @@ func NewOpenCmd(
 	resolver *layout.Resolver,
 	hooks hookexec.Runner,
 ) *cobra.Command {
-	var storyName string
-
 	cmd := &cobra.Command{
-		Use:   "open",
+		Use:   "open [story-name]",
 		Short: "Open (or attach to) the workspace for a story",
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			var storyName string
+
+			if len(args) > 0 {
+				storyName = args[0]
+			}
 
 			if storyName == "" {
 				storyName = os.Getenv("SWM_STORY")
@@ -140,8 +145,6 @@ func NewOpenCmd(
 			return nil
 		},
 	}
-
-	cmd.Flags().StringVar(&storyName, "story", "", "story name (default: $SWM_STORY or default story)")
 
 	return cmd
 }

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -46,7 +46,10 @@ func NewOpenCmd(
 	cmd := &cobra.Command{
 		Use:   "open [story-name]",
 		Short: "Open (or attach to) the workspace for a story",
-		Args:  cobra.MaximumNArgs(1),
+		Long: "Open (or attach to) the workspace for a story. " +
+			"If [story-name] is omitted, the command falls back to the $SWM_STORY " +
+			"environment variable, and then to the default story configured in swm.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -242,7 +242,7 @@ func TestOpenCmd_WithPicker_RecvFailedPrecondition_FallsBack(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
 	require.NotNil(t, sess.lastOpenReq, "expected OpenWorkspace to be called as fallback")

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -26,7 +26,6 @@ const (
 	testCodeRoot     = "/code"
 	testDefaultStory = "_default"
 	testStoryName    = "feat-x"
-	testStoryFlag    = "--story"
 	testHost         = "github.com"
 	testOwner        = "kalbasit"
 	testSegment      = "swm"
@@ -34,7 +33,7 @@ const (
 
 var errNoPlugin = errors.New("no plugin")
 
-func TestOpenCmd_WithStoryFlag(t *testing.T) {
+func TestOpenCmd_WithPositionalArg(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
@@ -44,7 +43,23 @@ func TestOpenCmd_WithStoryFlag(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, testStoryName, sess.lastOpenReq.GetStoryName())
+}
+
+func TestOpenCmd_PositionalArgOverridesEnv(t *testing.T) {
+	t.Setenv("SWM_STORY", "env-story")
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
+	sess := &stubSess{}
+	mgr := &stubMgr{sess: sess}
+	resolver := layout.NewResolver(testCodeRoot)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
 	require.Equal(t, testStoryName, sess.lastOpenReq.GetStoryName())
@@ -75,7 +90,7 @@ func TestOpenCmd_StoryNotFound(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, "nonexistent"})
+	cmd.SetArgs([]string{"nonexistent"})
 
 	require.Error(t, cmd.Execute())
 }
@@ -90,7 +105,7 @@ func TestOpenCmd_NoProjects(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
 	require.Empty(t, sess.lastOpenReq.GetWorktreePaths())
@@ -115,7 +130,7 @@ func TestOpenCmd_WithPicker_ProjectAlreadyAttached(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
 
@@ -145,7 +160,7 @@ func TestOpenCmd_WithPicker_ProjectNotAttached(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
 
@@ -172,7 +187,7 @@ func TestOpenCmd_WithPicker_Cancelled(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	// Cancellation is not an error.
 	require.NoError(t, cmd.Execute())
@@ -196,7 +211,7 @@ func TestOpenCmd_WithPicker_FailedPrecondition_FallsBack(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	// Should succeed by falling back to Phase-1 behavior.
 	require.NoError(t, cmd.Execute())
@@ -245,7 +260,7 @@ func TestOpenCmd_WithPicker_InvalidKey_EmptyHost(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -263,7 +278,7 @@ func TestOpenCmd_WithPicker_InvalidKey_EmptySegments(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -281,7 +296,7 @@ func TestOpenCmd_WithPicker_InvalidKey_EmptySegmentPart(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -303,7 +318,7 @@ func TestOpenCmd_NoPicker_FallsBackToPhase1(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
 

--- a/cmd/swm/tests/integration/integration_test.go
+++ b/cmd/swm/tests/integration/integration_test.go
@@ -216,7 +216,7 @@ func TestWorkspaceOpenWithPicker(t *testing.T) {
 	var buf bytes.Buffer
 
 	root2 := cli.NewRootCmd(cfg, mgr, store, resolver)
-	root2.SetArgs([]string{"workspace", cmdOpen, flagStory, testStoryName})
+	root2.SetArgs([]string{"workspace", cmdOpen, testStoryName})
 	root2.SetOut(&buf)
 	require.NoError(t, root2.Execute())
 
@@ -240,7 +240,7 @@ func TestWorkspaceOpen(t *testing.T) {
 	var buf bytes.Buffer
 
 	root := cli.NewRootCmd(cfg, mgr, store, resolver)
-	root.SetArgs([]string{"workspace", cmdOpen, flagStory, testStoryName})
+	root.SetArgs([]string{"workspace", cmdOpen, testStoryName})
 	root.SetOut(&buf)
 	require.NoError(t, root.Execute())
 

--- a/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/design.md
+++ b/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/design.md
@@ -1,0 +1,37 @@
+# Design: workspace-open-positional-argz
+
+## Context
+
+`workspace open` is the primary daily-driver command in swm. The current interface requires `--story <name>` which is more verbose than the idiomatic positional form. The entire change is contained in one file (`cmd/swm/internal/cli/workspace/open.go`) plus integration tests and the spec delta.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace `--story` flag with an optional positional argument
+- Preserve the existing resolution fallback chain: positional arg → `$SWM_STORY` → `cfg.DefaultStory`
+
+**Non-Goals:**
+- Changing fallback behaviour or priority order
+- Deprecating or aliasing the old flag (hard removal)
+
+## Decisions
+
+### Use `cobra.MaximumNArgs(1)` + `args[0]` instead of `StringVar`
+
+Replace `cmd.Flags().StringVar(&storyName, "story", ...)` with `Args: cobra.MaximumNArgs(1)` and read `args[0]` inside `RunE`. This is the standard cobra idiom for optional positional arguments. No helper libraries needed.
+
+**Alternatives considered:**
+- Keep `--story` as an alias: adds maintenance burden and contradicts the goal of simplifying the interface.
+- Accept both positional and `--story` with mutual exclusion: unnecessary complexity for a single optional arg.
+
+## Risks / Trade-offs
+
+- **Breaking change**: existing scripts/aliases using `--story` will break. Mitigation: this is intentional and the proposal explicitly marks it breaking.
+- **Autocomplete**: cobra's completion for positional args is less ergonomic than flag completion for some shells. Mitigation: out of scope for this change; story name completion can be added separately.
+
+## Migration Plan
+
+1. Remove `--story` flag registration from `NewOpenCmd`.
+2. Change `RunE` signature to use `args []string` and extract `storyName` from `args[0]` when present.
+3. Update integration tests that pass `--story`.
+4. No rollback required — this is a CLI-only change with no persisted state.

--- a/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/proposal.md
+++ b/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/proposal.md
@@ -1,0 +1,32 @@
+# Proposal: workspace-open-positional-argz
+
+## Why
+
+`swm workspace open --story <name>` is unnecessarily verbose for the most common operation in swm. Positional arguments are the idiomatic CLI convention for primary operands, and the `--story` flag adds friction compared to `swm workspace open swm-use-gh`.
+
+## What Changes
+
+- **BREAKING**: `swm workspace open <story-name>` replaces `swm workspace open --story <story-name>` as the canonical form
+- Remove the `--story` flag from `workspace open`
+- Positional story name remains optional; fallback order is unchanged: positional arg → `$SWM_STORY` → `cfg.DefaultStory`
+
+## Non-goals
+
+- Changing fallback behaviour (env var and default story remain)
+- Modifying any other command's argument style
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `workflow-commands`: `workspace open` switches from a named flag to a positional argument for story name — spec-level CLI contract change
+
+## Impact
+
+- `cmd/swm/internal/cli/workspace/open.go` — replace `StringVar` flag with `cobra.Args` positional arg parsing
+- Integration tests in `cmd/swm/tests/integration/` that invoke `workspace open --story` must be updated
+- Any documentation or examples using `--story` flag must be updated

--- a/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/specs/workflow-commands/spec.md
+++ b/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/specs/workflow-commands/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: swm workspace open
+`swm workspace open [<story-name>]` SHALL open (or switch to) the tmux workspace for a story. The flow depends on whether a picker plugin is configured:
+
+Before opening the workspace the command SHALL run `hookexec.Run` for event `pre-workspace-open` with the story name set. If any `pre-workspace-open` hook returns non-zero the command SHALL abort. After the workspace is open the command SHALL run `hookexec.Run` for event `post-workspace-open`; failures are logged but do not affect the exit code.
+
+**With picker configured:**
+1. Run `pre-workspace-open` hooks; abort if any fail.
+2. Resolve story from positional `<story-name>` argument, `$SWM_STORY` env var, or `_default`.
+3. Build a candidate list: all projects already attached to the story plus all repositories discovered under `$CODE_ROOT/repositories/` via `host.ListProjects`.
+4. Stream candidates to `picker.Pick`; each candidate's `display` is its project ID string (e.g. `github.com/kalbasit/swm`) and `key` is the same string.
+5. Receive the selected project ID from the picker.
+6. If the selected project is NOT already attached to the story: call `vcs.CreateWorktree` for that project and attach it to the story in the story store.
+7. Call `session.OpenWorkspace` to ensure the workspace is active.
+8. Call `session.OpenPaneGroup` with the derived worktree path for the selected project.
+9. Run `post-workspace-open` hooks.
+
+**Without picker configured (fallback):**
+1. Run `pre-workspace-open` hooks; abort if any fail.
+2. Resolve story.
+3. Load all attached projects from the story store.
+4. Call `session.OpenWorkspace({story_name, worktree_paths: {project_key: derived_path}})`.
+5. If the workspace was already open, call `session.SwitchTo` for the first pane group.
+6. Run `post-workspace-open` hooks.
+
+#### Scenario: Interactive selection with picker — project already attached
+- **WHEN** `swm workspace open feat-x` is run and picker is configured and `feat-x` has `proj-a` attached
+- **THEN** `pre-workspace-open` runs, picker receives all candidates, user selects `proj-a`, `OpenWorkspace` and `OpenPaneGroup` are called, `post-workspace-open` runs
+
+#### Scenario: Interactive selection with picker — project not yet attached
+- **WHEN** `swm workspace open feat-x` is run and picker is configured and user selects `proj-b` (not yet attached)
+- **THEN** `vcs.CreateWorktree` is called for `proj-b`, `proj-b` is attached to the story in the store, then workspace and pane group are opened
+
+#### Scenario: Picker cancelled by user
+- **WHEN** `swm workspace open feat-x` is run and picker is configured and the user cancels selection
+- **THEN** the command exits with code 0 and no workspace is opened
+
+#### Scenario: No picker configured — opens all attached projects
+- **WHEN** `swm workspace open feat-x` is run and no picker is configured
+- **THEN** `OpenWorkspace` is called with all attached projects' worktree paths
+
+#### Scenario: Story from environment
+- **WHEN** `swm workspace open` is run with `$SWM_STORY=feat-x` set and no positional argument
+- **THEN** the workspace for `feat-x` is opened
+
+#### Scenario: Positional argument overrides environment variable
+- **WHEN** `swm workspace open other-story` is run with `$SWM_STORY=feat-x` set
+- **THEN** the workspace for `other-story` is opened (positional arg takes priority)
+
+#### Scenario: Default story
+- **WHEN** `swm workspace open` is run with no positional argument and no `$SWM_STORY`
+- **THEN** the workspace for the `_default` story is opened
+
+#### Scenario: Story not found
+- **WHEN** `swm workspace open nonexistent` is run and no story named `nonexistent` exists
+- **THEN** the command exits with a non-zero code indicating the story was not found
+
+#### Scenario: Story with no projects and no picker
+- **WHEN** `swm workspace open feat-x` is run, no picker is configured, and `feat-x` has no attached projects
+- **THEN** `OpenWorkspace` is called with an empty worktree_paths map
+
+#### Scenario: pre-workspace-open hook aborts open
+- **WHEN** `swm workspace open feat-x` is run and a `pre-workspace-open` hook exits non-zero
+- **THEN** the command aborts before opening the workspace and returns a non-zero exit code

--- a/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/tasks.md
+++ b/openspec/changes/archive/2026-05-16-workspace-open-positional-argz/tasks.md
@@ -1,0 +1,13 @@
+## 1. Tests (TDD — write before implementation)
+
+- [x] 1.1 cmd/swm: Add unit tests in `open_test.go` covering positional arg resolves story name, positional arg takes priority over `$SWM_STORY`, and no positional arg falls back to `$SWM_STORY` then default story
+- [x] 1.2 cmd/swm: Update integration tests in `cmd/swm/tests/integration/` that call `workspace open --story <name>` to use the positional form `workspace open <name>`
+
+## 2. Core Implementation
+
+- [x] 2.1 cmd/swm: In `NewOpenCmd` (`cmd/swm/internal/cli/workspace/open.go`), remove `StringVar` registration for `--story`, add `Args: cobra.MaximumNArgs(1)` to the command, and extract story name from `args[0]` in `RunE` when present
+- [x] 2.2 cmd/swm: Update the `Use` field from `"open"` to `"open [story-name]"` and the `Short` description to reflect positional arg
+
+## 3. Verification
+
+- [x] 3.1 cmd/swm: Run `task fmt && task lint && task test` and confirm all exit 0

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -81,13 +81,13 @@ The repository is NOT attached to any story.
 - **THEN** `vcs.Clone` is NOT called and the command exits non-zero
 
 ### Requirement: swm workspace open
-`swm workspace open [--story <name>]` SHALL open (or switch to) the tmux workspace for a story. The flow depends on whether a picker plugin is configured:
+`swm workspace open [<story-name>]` SHALL open (or switch to) the tmux workspace for a story. The flow depends on whether a picker plugin is configured:
 
 Before opening the workspace the command SHALL run `hookexec.Run` for event `pre-workspace-open` with the story name set. If any `pre-workspace-open` hook returns non-zero the command SHALL abort. After the workspace is open the command SHALL run `hookexec.Run` for event `post-workspace-open`; failures are logged but do not affect the exit code.
 
 **With picker configured:**
 1. Run `pre-workspace-open` hooks; abort if any fail.
-2. Resolve story from `--story` flag, `$SWM_STORY` env var, or `_default`.
+2. Resolve story from positional `<story-name>` argument, `$SWM_STORY` env var, or `_default`.
 3. Build a candidate list: all projects already attached to the story plus all repositories discovered under `$CODE_ROOT/repositories/` via `host.ListProjects`.
 4. Stream candidates to `picker.Pick`; each candidate's `display` is its project ID string (e.g. `github.com/kalbasit/swm`) and `key` is the same string.
 5. Receive the selected project ID from the picker.
@@ -105,40 +105,44 @@ Before opening the workspace the command SHALL run `hookexec.Run` for event `pre
 6. Run `post-workspace-open` hooks.
 
 #### Scenario: Interactive selection with picker — project already attached
-- **WHEN** `swm workspace open --story feat-x` is run, a picker is configured, and the user selects a project already attached to `feat-x`
-- **THEN** `picker.Pick` is called with all candidates, `session.OpenPaneGroup` is called with the selected project's worktree path, and no `vcs.CreateWorktree` call is made
+- **WHEN** `swm workspace open feat-x` is run and picker is configured and `feat-x` has `proj-a` attached
+- **THEN** `pre-workspace-open` runs, picker receives all candidates, user selects `proj-a`, `OpenWorkspace` and `OpenPaneGroup` are called, `post-workspace-open` runs
 
 #### Scenario: Interactive selection with picker — project not yet attached
-- **WHEN** `swm workspace open --story feat-x` is run, a picker is configured, and the user selects a project NOT yet attached to `feat-x`
-- **THEN** `vcs.CreateWorktree` is called for the selected project, the project is recorded in the story store, and `session.OpenPaneGroup` is called with the new worktree path
+- **WHEN** `swm workspace open feat-x` is run and picker is configured and user selects `proj-b` (not yet attached)
+- **THEN** `vcs.CreateWorktree` is called for `proj-b`, `proj-b` is attached to the story in the store, then workspace and pane group are opened
 
 #### Scenario: Picker cancelled by user
-- **WHEN** `swm workspace open --story feat-x` is run, a picker is configured, and the user cancels the picker (Escape / Ctrl-C)
-- **THEN** the command exits 0 with no workspace changes and no error message to the user
+- **WHEN** `swm workspace open feat-x` is run and picker is configured and the user cancels selection
+- **THEN** the command exits with code 0 and no workspace is opened
 
 #### Scenario: No picker configured — opens all attached projects
-- **WHEN** `swm workspace open --story feat-x` is run and no picker plugin is configured
-- **THEN** `session.OpenWorkspace` is called with all projects attached to `feat-x` (Phase 1 behaviour)
+- **WHEN** `swm workspace open feat-x` is run and no picker is configured
+- **THEN** `OpenWorkspace` is called with all attached projects' worktree paths
 
 #### Scenario: Story from environment
-- **WHEN** `swm workspace open` is run with `$SWM_STORY=feat-x` set
-- **THEN** the workspace for `feat-x` is opened (same as `--story feat-x`)
+- **WHEN** `swm workspace open` is run with `$SWM_STORY=feat-x` set and no positional argument
+- **THEN** the workspace for `feat-x` is opened
+
+#### Scenario: Positional argument overrides environment variable
+- **WHEN** `swm workspace open other-story` is run with `$SWM_STORY=feat-x` set
+- **THEN** the workspace for `other-story` is opened (positional arg takes priority)
 
 #### Scenario: Default story
-- **WHEN** `swm workspace open` is run with no `--story` flag and no `$SWM_STORY`
+- **WHEN** `swm workspace open` is run with no positional argument and no `$SWM_STORY`
 - **THEN** the workspace for the `_default` story is opened
 
 #### Scenario: Story not found
-- **WHEN** `swm workspace open --story nonexistent` is run
-- **THEN** the command exits non-zero with an error indicating the story was not found
+- **WHEN** `swm workspace open nonexistent` is run and no story named `nonexistent` exists
+- **THEN** the command exits with a non-zero code indicating the story was not found
 
 #### Scenario: Story with no projects and no picker
-- **WHEN** `swm workspace open --story feat-x` is run, no picker is configured, and `feat-x` has no attached projects
-- **THEN** `session.OpenWorkspace` is called with an empty `worktree_paths` map; the session plugin opens an empty workspace
+- **WHEN** `swm workspace open feat-x` is run, no picker is configured, and `feat-x` has no attached projects
+- **THEN** `OpenWorkspace` is called with an empty worktree_paths map
 
 #### Scenario: pre-workspace-open hook aborts open
-- **WHEN** a `pre-workspace-open` hook exits non-zero
-- **THEN** no workspace is opened and the command exits non-zero
+- **WHEN** `swm workspace open feat-x` is run and a `pre-workspace-open` hook exits non-zero
+- **THEN** the command aborts before opening the workspace and returns a non-zero exit code
 
 ### Requirement: swm story list
 `swm story list` SHALL print all story names to stdout, one per line, in


### PR DESCRIPTION
Replace --story flag with an optional positional argument in
'swm workspace open'. The flag added friction compared to the
idiomatic form; 'swm workspace open swm-use-gh' is now valid.

Fallback order is unchanged: positional arg → $SWM_STORY →
cfg.DefaultStory. The --story flag is fully removed (hard
breaking change, no alias).

Adds TestOpenCmd_WithPositionalArg and
TestOpenCmd_PositionalArgOverridesEnv unit tests.