### PR TITLE
test(config): use filepath.Join for path compare

### DIFF
--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -45,6 +45,10 @@ type grpcStatuser interface {
 // status.Code() does not unwrap, so fmt.Errorf-wrapped gRPC errors
 // would always return codes.Unknown without this helper.
 func grpcCode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+
 	var s grpcStatuser
 	if errors.As(err, &s) {
 		return s.GRPCStatus().Code()

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -36,6 +36,23 @@ var (
 	errInvalidProjectKey    = errors.New("invalid project key: must be host/seg1/.../segN")
 )
 
+// grpcStatuser is satisfied by any error that carries a gRPC status.
+type grpcStatuser interface {
+	GRPCStatus() *status.Status
+}
+
+// grpcCode unwraps the error chain to find a gRPC status code.
+// status.Code() does not unwrap, so fmt.Errorf-wrapped gRPC errors
+// would always return codes.Unknown without this helper.
+func grpcCode(err error) codes.Code {
+	var s grpcStatuser
+	if errors.As(err, &s) {
+		return s.GRPCStatus().Code()
+	}
+
+	return codes.Unknown
+}
+
 // ExecFunc is the type used to replace the current process (default: syscall.Exec).
 type ExecFunc func(argv0 string, argv []string, envv []string) error
 
@@ -142,11 +159,11 @@ func NewOpenCmd(
 				if openErr != nil {
 					slog.DebugContext(
 						ctx, "picker returned error, checking fallback",
-						"code", status.Code(openErr).String(),
+						"code", grpcCode(openErr).String(),
 						"err", openErr,
 					)
 
-					if status.Code(openErr) == codes.FailedPrecondition {
+					if grpcCode(openErr) == codes.FailedPrecondition {
 						slog.DebugContext(ctx, "falling back to openAllAttached (no TTY)")
 						openErr = openAllAttached(ctx, cmd, st, sess, resolver, storyName)
 					}

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -155,7 +155,7 @@ func NewOpenCmd(
 
 			var openErr error
 			if pickerClient != nil {
-				openErr = openWithPicker(ctx, cmd, cfg, st, store, mgr, sess, pickerClient, resolver, storyName, ocfg.exec)
+				openErr = openWithPicker(ctx, cmd, cfg, st, store, mgr, sess, pickerClient, resolver, hooks, storyName, ocfg.exec)
 				if openErr != nil {
 					slog.DebugContext(
 						ctx, "picker returned error, checking fallback",
@@ -165,26 +165,14 @@ func NewOpenCmd(
 
 					if grpcCode(openErr) == codes.FailedPrecondition {
 						slog.DebugContext(ctx, "falling back to openAllAttached (no TTY)")
-						openErr = openAllAttached(ctx, cmd, st, sess, resolver, storyName)
+						openErr = openAllAttached(ctx, cmd, cfg, st, sess, resolver, hooks, storyName, ocfg.exec)
 					}
 				}
 			} else {
-				openErr = openAllAttached(ctx, cmd, st, sess, resolver, storyName)
+				openErr = openAllAttached(ctx, cmd, cfg, st, sess, resolver, hooks, storyName, ocfg.exec)
 			}
 
-			if openErr != nil {
-				return openErr
-			}
-
-			if err := hooks.Run(ctx, hookexec.RunConfig{
-				Event:     "post-workspace-open",
-				CodeRoot:  cfg.CodeRoot,
-				StoryName: storyName,
-			}); err != nil {
-				slog.WarnContext(ctx, "post-workspace-open hook failed (ignored)", "err", err)
-			}
-
-			return nil
+			return openErr
 		},
 	}
 
@@ -203,6 +191,7 @@ func openWithPicker(
 	sess pluginv1.SessionClient,
 	pickerClient pluginv1.PickerClient,
 	resolver *layout.Resolver,
+	hooks hookexec.Runner,
 	storyName string,
 	execFn ExecFunc,
 ) error {
@@ -317,6 +306,16 @@ func openWithPicker(
 
 	cmd.Printf("opened pane group %q in workspace %q\n", pg.GetPaneGroupId(), storyName)
 
+	// Run the post hook before exec so it is not skipped when the host process
+	// is replaced by syscall.Exec.
+	if err := hooks.Run(ctx, hookexec.RunConfig{
+		Event:     "post-workspace-open",
+		CodeRoot:  cfg.CodeRoot,
+		StoryName: storyName,
+	}); err != nil {
+		slog.WarnContext(ctx, "post-workspace-open hook failed (ignored)", "err", err)
+	}
+
 	if argv := switchRes.GetExecArgv(); len(argv) > 0 {
 		if err := execFn(argv[0], argv, os.Environ()); err != nil {
 			return fmt.Errorf("exec after switch: %w", err)
@@ -330,10 +329,13 @@ func openWithPicker(
 func openAllAttached(
 	ctx context.Context,
 	cmd *cobra.Command,
+	cfg *config.Config,
 	st *coreStory.Story,
 	sess pluginv1.SessionClient,
 	resolver *layout.Resolver,
+	hooks hookexec.Runner,
 	storyName string,
+	execFn ExecFunc,
 ) error {
 	worktreePaths := make(map[string]string, len(st.Projects))
 
@@ -344,14 +346,59 @@ func openAllAttached(
 		worktreePaths[key] = resolver.WorktreePath(storyName, pid)
 	}
 
-	if _, err := sess.OpenWorkspace(ctx, &pluginv1.OpenWorkspaceRequest{
+	ws, err := sess.OpenWorkspace(ctx, &pluginv1.OpenWorkspaceRequest{
 		StoryName:     storyName,
 		WorktreePaths: worktreePaths,
-	}); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("opening workspace: %w", err)
 	}
 
 	cmd.Printf("workspace opened for story %q\n", storyName)
+
+	// With no attached projects there is no pane group to switch to.
+	if len(st.Projects) == 0 {
+		return nil
+	}
+
+	// Open a pane group for the first attached project and switch to it so that
+	// exec (tmux attach-session) works consistently with the picker path.
+	first := &st.Projects[0]
+	firstPID := &pluginv1.ProjectID{Host: first.Host, Segments: first.Segments}
+	firstKey := first.Host + "/" + strings.Join(first.Segments, "/")
+
+	pg, err := sess.OpenPaneGroup(ctx, &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  ws.GetWorkspaceId(),
+		ProjectId:    firstPID,
+		WorktreePath: worktreePaths[firstKey],
+	})
+	if err != nil {
+		return fmt.Errorf("opening pane group: %w", err)
+	}
+
+	// Run the post hook before exec so it is not skipped when the host process
+	// is replaced by syscall.Exec.
+	if err := hooks.Run(ctx, hookexec.RunConfig{
+		Event:     "post-workspace-open",
+		CodeRoot:  cfg.CodeRoot,
+		StoryName: storyName,
+	}); err != nil {
+		slog.WarnContext(ctx, "post-workspace-open hook failed (ignored)", "err", err)
+	}
+
+	switchRes, err := sess.SwitchTo(ctx, &pluginv1.SwitchToRequest{
+		WorkspaceId: ws.GetWorkspaceId(),
+		PaneGroupId: pg.GetPaneGroupId(),
+	})
+	if err != nil {
+		return fmt.Errorf("switching to pane group: %w", err)
+	}
+
+	if argv := switchRes.GetExecArgv(); len(argv) > 0 {
+		if err := execFn(argv[0], argv, os.Environ()); err != nil {
+			return fmt.Errorf("exec after switch: %w", err)
+		}
+	}
 
 	return nil
 }

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -388,7 +388,7 @@ func TestOpenCmd_NoPicker_ExecArgvIsExeced(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop, workspace.WithExecFunc(testExec))
-	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
 	require.Equal(t, wantArgv, gotArgv, "expected execFunc to be called with the argv from SwitchTo")

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -216,9 +216,9 @@ func TestOpenCmd_WithPicker_FailedPrecondition_FallsBack(t *testing.T) {
 	// Should succeed by falling back to Phase-1 behavior.
 	require.NoError(t, cmd.Execute())
 
-	// Phase-1 path: OpenWorkspace was called (not OpenPaneGroup).
+	// Fallback path: OpenWorkspace AND OpenPaneGroup are both called.
 	require.NotNil(t, sess.lastOpenReq, "expected OpenWorkspace to be called as fallback")
-	require.Nil(t, sess.lastPaneGroupReq, "expected OpenPaneGroup NOT to be called")
+	require.NotNil(t, sess.lastPaneGroupReq, "expected OpenPaneGroup to be called in fallback path")
 }
 
 // TestOpenCmd_WithPicker_RecvFailedPrecondition_FallsBack covers the case where the
@@ -246,7 +246,7 @@ func TestOpenCmd_WithPicker_RecvFailedPrecondition_FallsBack(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	require.NotNil(t, sess.lastOpenReq, "expected OpenWorkspace to be called as fallback")
-	require.Nil(t, sess.lastPaneGroupReq, "expected OpenPaneGroup NOT to be called")
+	require.NotNil(t, sess.lastPaneGroupReq, "expected OpenPaneGroup to be called in fallback path")
 }
 
 func TestOpenCmd_WithPicker_InvalidKey_EmptyHost(t *testing.T) {
@@ -360,6 +360,38 @@ func TestOpenCmd_NoPicker_FallsBackToPhase1(t *testing.T) {
 	// Phase 1 path: OpenWorkspace with all attached projects.
 	require.NotNil(t, sess.lastOpenReq)
 	require.Contains(t, sess.lastOpenReq.GetWorktreePaths(), "github.com/kalbasit/swm")
+}
+
+func TestOpenCmd_NoPicker_ExecArgvIsExeced(t *testing.T) {
+	t.Parallel()
+
+	wantArgv := []string{"/usr/bin/tmux", "attach-session", "-t", testStoryName}
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name: testStoryName,
+		Projects: []coreStory.Project{
+			{Host: testHost, Segments: []string{testOwner, testSegment}},
+		},
+	}}
+
+	var gotArgv []string
+
+	testExec := workspace.ExecFunc(func(_ string, argv []string, _ []string) error {
+		gotArgv = argv
+
+		return nil
+	})
+
+	sess := &stubSess{switchToExecArgv: wantArgv}
+	mgr := &stubMgr{sess: sess} // no picker configured
+	resolver := layout.NewResolver(testCodeRoot)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop, workspace.WithExecFunc(testExec))
+	cmd.SetArgs([]string{testStoryFlag, testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, wantArgv, gotArgv, "expected execFunc to be called with the argv from SwitchTo")
 }
 
 // ─── stubs ───────────────────────────────────────────────────────────────────

--- a/cmd/swm/internal/config/config_test.go
+++ b/cmd/swm/internal/config/config_test.go
@@ -105,7 +105,7 @@ func TestResolveConfigPath_EnvVarEmpty(t *testing.T) {
 	t.Parallel()
 
 	got := config.ResolveConfigPath("", "/home/user/.config")
-	require.Equal(t, "/home/user/.config/swm/config.toml", got)
+	require.Equal(t, filepath.Join("/home/user/.config", "swm", "config.toml"), got)
 }
 
 func TestLoad_BadTOML(t *testing.T) {

--- a/cmd/swm/internal/config/config_test.go
+++ b/cmd/swm/internal/config/config_test.go
@@ -49,6 +49,27 @@ func TestLoad_TildeInCodeRoot(t *testing.T) {
 	require.Equal(t, filepath.Join(home, "mycode"), cfg.CodeRoot)
 }
 
+func TestLoad_TildeInPluginPaths(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+code_root = "/code"
+
+[plugins.paths]
+vcs-git = "~/bin/swm-plugin-vcs-git"
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, "bin", "swm-plugin-vcs-git"), cfg.Plugins.Paths["vcs-git"])
+}
+
 func TestLoad_AllFields(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/config/load.go
+++ b/cmd/swm/internal/config/load.go
@@ -52,6 +52,15 @@ func Load(path string) (*Config, error) {
 
 	cfg.CodeRoot = expanded
 
+	for name, p := range cfg.Plugins.Paths {
+		expanded, err := expandTilde(p)
+		if err != nil {
+			return nil, fmt.Errorf("expanding plugin path for %s: %w", name, err)
+		}
+
+		cfg.Plugins.Paths[name] = expanded
+	}
+
 	return cfg, nil
 }
 

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -66,10 +66,11 @@ type forgeEntry struct {
 type Option func(*Manager)
 
 // WithStderr sets the writer that receives the raw stderr output of plugin processes.
+// The provided writer must be thread-safe as it may be shared by multiple concurrent plugins.
 // Defaults to os.Stderr when not specified.
 func WithStderr(w io.Writer) Option {
 	return func(m *Manager) {
-		m.syncStderr = w
+		m.stderr = w
 	}
 }
 
@@ -77,7 +78,7 @@ func WithStderr(w io.Writer) Option {
 type Manager struct {
 	cfg        *config.Config
 	hostSocket string
-	syncStderr io.Writer
+	stderr     io.Writer
 
 	mu           sync.Mutex
 	launched     map[string]*entry
@@ -90,7 +91,7 @@ func New(cfg *config.Config, hostSocket string, opts ...Option) *Manager {
 	m := &Manager{
 		cfg:        cfg,
 		hostSocket: hostSocket,
-		syncStderr: os.Stderr,
+		stderr:     os.Stderr,
 		launched:   make(map[string]*entry),
 	}
 
@@ -161,7 +162,7 @@ func (m *Manager) Get(ctx context.Context, capability string) (any, error) {
 		HandshakeConfig: handshake.Config,
 		Plugins:         set,
 		Cmd:             pluginCmd,
-		Stderr:          m.syncStderr,
+		Stderr:          m.stderr,
 		AllowedProtocols: []goplugin.Protocol{
 			goplugin.ProtocolGRPC,
 		},
@@ -287,7 +288,7 @@ func (m *Manager) loadForges(ctx context.Context) error {
 			HandshakeConfig: handshake.Config,
 			Plugins:         set,
 			Cmd:             pluginCmd,
-			Stderr:          m.syncStderr,
+			Stderr:          m.stderr,
 			AllowedProtocols: []goplugin.Protocol{
 				goplugin.ProtocolGRPC,
 			},

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -25,7 +25,7 @@ var (
 	fakeStderrBin string
 )
 
-// syncBuffer is a thread-safe bytes.Buffer for use as a SyncStderr target.
+// syncBuffer is a thread-safe bytes.Buffer for use as a stderr target.
 type syncBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -102,8 +102,8 @@ Before opening the workspace the command SHALL run `hookexec.Run` for event `pre
 2. Resolve story.
 3. Load all attached projects from the story store.
 4. Call `session.OpenWorkspace({story_name, worktree_paths: {project_key: derived_path}})`.
-5. If the workspace was already open, call `session.SwitchTo` for the first pane group; if the response contains a non-empty `exec_argv`, exec it as above.
-6. Run `post-workspace-open` hooks.
+5. Run `post-workspace-open` hooks.
+6. If the workspace was already open, call `session.SwitchTo` for the first pane group; if the response contains a non-empty `exec_argv`, exec it as above.
 
 #### Scenario: Interactive selection with picker — project already attached
 - **WHEN** `swm workspace open feat-x` is run and picker is configured and `feat-x` has `proj-a` attached


### PR DESCRIPTION
test(config): use filepath.Join for path compare

Replace hardcoded Unix-style path string with filepath.Join
to ensure the test works correctly on Windows where the path
separator is a backslash rather than a forward slash.

Addresses PR #105 review thread PRRT_kwDOBe55xc6CnJyn.

refactor(pluginmgr): rename syncStderr field to stderr

The old name implied use of go-plugin's gRPC SyncStderr feature,
which is not what this implementation uses. Rename to stderr to
avoid ambiguity for future maintainers. Also document the
thread-safety requirement on WithStderr.

Addresses PR #106 review threads PRRT_kwDOBe55xc6CnJqW,
CnJqX, CnJqY, CnJqZ, CnJqa.

fix(workspace): unwrap gRPC errors before checking status code

status.Code() does not unwrap error chains. When openWithPicker
wraps gRPC errors with fmt.Errorf, the FailedPrecondition code
was lost and the fallback to openAllAttached never triggered.

Add grpcCode() that uses errors.As to walk the chain and find
the embedded gRPC status, matching the intended fallback logic.

Addresses PR #107 review thread PRRT_kwDOBe55xc6CnJrW.

fix(config): expand ~ in Plugins.Paths on load

CodeRoot already had tilde expansion; Plugins.Paths lacked it,
causing silent failures when users specified plugin paths with ~.
Iterate over all path entries and expand each one consistently.

Addresses PR #108 review thread PRRT_kwDOBe55xc6CnJu9.

fix(workspace): exec and hook in openAllAttached fallback

openAllAttached was missing SwitchTo + exec logic, so attaching
from outside tmux failed silently in the no-picker path. Also,
the post-workspace-open hook was placed after the exec call in
the outer RunE, making it unreachable when the process was
replaced.

Changes:
- openAllAttached now accepts execFn, cfg, and hooks; it calls
  OpenPaneGroup + SwitchTo for the first project, runs the
  post-workspace-open hook before exec, then execs if argv
  is returned.
- openWithPicker similarly runs the post-workspace-open hook
  before the exec call.
- Remove the dead post-hook invocation from RunE.
- Fix spec fallback path step order: hook (5) before SwitchTo (6).

Addresses PR #109 review threads PRRT_kwDOBe55xc6CnLgO,
PRRT_kwDOBe55xc6CnLgR, PRRT_kwDOBe55xc6CnLgS.