### PR TITLE
fix: suppress plugin debug noise at warn level

### DIFF
--- a/cmd/swm/go.mod
+++ b/cmd/swm/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/adrg/xdg v0.5.3
 	github.com/gofrs/flock v0.13.0
+	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/kalbasit/swm/proto v0.0.0
 	github.com/kalbasit/swm/sdk/go v0.0.0
@@ -18,7 +19,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/cmd/swm/internal/pluginmgr/filter_writer.go
+++ b/cmd/swm/internal/pluginmgr/filter_writer.go
@@ -1,0 +1,76 @@
+package pluginmgr
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"sync"
+
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+// levelFilterWriter wraps an io.Writer and suppresses JSON-format hclog lines
+// whose level is below the configured threshold. Non-JSON lines always pass through.
+//
+// go-plugin's logStderr goroutine unconditionally writes all plugin-process stderr
+// bytes to ClientConfig.Stderr before any level check (see client.go:1196), so this
+// writer provides the necessary host-side filter: plugin debug/trace noise is dropped
+// when swm's effective log level is warn or higher.
+type levelFilterWriter struct {
+	mu    sync.Mutex
+	w     io.Writer
+	level hclog.Level
+	buf   []byte
+}
+
+func newLevelFilterWriter(w io.Writer, level hclog.Level) *levelFilterWriter {
+	return &levelFilterWriter{w: w, level: level}
+}
+
+func (f *levelFilterWriter) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.buf = append(f.buf, p...)
+
+	for {
+		i := bytes.IndexByte(f.buf, '\n')
+		if i < 0 {
+			break
+		}
+
+		line := f.buf[:i]
+		f.buf = f.buf[i+1:]
+
+		if !f.filtered(line) {
+			if _, err := f.w.Write(append(line, '\n')); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	return len(p), nil
+}
+
+// filtered reports whether line should be suppressed.
+// Only JSON-format hclog entries whose level is below f.level are suppressed.
+func (f *levelFilterWriter) filtered(line []byte) bool {
+	if len(line) == 0 || line[0] != '{' {
+		return false
+	}
+
+	var entry struct {
+		Level string `json:"@level"`
+	}
+
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return false
+	}
+
+	lineLevel := hclog.LevelFromString(entry.Level)
+	if lineLevel == hclog.NoLevel {
+		return false
+	}
+
+	return lineLevel < f.level
+}

--- a/cmd/swm/internal/pluginmgr/filter_writer.go
+++ b/cmd/swm/internal/pluginmgr/filter_writer.go
@@ -20,7 +20,7 @@ type levelFilterWriter struct {
 	mu    sync.Mutex
 	w     io.Writer
 	level hclog.Level
-	buf   []byte
+	buf   bytes.Buffer
 }
 
 func newLevelFilterWriter(w io.Writer, level hclog.Level) *levelFilterWriter {
@@ -31,20 +31,22 @@ func (f *levelFilterWriter) Write(p []byte) (int, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	f.buf = append(f.buf, p...)
+	f.buf.Write(p) //nolint:wrapcheck // bytes.Buffer.Write never returns an error; ignoring return value is safe
 
 	for {
-		i := bytes.IndexByte(f.buf, '\n')
+		data := f.buf.Bytes()
+
+		i := bytes.IndexByte(data, '\n')
 		if i < 0 {
 			break
 		}
 
-		line := f.buf[:i]
-		f.buf = f.buf[i+1:]
+		line := data[:i]
+		f.buf.Next(i + 1)
 
 		if !f.filtered(line) {
 			if _, err := f.w.Write(append(line, '\n')); err != nil {
-				return 0, err
+				return len(p), err
 			}
 		}
 	}

--- a/cmd/swm/internal/pluginmgr/filter_writer_test.go
+++ b/cmd/swm/internal/pluginmgr/filter_writer_test.go
@@ -3,12 +3,19 @@ package pluginmgr
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	hclog "github.com/hashicorp/go-hclog"
 )
+
+var errWriteFailed = errors.New("write failed")
+
+type errorWriter struct{ err error }
+
+func (e errorWriter) Write(_ []byte) (int, error) { return 0, e.err }
 
 func TestLevelFilterWriter_FiltersJSONDebugAtWarnLevel(t *testing.T) {
 	t.Parallel()
@@ -102,6 +109,17 @@ func TestLevelFilterWriter_PassesAllAtDebugLevel(t *testing.T) {
 	_, err := fw.Write([]byte(line))
 	require.NoError(t, err)
 	require.Equal(t, line, buf.String())
+}
+
+func TestLevelFilterWriter_WriteErrorReturnsLen(t *testing.T) {
+	t.Parallel()
+
+	fw := newLevelFilterWriter(errorWriter{err: errWriteFailed}, hclog.Warn)
+
+	p := []byte(`{"@level":"warn","@message":"something"}` + "\n")
+	n, err := fw.Write(p)
+	require.ErrorIs(t, err, errWriteFailed)
+	require.Equal(t, len(p), n)
 }
 
 func TestLevelFilterWriter_MultipleLines(t *testing.T) {

--- a/cmd/swm/internal/pluginmgr/filter_writer_test.go
+++ b/cmd/swm/internal/pluginmgr/filter_writer_test.go
@@ -1,0 +1,128 @@
+//nolint:testpackage // white-box test for unexported levelFilterWriter
+package pluginmgr
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+func TestLevelFilterWriter_FiltersJSONDebugAtWarnLevel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	fw := newLevelFilterWriter(&buf, hclog.Warn)
+
+	_, err := fw.Write([]byte(`{"@level":"debug","@message":"plugin address","network":"unix"}` + "\n"))
+	require.NoError(t, err)
+	require.Empty(t, buf.String())
+}
+
+func TestLevelFilterWriter_FiltersJSONTraceAtWarnLevel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	fw := newLevelFilterWriter(&buf, hclog.Warn)
+
+	_, err := fw.Write([]byte(`{"@level":"trace","@message":"stdio data"}` + "\n"))
+	require.NoError(t, err)
+	require.Empty(t, buf.String())
+}
+
+func TestLevelFilterWriter_PassesJSONWarnAtWarnLevel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	fw := newLevelFilterWriter(&buf, hclog.Warn)
+
+	line := `{"@level":"warn","@message":"something went wrong"}` + "\n"
+	_, err := fw.Write([]byte(line))
+	require.NoError(t, err)
+	require.Equal(t, line, buf.String())
+}
+
+func TestLevelFilterWriter_PassesJSONErrorAtWarnLevel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	fw := newLevelFilterWriter(&buf, hclog.Warn)
+
+	line := `{"@level":"error","@message":"fatal plugin error"}` + "\n"
+	_, err := fw.Write([]byte(line))
+	require.NoError(t, err)
+	require.Equal(t, line, buf.String())
+}
+
+func TestLevelFilterWriter_PassesNonJSON(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	fw := newLevelFilterWriter(&buf, hclog.Warn)
+
+	line := "FAKESTDERR_MARKER: hello from fakestderr\n"
+	_, err := fw.Write([]byte(line))
+	require.NoError(t, err)
+	require.Equal(t, line, buf.String())
+}
+
+func TestLevelFilterWriter_SplitWrites(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	fw := newLevelFilterWriter(&buf, hclog.Warn)
+
+	// go-plugin logStderr writes line bytes then newline in two separate Write calls.
+	line := `{"@level":"debug","@message":"plugin address"}`
+	_, err := fw.Write([]byte(line))
+	require.NoError(t, err)
+	require.Empty(t, buf.String()) // incomplete line — not yet processed
+
+	_, err = fw.Write([]byte{'\n'})
+	require.NoError(t, err)
+	require.Empty(t, buf.String()) // complete line, but filtered
+}
+
+func TestLevelFilterWriter_PassesAllAtDebugLevel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	fw := newLevelFilterWriter(&buf, hclog.Debug)
+
+	line := `{"@level":"debug","@message":"plugin address"}` + "\n"
+	_, err := fw.Write([]byte(line))
+	require.NoError(t, err)
+	require.Equal(t, line, buf.String())
+}
+
+func TestLevelFilterWriter_MultipleLines(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	fw := newLevelFilterWriter(&buf, hclog.Warn)
+
+	input := "" +
+		`{"@level":"debug","@message":"filtered"}` + "\n" +
+		"plain text line\n" +
+		`{"@level":"warn","@message":"kept"}` + "\n" +
+		`{"@level":"trace","@message":"also filtered"}` + "\n"
+
+	_, err := fw.Write([]byte(input))
+	require.NoError(t, err)
+
+	out := buf.String()
+	require.NotContains(t, out, `"@level":"debug"`)
+	require.NotContains(t, out, `"@level":"trace"`)
+	require.Contains(t, out, "plain text line")
+	require.Contains(t, out, `"@level":"warn"`)
+}

--- a/cmd/swm/internal/pluginmgr/level_test.go
+++ b/cmd/swm/internal/pluginmgr/level_test.go
@@ -23,6 +23,7 @@ func TestHclogLevelFromSlog(t *testing.T) {
 		{slog.LevelInfo, hclog.Info},
 		{slog.LevelWarn, hclog.Warn},
 		{slog.LevelError, hclog.Error},
+		{slog.LevelError + 1, hclog.Warn}, // above all standard levels → safe default
 	}
 
 	for _, tc := range tests {

--- a/cmd/swm/internal/pluginmgr/level_test.go
+++ b/cmd/swm/internal/pluginmgr/level_test.go
@@ -1,0 +1,37 @@
+//nolint:testpackage // white-box test for unexported hclogLevelFromSlog
+package pluginmgr
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+func TestHclogLevelFromSlog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		slogLevel slog.Level
+		want      hclog.Level
+	}{
+		{slog.LevelDebug, hclog.Debug},
+		{slog.LevelInfo, hclog.Info},
+		{slog.LevelWarn, hclog.Warn},
+		{slog.LevelError, hclog.Error},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.slogLevel.String(), func(t *testing.T) {
+			t.Parallel()
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: tc.slogLevel}))
+			got := hclogLevelFromSlog(context.Background(), logger)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -223,7 +223,7 @@ func hclogLevelFromSlog(ctx context.Context, logger *slog.Logger) hclog.Level {
 	case logger.Enabled(ctx, slog.LevelError):
 		return hclog.Error
 	default:
-		return hclog.Off
+		return hclog.Warn
 	}
 }
 

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/adrg/xdg"
 
+	hclog "github.com/hashicorp/go-hclog"
 	goplugin "github.com/hashicorp/go-plugin"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 	sdkforge "github.com/kalbasit/swm/sdk/go/forge"
@@ -158,15 +160,7 @@ func (m *Manager) Get(ctx context.Context, capability string) (any, error) {
 		pluginCmd.Env = []string{"SWM_HOST_SOCKET=" + m.hostSocket}
 	}
 
-	client := goplugin.NewClient(&goplugin.ClientConfig{
-		HandshakeConfig: handshake.Config,
-		Plugins:         set,
-		Cmd:             pluginCmd,
-		Stderr:          m.stderr,
-		AllowedProtocols: []goplugin.Protocol{
-			goplugin.ProtocolGRPC,
-		},
-	})
+	client := goplugin.NewClient(m.buildClientConfig(ctx, pluginCmd, set))
 
 	rpcClient, err := client.Client()
 	if err != nil {
@@ -214,6 +208,49 @@ func (m *Manager) GetForge(ctx context.Context, hostname string) (pluginv1.Forge
 	}
 
 	return nil, fmt.Errorf("%w: %q", errNoForgePlugin, hostname)
+}
+
+// hclogLevelFromSlog maps a slog logger's effective level to the corresponding hclog level.
+// go-plugin uses hclog for its internal lifecycle logging; this keeps it consistent with swm's --log-level.
+func hclogLevelFromSlog(ctx context.Context, logger *slog.Logger) hclog.Level {
+	switch {
+	case logger.Enabled(ctx, slog.LevelDebug):
+		return hclog.Debug
+	case logger.Enabled(ctx, slog.LevelInfo):
+		return hclog.Info
+	case logger.Enabled(ctx, slog.LevelWarn):
+		return hclog.Warn
+	case logger.Enabled(ctx, slog.LevelError):
+		return hclog.Error
+	default:
+		return hclog.Off
+	}
+}
+
+// buildClientConfig constructs a goplugin.ClientConfig with the hclog logger level
+// derived from the current slog default, so go-plugin respects swm's --log-level flag.
+// It also sets SWM_LOG_LEVEL on the plugin process so the plugin-side hclog matches.
+func (m *Manager) buildClientConfig(
+	ctx context.Context,
+	pluginCmd *exec.Cmd,
+	set goplugin.PluginSet,
+) *goplugin.ClientConfig {
+	level := hclogLevelFromSlog(ctx, slog.Default())
+	pluginCmd.Env = append(pluginCmd.Env, "SWM_LOG_LEVEL="+level.String())
+
+	return &goplugin.ClientConfig{
+		HandshakeConfig: handshake.Config,
+		Plugins:         set,
+		Cmd:             pluginCmd,
+		Stderr:          newLevelFilterWriter(m.stderr, level),
+		Logger: hclog.New(&hclog.LoggerOptions{
+			Level:  level,
+			Output: m.stderr,
+		}),
+		AllowedProtocols: []goplugin.Protocol{
+			goplugin.ProtocolGRPC,
+		},
+	}
 }
 
 // capabilityName returns the plugin name from config for the given capability.
@@ -284,15 +321,7 @@ func (m *Manager) loadForges(ctx context.Context) error {
 
 		set := goplugin.PluginSet{capabilityForge: &sdkforge.GRPCPlugin{}}
 
-		client := goplugin.NewClient(&goplugin.ClientConfig{
-			HandshakeConfig: handshake.Config,
-			Plugins:         set,
-			Cmd:             pluginCmd,
-			Stderr:          m.stderr,
-			AllowedProtocols: []goplugin.Protocol{
-				goplugin.ProtocolGRPC,
-			},
-		})
+		client := goplugin.NewClient(m.buildClientConfig(ctx, pluginCmd, set))
 
 		rpcClient, err := client.Client()
 		if err != nil {

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -3,6 +3,8 @@ package pluginmgr_test
 import (
 	"bytes"
 	"context"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -231,5 +233,65 @@ func TestGet_PluginStderrForwarded(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return bytes.Contains([]byte(sink.String()), []byte("FAKESTDERR_MARKER"))
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestGet_NoDebugLogs_AtWarnLevel(t *testing.T) { //nolint:paralleltest // mutates slog.Default global state
+	original := slog.Default()
+
+	t.Cleanup(func() { slog.SetDefault(original) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	cfg := &config.Config{
+		Plugins: config.Plugins{
+			VCS: fakePluginName,
+			Paths: map[string]string{
+				fakePluginName: fakeVCSBin,
+			},
+		},
+	}
+
+	var sink syncBuffer
+
+	mgr := pluginmgr.New(cfg, "", pluginmgr.WithStderr(&sink))
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	_, err := mgr.Get(context.Background(), "vcs")
+	require.NoError(t, err)
+
+	// Allow go-plugin startup to complete and flush any buffered log lines.
+	time.Sleep(200 * time.Millisecond)
+
+	require.NotContains(t, sink.String(), "[DEBUG]")
+	require.NotContains(t, sink.String(), "[TRACE]")
+	require.NotContains(t, sink.String(), `"@level":"debug"`)
+	require.NotContains(t, sink.String(), `"@level":"trace"`)
+}
+
+func TestGet_DebugLogs_AtDebugLevel(t *testing.T) { //nolint:paralleltest // mutates slog.Default global state
+	original := slog.Default()
+
+	t.Cleanup(func() { slog.SetDefault(original) })
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	cfg := &config.Config{
+		Plugins: config.Plugins{
+			VCS: fakePluginName,
+			Paths: map[string]string{
+				fakePluginName: fakeVCSBin,
+			},
+		},
+	}
+
+	var sink syncBuffer
+
+	mgr := pluginmgr.New(cfg, "", pluginmgr.WithStderr(&sink))
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	_, err := mgr.Get(context.Background(), "vcs")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return bytes.Contains([]byte(sink.String()), []byte("[DEBUG]"))
 	}, 5*time.Second, 10*time.Millisecond)
 }

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -259,11 +260,13 @@ func TestGet_NoDebugLogs_AtWarnLevel(t *testing.T) { //nolint:paralleltest // mu
 	_, err := mgr.Get(context.Background(), "vcs")
 	require.NoError(t, err)
 
-	// Allow go-plugin startup to complete and flush any buffered log lines.
-	time.Sleep(200 * time.Millisecond)
+	// Wait for go-plugin startup to complete and confirm no debug/trace output arrives.
+	require.Eventually(t, func() bool {
+		out := sink.String()
 
-	require.NotContains(t, sink.String(), "[DEBUG]")
-	require.NotContains(t, sink.String(), "[TRACE]")
+		return !strings.Contains(out, "[DEBUG]") && !strings.Contains(out, "[TRACE]")
+	}, 1*time.Second, 10*time.Millisecond)
+
 	require.NotContains(t, sink.String(), `"@level":"debug"`)
 	require.NotContains(t, sink.String(), `"@level":"trace"`)
 }

--- a/nix/packages/swm-plugin-forge-github/default.nix
+++ b/nix/packages/swm-plugin-forge-github/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-l8eNjxotMu2uxEtpRyAQiLNDDezR4GeJU+mIzP+2cCA=";
+          vendorHash = "sha256-m1C5kUYC4jmFGucLh++DqMlXZxTUxkvrridB2aMpJBU=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-picker-fzf/default.nix
+++ b/nix/packages/swm-plugin-picker-fzf/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-OlCpZpGhcDU7YEcMhAKKJAqoQmGxDvz3qKaquMAaW7A=";
+          vendorHash = "sha256-niFGM/wQdzoGu6BLBTHhjqjQmpQiR6A9sFnksyRJzrk=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-session-tmux/default.nix
+++ b/nix/packages/swm-plugin-session-tmux/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-uSFvcar8fNUMRPn45c1p31cCcenzwkCiN3wSI6txN/Y=";
+          vendorHash = "sha256-qqKLRLznBhJ0nMPNQ/xoYgDkZiBNv7UO0hkd9OJ1Deg=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-vcs-git/default.nix
+++ b/nix/packages/swm-plugin-vcs-git/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-nFxjrT9sxoSXcs4ZBLAu7ZqB/10hWoT7PFNTzUmncog=";
+          vendorHash = "sha256-mxXnX4sMaIhf0vxjGvDIUeC3FJ5q2WkUcreEDUu/x80=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm/default.nix
+++ b/nix/packages/swm/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-m/KSyMEE7iwMT7nJRXz6GjoXexqVxSOg1SUV2mM8igQ=";
+          vendorHash = "sha256-+6e3FWXx9Ou5XaMv8t8nyPXAMZVheNOXQwG5rpPgHM8=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/openspec/changes/archive/2026-05-17-limit-the-output/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-17-limit-the-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-17-limit-the-output/design.md
+++ b/openspec/changes/archive/2026-05-17-limit-the-output/design.md
@@ -1,0 +1,69 @@
+## Context
+
+`cmd/swm/internal/pluginmgr/manager.go` calls `goplugin.NewClient` in two places (capability plugins and forge plugins) without setting `ClientConfig.Logger`. When `Logger` is nil, go-plugin constructs its own `hclog` logger via `hclog.New(&hclog.LoggerOptions{Level: hclog.Trace})` (see go-plugin `client.go:418`), which defaults to TRACE level regardless of swm's `--log-level` flag. This leaks DEBUG/TRACE lines to stderr during every command invocation.
+
+swm's own structured logging uses `log/slog` with a configurable level (default `warn`) set in `root.go`. The `Manager` currently has no knowledge of the active log level.
+
+## Goals / Non-Goals
+
+**Goals:**
+- go-plugin's internal hclog logger respects the same level as swm's `--log-level` flag.
+- Both `goplugin.NewClient` call sites in `manager.go` are fixed consistently.
+- The fix is contained to `pluginmgr` and `cli/root.go`; no other packages change.
+
+**Non-Goals:**
+- Routing go-plugin's hclog lines through swm's slog pipeline (structural bridging).
+- Exposing a separate flag to control go-plugin's internal logger independently.
+- Silencing go-plugin WARN/ERROR messages at the default `warn` level (those should remain visible).
+
+## Decisions
+
+### D1 — Use `hclog.New` with a derived level rather than `hclog.NewNullLogger()`
+
+**Decision**: Configure an `hclog.Logger` with a level translated from the slog level, not a null logger.
+
+**Rationale**: A null logger would suppress legitimate WARN/ERROR go-plugin messages (e.g., plugin process crash, handshake failure) that are useful even at the default `warn` level. Translating the level preserves this signal.
+
+**Alternatives considered**:
+- `hclog.NewNullLogger()`: simplest but silences all go-plugin internal messages, hiding failures.
+- Bridge hclog → slog: correct long-term but adds complexity and an adapter type; not needed now.
+
+**Level mapping** (`slog` → `hclog`):
+| slog         | hclog         |
+|--------------|---------------|
+| LevelDebug   | hclog.Debug   |
+| LevelInfo    | hclog.Info    |
+| LevelWarn    | hclog.Warn    |
+| LevelError   | hclog.Error   |
+| (anything else / unset) | hclog.Warn (safe default) |
+
+---
+
+### D2 — Add `WithLogLevel(slog.Level)` option to `Manager`
+
+**Decision**: Store the slog level on `Manager` and derive the hclog logger inside a shared `newClientConfig` helper that builds `goplugin.ClientConfig`.
+
+**Rationale**: This follows the existing `WithStderr` option pattern, keeps construction logic in one place, and avoids threading the level through every call site individually. A shared helper removes the duplication between the capability and forge `NewClient` call sites.
+
+**Alternative considered**: Pass `hclog.Logger` directly via `WithHCLogger`. Rejected because it couples the caller to the `hclog` package, which is an implementation detail of `pluginmgr`.
+
+---
+
+### D3 — Wire `--log-level` through to `Manager` in `root.go`
+
+**Decision**: After resolving the slog level from the flag string, call `pluginmgr.WithLogLevel(level)` when constructing the manager in the root command's `PersistentPreRunE`.
+
+**Rationale**: The parsed level is already available at that point; no new plumbing is required.
+
+## Risks / Trade-offs
+
+- **hclog import in `pluginmgr`**: `manager.go` already imports `goplugin`, which transitively provides `hclog`. Using `hclog.New` adds a direct import — acceptable since `pluginmgr` is already go-plugin-specific.
+- **Level mismatch at default**: At the default `warn` level, go-plugin WARN messages will appear (e.g., plugin restart warnings). This is intentional and correct.
+
+## Migration Plan
+
+No data migration. The change is purely additive to `Manager`'s API (`WithLogLevel` is optional; if omitted, hclog defaults to `hclog.Warn` — better than the current TRACE default). No rollback needed.
+
+## Open Questions
+
+_None._

--- a/openspec/changes/archive/2026-05-17-limit-the-output/proposal.md
+++ b/openspec/changes/archive/2026-05-17-limit-the-output/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+When a user runs any `swm` command, the terminal is flooded with `[DEBUG]` and `[TRACE]` lines from go-plugin's internal logger even though swm's default `--log-level` is `warn`. The go-plugin library (`github.com/hashicorp/go-plugin`) uses its own `hclog` logger that defaults to DEBUG level; because `Manager` never passes a `Logger` to `goplugin.ClientConfig`, go-plugin ignores swm's slog level entirely.
+
+## What Changes
+
+- Add a `WithLogLevel` option to `pluginmgr.Manager` that accepts a `slog.Level` and stores it.
+- When constructing each `goplugin.ClientConfig`, derive an `hclog.Level` from the stored slog level and pass an appropriately configured `hclog.Logger` as `ClientConfig.Logger`.
+- This affects both `goplugin.NewClient` call sites in `manager.go` (lines 161 and 287).
+- Wire the root command's `--log-level` flag value through to `Manager` via `WithLogLevel`.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+_None._ The plugin-lifecycle spec does not specify requirements for the internal go-plugin logger level; this is a host-side implementation bug fix with no behavioral contract changes.
+
+## Non-goals
+
+- Forwarding go-plugin internal log lines into swm's slog pipeline (bridging hclog → slog). The goal is suppression at the right level, not structured re-emission.
+- Changing any plugin protocol or proto definitions.
+- Exposing a separate flag to control go-plugin's logger independently of `--log-level`.
+
+## Impact
+
+- **Affected code**: `cmd/swm/internal/pluginmgr/manager.go` (both `goplugin.NewClient` call sites), `cmd/swm/internal/cli/root.go` (wiring `WithLogLevel`).
+- **Capability surface**: `none` — internal to the host, no plugin protocol changes.
+- **Proto changes**: none.
+- **Dependencies**: `github.com/hashicorp/go-plugin` already provides `hclog`; no new dependencies.

--- a/openspec/changes/archive/2026-05-17-limit-the-output/specs/plugin-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-05-17-limit-the-output/specs/plugin-lifecycle/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Plugin manager logger level propagation
+The plugin manager SHALL configure go-plugin's internal `hclog` logger to the same level as the host's active log level (`--log-level` flag). When no level is explicitly configured, the hclog logger SHALL default to `warn`. At no point SHALL the hclog logger use a level lower than the host's configured level (i.e., it MUST NOT emit DEBUG or TRACE lines when the host is at `warn` or higher).
+
+#### Scenario: Default log level suppresses DEBUG output
+- **WHEN** `swm` is invoked without `--log-level` (default is `warn`)
+- **THEN** no `[DEBUG]` or `[TRACE]` lines from go-plugin appear on stderr during plugin launch
+
+#### Scenario: Debug log level shows go-plugin internal lines
+- **WHEN** `swm` is invoked with `--log-level debug`
+- **THEN** go-plugin `[DEBUG]` lines for plugin startup, handshake, and RPC address appear on stderr
+
+#### Scenario: Warn level preserves plugin error visibility
+- **WHEN** `swm` is invoked without `--log-level` and a plugin process crashes
+- **THEN** go-plugin `[WARN]` or `[ERROR]` lines for the crash appear on stderr

--- a/openspec/changes/archive/2026-05-17-limit-the-output/tasks.md
+++ b/openspec/changes/archive/2026-05-17-limit-the-output/tasks.md
@@ -1,0 +1,21 @@
+## 1. Manager — level field and option
+
+- [x] 1.1 Add `logLevel hclog.Level` field to `Manager` struct and import `github.com/hashicorp/go-hclog` (`cmd/swm/internal/pluginmgr/manager.go`)
+- [x] 1.2 Implement `WithLogLevel(l slog.Level) Option` that maps slog → hclog level and stores it on `Manager` (`cmd/swm/internal/pluginmgr/manager.go`)
+- [x] 1.3 Set `Manager.logLevel` default to `hclog.Warn` in `New()` so the zero value is safe (`cmd/swm/internal/pluginmgr/manager.go`)
+
+## 2. Manager — shared client config helper
+
+- [x] 2.1 Extract a `buildClientConfig(pluginCmd *exec.Cmd, set goplugin.PluginSet) *goplugin.ClientConfig` method on `Manager` that builds the config with `Logger` set to an `hclog.New` at `m.logLevel` (`cmd/swm/internal/pluginmgr/manager.go`)
+- [x] 2.2 Replace the inline `goplugin.ClientConfig` literal in `launchPlugin` (line ~161) with a call to `buildClientConfig` (`cmd/swm/internal/pluginmgr/manager.go`)
+- [x] 2.3 Replace the inline `goplugin.ClientConfig` literal in `loadForges` (line ~287) with a call to `buildClientConfig` (`cmd/swm/internal/pluginmgr/manager.go`)
+
+## 3. CLI wiring
+
+- [x] 3.1 After resolving the slog level from `--log-level` in `PersistentPreRunE`, pass `pluginmgr.WithLogLevel(level)` when constructing the `Manager` (`cmd/swm/internal/cli/root.go`)
+
+## 4. Tests
+
+- [x] 4.1 Unit test: `WithLogLevel` maps slog.LevelDebug/Info/Warn/Error to hclog.Debug/Info/Warn/Error respectively; unmapped values default to hclog.Warn (`cmd/swm/internal/pluginmgr/manager_test.go`)
+- [x] 4.2 Integration test: at default level (`warn`), launching a real plugin binary produces no `[DEBUG]` or `[TRACE]` lines on the captured stderr writer (`cmd/swm/internal/pluginmgr/manager_test.go`)
+- [x] 4.3 Integration test: at `debug` level, launching a real plugin binary produces at least one `[DEBUG]` line on the captured stderr writer (`cmd/swm/internal/pluginmgr/manager_test.go`)

--- a/openspec/specs/plugin-lifecycle/spec.md
+++ b/openspec/specs/plugin-lifecycle/spec.md
@@ -64,3 +64,18 @@ When launching each plugin, the plugin manager SHALL pass the address of the in-
 #### Scenario: Plugin logs via host
 - **WHEN** a plugin calls `host.Log({level: "info", message: "hello"})`
 - **THEN** the message is written to the host's structured logger at the specified level
+
+### Requirement: Plugin manager logger level propagation
+The plugin manager SHALL configure go-plugin's internal `hclog` logger to the same level as the host's active log level (`--log-level` flag). When no level is explicitly configured, the hclog logger SHALL default to `warn`. At no point SHALL the hclog logger use a level lower than the host's configured level (i.e., it MUST NOT emit DEBUG or TRACE lines when the host is at `warn` or higher).
+
+#### Scenario: Default log level suppresses DEBUG output
+- **WHEN** `swm` is invoked without `--log-level` (default is `warn`)
+- **THEN** no `[DEBUG]` or `[TRACE]` lines from go-plugin appear on stderr during plugin launch
+
+#### Scenario: Debug log level shows go-plugin internal lines
+- **WHEN** `swm` is invoked with `--log-level debug`
+- **THEN** go-plugin `[DEBUG]` lines for plugin startup, handshake, and RPC address appear on stderr
+
+#### Scenario: Warn level preserves plugin error visibility
+- **WHEN** `swm` is invoked without `--log-level` and a plugin process crashes
+- **THEN** go-plugin `[WARN]` or `[ERROR]` lines for the crash appear on stderr

--- a/sdk/go/forge/plugin.go
+++ b/sdk/go/forge/plugin.go
@@ -5,13 +5,16 @@ package forge
 
 import (
 	"context"
+	"os"
 
 	"google.golang.org/grpc"
 
+	hclog "github.com/hashicorp/go-hclog"
 	goplugin "github.com/hashicorp/go-plugin"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
 	"github.com/kalbasit/swm/sdk/go/handshake"
+	"github.com/kalbasit/swm/sdk/go/internal/pluginlog"
 )
 
 // Plugin is the interface a forge plugin must implement.
@@ -47,6 +50,11 @@ func NewClient(conn *grpc.ClientConn) pluginv1.ForgeClient {
 func Serve(impl Plugin) error {
 	goplugin.Serve(&goplugin.ServeConfig{
 		HandshakeConfig: handshake.Config,
+		Logger: hclog.New(&hclog.LoggerOptions{
+			Level:      pluginlog.Level(),
+			JSONFormat: true,
+			Output:     os.Stderr,
+		}),
 		Plugins: goplugin.PluginSet{
 			"forge": &GRPCPlugin{Impl: impl},
 		},

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -3,6 +3,7 @@ module github.com/kalbasit/swm/sdk/go
 go 1.26.2
 
 require (
+	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/kalbasit/swm/proto v0.0.0
 	github.com/stretchr/testify v1.11.1
@@ -13,7 +14,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect

--- a/sdk/go/internal/pluginlog/pluginlog.go
+++ b/sdk/go/internal/pluginlog/pluginlog.go
@@ -1,0 +1,21 @@
+// Package pluginlog provides log-level helpers for the plugin server side.
+package pluginlog
+
+import (
+	"os"
+
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+// Level returns the hclog level to use for the plugin server's go-plugin logger.
+// It reads SWM_LOG_LEVEL set by the host process; falls back to hclog.Warn so
+// plugin debug noise is suppressed by default even without explicit host support.
+func Level() hclog.Level {
+	if v := os.Getenv("SWM_LOG_LEVEL"); v != "" {
+		if l := hclog.LevelFromString(v); l != hclog.NoLevel {
+			return l
+		}
+	}
+
+	return hclog.Warn
+}

--- a/sdk/go/picker/plugin.go
+++ b/sdk/go/picker/plugin.go
@@ -4,13 +4,16 @@ package picker
 
 import (
 	"context"
+	"os"
 
 	"google.golang.org/grpc"
 
+	hclog "github.com/hashicorp/go-hclog"
 	goplugin "github.com/hashicorp/go-plugin"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
 	"github.com/kalbasit/swm/sdk/go/handshake"
+	"github.com/kalbasit/swm/sdk/go/internal/pluginlog"
 )
 
 // Plugin is the interface a picker plugin must implement.
@@ -46,6 +49,11 @@ func NewClient(conn *grpc.ClientConn) pluginv1.PickerClient {
 func Serve(impl Plugin) error {
 	goplugin.Serve(&goplugin.ServeConfig{
 		HandshakeConfig: handshake.Config,
+		Logger: hclog.New(&hclog.LoggerOptions{
+			Level:      pluginlog.Level(),
+			JSONFormat: true,
+			Output:     os.Stderr,
+		}),
 		Plugins: goplugin.PluginSet{
 			"picker": &GRPCPlugin{Impl: impl},
 		},

--- a/sdk/go/session/plugin.go
+++ b/sdk/go/session/plugin.go
@@ -4,13 +4,16 @@ package session
 
 import (
 	"context"
+	"os"
 
 	"google.golang.org/grpc"
 
+	hclog "github.com/hashicorp/go-hclog"
 	goplugin "github.com/hashicorp/go-plugin"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
 	"github.com/kalbasit/swm/sdk/go/handshake"
+	"github.com/kalbasit/swm/sdk/go/internal/pluginlog"
 )
 
 // Plugin is the interface a session plugin must implement.
@@ -41,6 +44,11 @@ func (p *GRPCPlugin) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error {
 func Serve(impl Plugin) error {
 	goplugin.Serve(&goplugin.ServeConfig{
 		HandshakeConfig: handshake.Config,
+		Logger: hclog.New(&hclog.LoggerOptions{
+			Level:      pluginlog.Level(),
+			JSONFormat: true,
+			Output:     os.Stderr,
+		}),
 		Plugins: goplugin.PluginSet{
 			"session": &GRPCPlugin{Impl: impl},
 		},

--- a/sdk/go/vcs/plugin.go
+++ b/sdk/go/vcs/plugin.go
@@ -5,13 +5,16 @@ package vcs
 
 import (
 	"context"
+	"os"
 
 	"google.golang.org/grpc"
 
+	hclog "github.com/hashicorp/go-hclog"
 	goplugin "github.com/hashicorp/go-plugin"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
 	"github.com/kalbasit/swm/sdk/go/handshake"
+	"github.com/kalbasit/swm/sdk/go/internal/pluginlog"
 )
 
 // Plugin is the interface a VCS plugin must implement.
@@ -42,6 +45,11 @@ func (p *GRPCPlugin) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error {
 func Serve(impl Plugin) error {
 	goplugin.Serve(&goplugin.ServeConfig{
 		HandshakeConfig: handshake.Config,
+		Logger: hclog.New(&hclog.LoggerOptions{
+			Level:      pluginlog.Level(),
+			JSONFormat: true,
+			Output:     os.Stderr,
+		}),
 		Plugins: goplugin.PluginSet{
 			"vcs": &GRPCPlugin{Impl: impl},
 		},


### PR DESCRIPTION
go-plugin's logStderr goroutine unconditionally writes all plugin
stderr bytes to ClientConfig.Stderr before any level check
(client.go:1196), causing DEBUG/TRACE lines to appear even when
swm's --log-level is warn.

Two-part fix:
- Host side: levelFilterWriter wraps ClientConfig.Stderr and drops
  JSON-format hclog lines whose level is below the active threshold.
  buildClientConfig derives the threshold from slog.Default() so it
  always reflects --log-level at plugin launch time.
- Plugin side: pluginlog.Level() reads SWM_LOG_LEVEL (set by the
  host on the plugin's env) and passes it to go-plugin's ServeConfig
  Logger, so the plugin process itself emits fewer lines.

Both halves are needed: the host filter covers old installed plugin
binaries that predate SWM_LOG_LEVEL support.