### PR TITLE
fix: create go.work file as part of the shellHook

### DIFF
--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -33,17 +33,13 @@
 
             if [[ ! -f go.work ]]; then
               go work init
-              go work use ./cmd/swm
-              go work use ./plugins/forge-github
-              go work use ./plugins/picker-fzf
-              go work use ./plugins/session-tmux
-              go work use ./plugins/vcs-git
-              go work use ./proto
-              go work use ./sdk/go
             fi
+            for __go_mod__ in cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod proto/go.mod; do
+              go work use "$(dirname "$__go_mod__")"
+            done
 
             (
-              for __go_mod__ in go.work cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod; do
+              for __go_mod__ in go.work cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod proto/go.mod; do
                 if [[ "$(${pkgs.gnugrep}/bin/grep '^\(go \)[0-9.]*$' "$__go_mod__")" != "go ${goVersion}" ]]; then
                   ${pkgs.gnused}/bin/sed -e "s:^\(go \)[0-9.]*$:\1${goVersion}:" -i "$__go_mod__"
                 fi

--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -31,8 +31,19 @@
           ''
             ${config.pre-commit.installationScript}
 
+            if [[ ! -f go.work ]]; then
+              go work init
+              go work use ./cmd/swm
+              go work use ./plugins/forge-github
+              go work use ./plugins/picker-fzf
+              go work use ./plugins/session-tmux
+              go work use ./plugins/vcs-git
+              go work use ./proto
+              go work use ./sdk/go
+            fi
+
             (
-              for __go_mod__ in cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod; do
+              for __go_mod__ in go.work cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod; do
                 if [[ "$(${pkgs.gnugrep}/bin/grep '^\(go \)[0-9.]*$' "$__go_mod__")" != "go ${goVersion}" ]]; then
                   ${pkgs.gnused}/bin/sed -e "s:^\(go \)[0-9.]*$:\1${goVersion}:" -i "$__go_mod__"
                 fi


### PR DESCRIPTION
The go.work file is required to work with swm but is git-ignored so
create it from the shellHook.