### PR TITLE
fix: run hooks in contextually correct dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Plugins are resolved in this order (first match per capability wins):
 
 ## Hook system
 
-Hooks are plain executables placed in tiered directories. All applicable tiers run for each event — they compose rather than override.
+Hooks are plain executables placed in tiered directories. All applicable tiers run for each event — they compose rather than override. Each hook runs with its working directory set to a contextually appropriate path (the worktree, the repo root, or `code_root` depending on the event).
 
 | Tier           | Path                                                     |
 | -------------- | -------------------------------------------------------- |
@@ -174,7 +174,7 @@ Hooks are plain executables placed in tiered directories. All applicable tiers r
 
 `pre-*` hooks abort the operation on non-zero exit. `post-*` hooks log failures but do not abort.
 
-See [`cmd/swm/README.md`](cmd/swm/README.md) for the full list of hook events.
+See the [Hook System reference](cmd/swm/README.md#hook-system) in the host CLI README for the full event list, working directories, environment variables, and stdin JSON contract.
 
 ## Module READMEs
 

--- a/cmd/swm/README.md
+++ b/cmd/swm/README.md
@@ -123,24 +123,50 @@ Files within each `.d/` directory run in lexicographic order.
 
 ### Hook events
 
-| Event                  | Blocking | Trigger                                    |
-| ---------------------- | -------- | ------------------------------------------ |
-| `pre-story-create`     | yes      | Before a story is created                  |
-| `post-story-create`    | no       | After a story is created                   |
-| `pre-story-remove`     | yes      | Before a story is removed                  |
-| `post-story-remove`    | no       | After a story is removed                   |
-| `pre-worktree-create`  | yes      | Before a worktree is created for a project |
-| `post-worktree-create` | no       | After a worktree is created                |
-| `pre-worktree-remove`  | yes      | Before a worktree is removed               |
-| `post-worktree-remove` | no       | After a worktree is removed                |
-| `pre-clone`            | yes      | Before a repository is cloned              |
-| `post-clone`           | no       | After a repository is cloned               |
-| `pre-workspace-open`   | yes      | Before a workspace session is opened       |
-| `post-workspace-open`  | no       | After a workspace session is opened        |
+| Event                  | Blocking | Working directory | Trigger                                    |
+| ---------------------- | -------- | ----------------- | ------------------------------------------ |
+| `pre-story-create`     | yes      | `code_root`       | Before a story is created                  |
+| `post-story-create`    | no       | `code_root`       | After a story is created                   |
+| `pre-story-remove`     | yes      | `code_root`       | Before a story is removed                  |
+| `post-story-remove`    | no       | `code_root`       | After a story is removed                   |
+| `pre-worktree-create`  | yes      | repo path         | Before a worktree is created for a project |
+| `post-worktree-create` | no       | worktree path     | After a worktree is created                |
+| `pre-worktree-remove`  | yes      | worktree path     | Before a worktree is removed               |
+| `post-worktree-remove` | no       | repo path         | After a worktree is removed                |
+| `pre-clone`            | yes      | `code_root`       | Before a repository is cloned              |
+| `post-clone`           | no       | repo path         | After a repository is cloned               |
+| `pre-workspace-open`   | yes      | `code_root`       | Before a workspace session is opened       |
+| `post-workspace-open`  | no       | worktree path     | After a workspace session is opened        |
 
 **Blocking** (`pre-*`): a non-zero exit code aborts the operation immediately.
 **Non-blocking** (`post-*`): failures are logged but do not affect the return value.
 
-### Environment variables in hooks
+### Environment variables
 
-Hooks receive the standard swm environment, including `SWM_STORY`, `SWM_CODE_ROOT`, and any variables set by the session plugin.
+Each hook is invoked with the following variables in addition to the calling process's environment:
+
+| Variable            | Description                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `SWM_HOOK`          | Event name (e.g. `post-worktree-create`)                                               |
+| `SWM_STORY`         | Story name                                                                             |
+| `SWM_PROJECT_HOST`  | Project host (e.g. `github.com`); empty if no project context                          |
+| `SWM_PROJECT_PATH`  | Project path segments joined by `/` (e.g. `kalbasit/swm`); empty if no project context |
+| `SWM_WORKTREE_PATH` | Full path to the worktree; empty if not applicable                                     |
+| `SWM_REPO_PATH`     | Full path to the canonical repository clone; empty if not applicable                   |
+
+### stdin JSON
+
+Each hook also receives the same data as a JSON object on stdin:
+
+```json
+{
+  "hook": "post-worktree-create",
+  "story": "feat-x",
+  "project_host": "github.com",
+  "project_path": "kalbasit/swm",
+  "worktree_path": "/home/user/code/stories/feat-x/github.com/kalbasit/swm",
+  "repo_path": "/home/user/code/repositories/github.com/kalbasit/swm"
+}
+```
+
+Hooks that do not read stdin will not block — the executor closes the pipe after writing.

--- a/cmd/swm/internal/cli/clone.go
+++ b/cmd/swm/internal/cli/clone.go
@@ -59,6 +59,7 @@ func NewCloneCmd(mgr PluginManager, resolver *layout.Resolver, hooks hookexec.Ru
 				CodeRoot:    codeRoot,
 				ProjectHost: id.GetHost(),
 				ProjectPath: projectPath,
+				WorkDir:     codeRoot,
 			}); err != nil {
 				return fmt.Errorf("pre-clone hook: %w", err)
 			}
@@ -76,6 +77,7 @@ func NewCloneCmd(mgr PluginManager, resolver *layout.Resolver, hooks hookexec.Ru
 				ProjectHost: id.GetHost(),
 				ProjectPath: projectPath,
 				RepoPath:    canonical,
+				WorkDir:     canonical,
 			}); err != nil {
 				// post-clone hooks are informational; log the failure but don't abort.
 				cmd.PrintErrf("post-clone hook failed (ignored): %v\n", err)

--- a/cmd/swm/internal/cli/story/create.go
+++ b/cmd/swm/internal/cli/story/create.go
@@ -31,6 +31,7 @@ func NewCreateCmd(store coreStory.Store, codeRoot string, hooks hookexec.Runner)
 				Event:     "pre-story-create",
 				CodeRoot:  codeRoot,
 				StoryName: name,
+				WorkDir:   codeRoot,
 			}
 
 			if err := hooks.Run(ctx, preCfg); err != nil {
@@ -45,6 +46,7 @@ func NewCreateCmd(store coreStory.Store, codeRoot string, hooks hookexec.Runner)
 				Event:     "post-story-create",
 				CodeRoot:  codeRoot,
 				StoryName: name,
+				WorkDir:   codeRoot,
 			}
 
 			if err := hooks.Run(ctx, postCfg); err != nil {

--- a/cmd/swm/internal/cli/story/remove.go
+++ b/cmd/swm/internal/cli/story/remove.go
@@ -103,6 +103,7 @@ func removeStory(
 		Event:     "pre-story-remove",
 		CodeRoot:  codeRoot,
 		StoryName: name,
+		WorkDir:   codeRoot,
 	}); err != nil {
 		return fmt.Errorf("pre-story-remove hook: %w", err)
 	}
@@ -130,6 +131,7 @@ func removeStory(
 					ProjectPath:  projectPath,
 					WorktreePath: worktreePath,
 					RepoPath:     repoPath,
+					WorkDir:      worktreePath,
 				}
 
 				if err := hooks.Run(ctx, preWT); err != nil {
@@ -152,6 +154,7 @@ func removeStory(
 					ProjectPath:  projectPath,
 					WorktreePath: worktreePath,
 					RepoPath:     repoPath,
+					WorkDir:      repoPath,
 				}
 
 				if err := hooks.Run(ctx, postWT); err != nil {
@@ -185,6 +188,7 @@ func removeStory(
 		Event:     "post-story-remove",
 		CodeRoot:  codeRoot,
 		StoryName: name,
+		WorkDir:   codeRoot,
 	}); err != nil {
 		slog.WarnContext(ctx, "post-story-remove hook failed", "err", err)
 	}

--- a/cmd/swm/internal/cli/story/remove_test.go
+++ b/cmd/swm/internal/cli/story/remove_test.go
@@ -111,6 +111,40 @@ func TestRemoveCmd_Confirm_ScanError_Aborts(t *testing.T) {
 	require.Contains(t, out.String(), "aborted")
 }
 
+func TestRemoveCmd_WorktreeHookWorkDirs(t *testing.T) {
+	t.Parallel()
+
+	st := &coreStory.Story{
+		Name: testStoryName,
+		Projects: []coreStory.Project{
+			{Host: testGitHubHost, Segments: []string{testKalbasitOrg, testSWMRepo}},
+		},
+	}
+	store := &stubStore{getStory: st}
+	vcs := &stubVCSClient{}
+	mgr := &stubManager{vcs: vcs}
+	resolver := layout.NewResolver("/code")
+
+	capturedCfgs := make(map[string]hookexec.RunConfig)
+
+	captureHook := hookexec.RunnerFunc(func(_ context.Context, cfg hookexec.RunConfig) error {
+		capturedCfgs[cfg.Event] = cfg
+
+		return nil
+	})
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, captureHook)
+	cmd.SetArgs([]string{testStoryName, testForceFlag})
+
+	require.NoError(t, cmd.Execute())
+
+	preWT := capturedCfgs["pre-worktree-remove"]
+	require.Equal(t, preWT.WorktreePath, preWT.WorkDir, "pre-worktree-remove WorkDir must be worktree path")
+
+	postWT := capturedCfgs["post-worktree-remove"]
+	require.Equal(t, postWT.RepoPath, postWT.WorkDir, "post-worktree-remove WorkDir must be repo path")
+}
+
 func TestRemoveCmd_HooksCalledInOrder(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -180,6 +180,7 @@ func NewOpenCmd(
 				Event:     "pre-workspace-open",
 				CodeRoot:  cfg.CodeRoot,
 				StoryName: storyName,
+				WorkDir:   cfg.CodeRoot,
 			}); err != nil {
 				return fmt.Errorf("pre-workspace-open hook: %w", err)
 			}
@@ -287,6 +288,7 @@ func openWithPicker(
 			ProjectPath:  projectPath,
 			WorktreePath: worktreePath,
 			RepoPath:     repoPath,
+			WorkDir:      repoPath,
 		}); err != nil {
 			return fmt.Errorf("pre-worktree-create hook: %w", err)
 		}
@@ -329,6 +331,7 @@ func openWithPicker(
 			ProjectPath:  projectPath,
 			WorktreePath: worktreePath,
 			RepoPath:     repoPath,
+			WorkDir:      worktreePath,
 		})
 	}
 
@@ -368,6 +371,7 @@ func openWithPicker(
 		Event:     "post-workspace-open",
 		CodeRoot:  cfg.CodeRoot,
 		StoryName: storyName,
+		WorkDir:   worktreePath,
 	})
 
 	if argv := switchRes.GetExecArgv(); len(argv) > 0 {
@@ -436,6 +440,7 @@ func openAllAttached(
 		Event:     "post-workspace-open",
 		CodeRoot:  cfg.CodeRoot,
 		StoryName: storyName,
+		WorkDir:   worktreePaths[firstKey],
 	})
 
 	switchRes, err := sess.SwitchTo(ctx, &pluginv1.SwitchToRequest{

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -30,6 +30,9 @@ const (
 	testHost         = "github.com"
 	testOwner        = "kalbasit"
 	testSegment      = "swm"
+
+	eventPreWorktreeCreate  = "pre-worktree-create"
+	eventPostWorktreeCreate = "post-worktree-create"
 )
 
 var (
@@ -195,7 +198,7 @@ func TestOpenCmd_WithPicker_PreWorktreeCreateHookAborts(t *testing.T) {
 	resolver := layout.NewResolver(testCodeRoot)
 
 	hooks := hookexec.RunnerFunc(func(_ context.Context, rc hookexec.RunConfig) error {
-		if rc.Event == "pre-worktree-create" {
+		if rc.Event == eventPreWorktreeCreate {
 			return errFakeHook
 		}
 
@@ -230,7 +233,7 @@ func TestOpenCmd_WithPicker_PostWorktreeCreateHookFailureContinues(t *testing.T)
 	var postHookCalled bool
 
 	hooks := hookexec.RunnerFunc(func(_ context.Context, rc hookexec.RunConfig) error {
-		if rc.Event == "post-worktree-create" {
+		if rc.Event == eventPostWorktreeCreate {
 			postHookCalled = true
 
 			return errFakeHook
@@ -271,7 +274,7 @@ func TestOpenCmd_WithPicker_PostWorktreeCreateHookReceivesContext(t *testing.T) 
 	var capturedCfg hookexec.RunConfig
 
 	hooks := hookexec.RunnerFunc(func(_ context.Context, rc hookexec.RunConfig) error {
-		if rc.Event == "post-worktree-create" {
+		if rc.Event == eventPostWorktreeCreate {
 			capturedCfg = rc
 		}
 
@@ -287,6 +290,45 @@ func TestOpenCmd_WithPicker_PostWorktreeCreateHookReceivesContext(t *testing.T) 
 	require.Equal(t, "kalbasit/dotfiles", capturedCfg.ProjectPath)
 	require.Equal(t, "/code/stories/feat-x/github.com/kalbasit/dotfiles", capturedCfg.WorktreePath)
 	require.Equal(t, "/code/repositories/github.com/kalbasit/dotfiles", capturedCfg.RepoPath)
+}
+
+func TestOpenCmd_WithPicker_PostWorktreeCreateHookWorkDir(t *testing.T) {
+	t.Parallel()
+
+	const selectedKey = "github.com/kalbasit/dotfiles"
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name:       testStoryName,
+		BranchName: testBranchName,
+	}}
+	sess := &stubSess{}
+	vcs := &stubVCS{}
+	picker := &stubPickerClient{selectedKey: selectedKey}
+	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
+	resolver := layout.NewResolver(testCodeRoot)
+
+	var capturedCfgs []hookexec.RunConfig
+
+	hooks := hookexec.RunnerFunc(func(_ context.Context, rc hookexec.RunConfig) error {
+		capturedCfgs = append(capturedCfgs, rc)
+
+		return nil
+	})
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hooks)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+
+	for _, rc := range capturedCfgs {
+		switch rc.Event {
+		case eventPostWorktreeCreate:
+			require.Equal(t, rc.WorktreePath, rc.WorkDir, "post-worktree-create WorkDir must be worktree path")
+		case eventPreWorktreeCreate:
+			require.Equal(t, rc.RepoPath, rc.WorkDir, "pre-worktree-create WorkDir must be repo path")
+		}
+	}
 }
 
 func TestOpenCmd_WithPicker_Cancelled(t *testing.T) {

--- a/cmd/swm/internal/hookexec/hookexec.go
+++ b/cmd/swm/internal/hookexec/hookexec.go
@@ -42,6 +42,10 @@ type RunConfig struct {
 	// RepoPath is the full path to the canonical repository clone. Empty if not applicable.
 	RepoPath string
 
+	// WorkDir sets the working directory for hook processes. When empty, hook
+	// processes inherit the working directory of the swm process.
+	WorkDir string
+
 	// ConfigHome overrides the XDG config home used for global and per-story
 	// hook tiers. When empty, xdg.ConfigHome is used. Inject in tests to avoid
 	// relying on the xdg package's cached (init-time) value.
@@ -168,6 +172,10 @@ func findHooks(dir string) ([]string, error) {
 // runHook executes a single hook binary with the appropriate env and stdin.
 func runHook(ctx context.Context, hookPath string, cfg RunConfig) error {
 	cmd := exec.CommandContext(ctx, hookPath)
+
+	if cfg.WorkDir != "" {
+		cmd.Dir = cfg.WorkDir
+	}
 
 	// Inherit the current environment and add the SWM_* vars.
 	cmd.Env = append(

--- a/cmd/swm/internal/hookexec/hookexec_test.go
+++ b/cmd/swm/internal/hookexec/hookexec_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -236,6 +237,57 @@ func TestRun_StdinJSON(t *testing.T) {
 	require.Contains(t, log, `"hook":"post-clone"`)
 	require.Contains(t, log, `"story":"feat-x"`)
 	require.Contains(t, log, `"project_host":"github.com"`)
+}
+
+func TestRun_WorkDirIsSet(t *testing.T) {
+	t.Parallel()
+
+	configHome := t.TempDir()
+	workDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "pwd.log")
+
+	globalDir := filepath.Join(configHome, "swm", "hooks")
+	installScript(t, globalDir, eventPostStory, "00-pwd", "pwd > "+logFile+"\n")
+
+	cfg := hookexec.RunConfig{
+		Event:      eventPostStory,
+		CodeRoot:   t.TempDir(),
+		StoryName:  testStoryName,
+		ConfigHome: configHome,
+		WorkDir:    workDir,
+	}
+
+	require.NoError(t, hookexec.Run(context.Background(), cfg))
+
+	got, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+	require.Equal(t, workDir, strings.TrimSpace(string(got)))
+}
+
+func TestRun_WorkDirEmpty_InheritsCwd(t *testing.T) {
+	t.Parallel()
+
+	configHome := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "pwd.log")
+
+	globalDir := filepath.Join(configHome, "swm", "hooks")
+	installScript(t, globalDir, eventPostStory, "00-pwd", "pwd > "+logFile+"\n")
+
+	cfg := hookexec.RunConfig{
+		Event:      eventPostStory,
+		CodeRoot:   t.TempDir(),
+		StoryName:  testStoryName,
+		ConfigHome: configHome,
+	}
+
+	processCwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	require.NoError(t, hookexec.Run(context.Background(), cfg))
+
+	got, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+	require.Equal(t, processCwd, strings.TrimSpace(string(got)))
 }
 
 func TestRun_CustomStdout(t *testing.T) {

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/design.md
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`hookexec.RunConfig` already carries `WorktreePath`, `RepoPath`, and `CodeRoot` for use as environment variables, but the executor builds the hook command with `exec.CommandContext` and never sets `Cmd.Dir`. As a result, every hook inherits the working directory of the swm process — typically wherever the user invoked the CLI — rather than a path meaningful to the hook script.
+
+The fix is a single-field addition to `RunConfig` (`WorkDir string`) and a one-liner in the executor. All existing call sites are updated in the same change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Hooks execute with a working directory appropriate to their event.
+- Hook authors can rely on `$PWD` matching the documented run location without reading env vars.
+- The hook system is documented in both root and host-CLI READMEs.
+
+**Non-Goals:**
+- No changes to hook discovery, tier resolution, environment variables, or stdin JSON.
+- No new hook events.
+- No validation that `WorkDir` exists before invoking hooks (OS error is sufficient).
+- No changes to pre-/post-* failure semantics.
+
+## Decisions
+
+### Add `WorkDir string` to `RunConfig`; callers set it explicitly
+
+**Alternatives considered:**
+- *Infer from event name inside the executor*: hookexec would need a mapping from event → which path field to use. This couples the executor to event semantics and makes it harder to add new events or override the directory in tests.
+- *Derive from existing path fields + event name at call site*: same coupling, just moved to the caller.
+
+**Decision:** A plain `WorkDir string` field on `RunConfig`. Each call site sets it to the appropriate path from the values it already has. The executor does one thing: `cmd.Dir = cfg.WorkDir` (when non-empty). Policy lives with the caller; the executor stays dumb.
+
+### Fall back to inherited cwd when `WorkDir` is empty
+
+All known call sites will be updated, but leaving the fallback as "inherit cwd" (rather than returning an error on empty `WorkDir`) keeps the change non-breaking for any future call sites added before they set `WorkDir`, and avoids a hard failure during the transition.
+
+### `WorkDir` per event
+
+| Event | WorkDir | Rationale |
+|---|---|---|
+| `pre-story-create` | `codeRoot` | no repo context |
+| `post-story-create` | `codeRoot` | no repo context |
+| `pre-story-remove` | `codeRoot` | no repo context |
+| `post-story-remove` | `codeRoot` | no repo context |
+| `pre-worktree-create` | `repoPath` | worktree not yet created; repo exists |
+| `post-worktree-create` | `worktreePath` | worktree was just created |
+| `pre-worktree-remove` | `worktreePath` | last chance to act inside the worktree |
+| `post-worktree-remove` | `repoPath` | worktree gone; repo still present (e.g. `git worktree prune`) |
+| `pre-clone` | `codeRoot` | repo does not exist yet |
+| `post-clone` | `repoPath` | newly cloned repo |
+| `pre-workspace-open` | `worktreePath` | opening into the worktree |
+| `post-workspace-open` | `worktreePath` | opened into the worktree |
+
+## Risks / Trade-offs
+
+- **`pre-worktree-create` with a non-existent repo** → If the repo has never been cloned, `repoPath` won't exist. The OS will fail to start the hook process. This is intentional: hook authors should only place a `pre-worktree-create` hook in a per-repo tier if the repo exists. Global and per-story hooks for this event would need to check `$SWM_REPO_PATH` themselves. Acceptable trade-off; the alternative (silently falling back to cwd) is worse than an obvious failure.
+
+- **Existing hook scripts that relied on the inherited cwd** → Breaking change in behavior, but those scripts were relying on undefined/accidental behavior. The new behavior is correct and documented.
+
+## Migration Plan
+
+All changes ship in a single commit set:
+1. Add `WorkDir` to `RunConfig` and set `cmd.Dir` in the executor.
+2. Update all call sites (`clone.go`, `story/create.go`, `story/remove.go`, `workspace/open.go`).
+3. Add spec scenarios and update `cmd/swm/README.md` and root `README.md`.
+
+No rollback concern — the change is confined to the swm host binary with no protocol or plugin API impact.

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/design.md
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/design.md
@@ -45,7 +45,7 @@ All known call sites will be updated, but leaving the fallback as "inherit cwd" 
 | `post-worktree-remove` | `repoPath` | worktree gone; repo still present (e.g. `git worktree prune`) |
 | `pre-clone` | `codeRoot` | repo does not exist yet |
 | `post-clone` | `repoPath` | newly cloned repo |
-| `pre-workspace-open` | `worktreePath` | opening into the worktree |
+| `pre-workspace-open` | `codeRoot` | opening into the workspace |
 | `post-workspace-open` | `worktreePath` | opened into the worktree |
 
 ## Risks / Trade-offs

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/proposal.md
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/proposal.md
@@ -19,7 +19,7 @@ Hook executables currently inherit the working directory of the swm process rath
   | `post-worktree-remove` | `repoPath` |
   | `pre-clone` | `codeRoot` |
   | `post-clone` | `repoPath` |
-  | `pre-workspace-open` | `worktreePath` |
+  | `pre-workspace-open` | `codeRoot` |
   | `post-workspace-open` | `worktreePath` |
 
 - Add a Hook System section to `cmd/swm/README.md` covering: all supported events, their working directory, tier resolution order, environment variables, and stdin JSON contract.

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/proposal.md
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Hook executables currently inherit the working directory of the swm process rather than the contextually appropriate path, so hooks like `post-worktree-create` run in an arbitrary directory instead of inside the new worktree. Users have no documented reference for what hooks exist, when they fire, or where they run.
+
+## What Changes
+
+- Add a `WorkDir` field to `hookexec.RunConfig`; the hook executor SHALL set `cmd.Dir` to this value when non-empty.
+- Each call site SHALL populate `WorkDir` according to the table below:
+
+  | Event | WorkDir |
+  |---|---|
+  | `pre-story-create` | `codeRoot` |
+  | `post-story-create` | `codeRoot` |
+  | `pre-story-remove` | `codeRoot` |
+  | `post-story-remove` | `codeRoot` |
+  | `pre-worktree-create` | `repoPath` |
+  | `post-worktree-create` | `worktreePath` |
+  | `pre-worktree-remove` | `worktreePath` |
+  | `post-worktree-remove` | `repoPath` |
+  | `pre-clone` | `codeRoot` |
+  | `post-clone` | `repoPath` |
+  | `pre-workspace-open` | `worktreePath` |
+  | `post-workspace-open` | `worktreePath` |
+
+- Add a Hook System section to `cmd/swm/README.md` covering: all supported events, their working directory, tier resolution order, environment variables, and stdin JSON contract.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `hook-executor`: add `WorkDir` field to `RunConfig`; executor sets `cmd.Dir` when non-empty; spec gains a working-directory requirement and scenarios per event class.
+- `project-documentation`: `cmd/swm/README.md` must include a Hook System section (event reference table + tier resolution + env vars + stdin JSON). The root `README.md` must include a brief hook system mention with a link to `cmd/swm/README.md#hook-system`.
+
+## Impact
+
+- `cmd/swm/internal/hookexec/hookexec.go` — set `cmd.Dir = cfg.WorkDir` when non-empty.
+- `cmd/swm/internal/hookexec/hookexec_test.go` — add scenarios asserting correct working directory per event class.
+- `cmd/swm/internal/cli/workspace/open.go` — populate `WorkDir` on all four `RunConfig` values.
+- `cmd/swm/internal/cli/story/create.go` — populate `WorkDir = codeRoot` on both `RunConfig` values.
+- `cmd/swm/internal/cli/story/remove.go` — populate `WorkDir` on all four `RunConfig` values.
+- `cmd/swm/internal/cli/clone.go` — populate `WorkDir` on both `RunConfig` values.
+- `cmd/swm/README.md` — new Hook System section.
+- `README.md` — brief hook system mention with link to `cmd/swm/README.md#hook-system`.
+- No proto changes. No plugin API changes.

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/specs/hook-executor/spec.md
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/specs/hook-executor/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Hook executor package
+`cmd/swm/internal/hookexec` SHALL provide a `Run(ctx context.Context, cfg RunConfig) error` function that discovers and executes plain executables for a named lifecycle event. `RunConfig` SHALL carry: `event` (string), `codeRoot` (string), `storyName` (string), `projectHost` (string, optional), `projectPath` (string, optional — segments joined by `/`), `worktreePath` (string, optional), `repoPath` (string, optional), `workDir` (string, optional — working directory for hook processes).
+
+#### Scenario: No hooks configured — exits cleanly
+- **WHEN** `hookexec.Run` is called and none of the three hook tier directories exist
+- **THEN** the function returns nil without executing anything
+
+#### Scenario: Executables run in lexical order within a tier
+- **WHEN** a global hook tier contains `00-first` and `10-second`
+- **THEN** `00-first` is executed before `10-second`
+
+## ADDED Requirements
+
+### Requirement: Hook working directory
+When `RunConfig.WorkDir` is non-empty, the executor SHALL set `cmd.Dir` to `WorkDir` for every hook process it spawns. When `WorkDir` is empty, the hook process SHALL inherit the working directory of the swm process.
+
+#### Scenario: Hook runs in the specified working directory
+- **WHEN** `hookexec.Run` is called with `WorkDir` set to a valid directory path
+- **THEN** each hook executable runs with that directory as its working directory (i.e. `$PWD` equals `WorkDir`)
+
+#### Scenario: Hook inherits cwd when WorkDir is empty
+- **WHEN** `hookexec.Run` is called with an empty `WorkDir`
+- **THEN** hook executables inherit the working directory of the swm process
+
+### Requirement: Hook working directory per event
+Each call site SHALL populate `WorkDir` according to the event:
+
+- `pre-story-create`, `post-story-create`, `pre-story-remove`, `post-story-remove`: `codeRoot`
+- `pre-worktree-create`: `repoPath` (repo exists; worktree not yet created)
+- `post-worktree-create`: `worktreePath` (worktree was just created)
+- `pre-worktree-remove`: `worktreePath` (last chance to act inside the worktree)
+- `post-worktree-remove`: `repoPath` (worktree gone; repo still present)
+- `pre-clone`: `codeRoot` (repo does not exist yet)
+- `post-clone`: `repoPath` (newly cloned repo)
+- `pre-workspace-open`, `post-workspace-open`: `worktreePath`
+
+#### Scenario: post-worktree-create hook runs inside the worktree
+- **WHEN** `swm workspace open` creates a worktree and runs `post-worktree-create` hooks
+- **THEN** the hook's working directory is the newly created worktree path
+
+#### Scenario: post-worktree-remove hook runs inside the repo
+- **WHEN** `swm story remove` removes a worktree and runs `post-worktree-remove` hooks
+- **THEN** the hook's working directory is the canonical repository path, allowing operations such as `git worktree prune`
+
+#### Scenario: pre-worktree-remove hook runs inside the worktree
+- **WHEN** `swm story remove` is about to remove a worktree and runs `pre-worktree-remove` hooks
+- **THEN** the hook's working directory is the worktree path, allowing final cleanup inside it
+
+#### Scenario: story-level hooks run at code root
+- **WHEN** `swm story create` or `swm story remove` runs story-level hooks
+- **THEN** the hook's working directory is `codeRoot`, since no single repository context applies

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/specs/hook-executor/spec.md
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/specs/hook-executor/spec.md
@@ -34,7 +34,8 @@ Each call site SHALL populate `WorkDir` according to the event:
 - `post-worktree-remove`: `repoPath` (worktree gone; repo still present)
 - `pre-clone`: `codeRoot` (repo does not exist yet)
 - `post-clone`: `repoPath` (newly cloned repo)
-- `pre-workspace-open`, `post-workspace-open`: `worktreePath`
+- `pre-workspace-open`: `codeRoot`
+- `post-workspace-open`: `worktreePath`
 
 #### Scenario: post-worktree-create hook runs inside the worktree
 - **WHEN** `swm workspace open` creates a worktree and runs `post-worktree-create` hooks

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/specs/project-documentation/spec.md
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/specs/project-documentation/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Root README introduces the project
+The repository root SHALL contain a `README.md` that gives a first-time visitor a clear understanding of the project within 60 seconds of reading.
+
+#### Scenario: Root README covers minimum required sections
+- **WHEN** a visitor reads `README.md` at the repo root
+- **THEN** it SHALL contain: project name and one-line description, use-case summary, architecture overview (host + plugin model), quick-start install instructions, a brief hook system mention with a link to the hook system reference in `cmd/swm/README.md`, link to contributing guide, and links to per-module READMEs
+
+### Requirement: Host CLI has a module-level README
+`cmd/swm/README.md` SHALL document the host CLI in sufficient detail for a new user to install, configure, and run it.
+
+#### Scenario: Host README covers CLI usage
+- **WHEN** a user reads `cmd/swm/README.md`
+- **THEN** it SHALL cover: available commands, configuration file format (TOML), plugin discovery order, and a Hook System section containing: all supported event names, the working directory each event runs in, tier resolution order (global → per-repo → per-story), the environment variables passed to each hook (`SWM_HOOK`, `SWM_STORY`, `SWM_PROJECT_HOST`, `SWM_PROJECT_PATH`, `SWM_WORKTREE_PATH`, `SWM_REPO_PATH`), and the stdin JSON contract
+
+#### Scenario: Hook System section is reachable via anchor
+- **WHEN** a reader follows a link to `cmd/swm/README.md#hook-system`
+- **THEN** they land directly on the Hook System section

--- a/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/tasks.md
+++ b/openspec/changes/archive/2026-05-17-post-worktree-create-hook-ran-wrong-location/tasks.md
@@ -1,0 +1,26 @@
+## 1. hookexec — Add WorkDir field (cmd/swm)
+
+- [x] 1.1 Add `WorkDir string` field to `hookexec.RunConfig` in `cmd/swm/internal/hookexec/hookexec.go`
+- [x] 1.2 Set `cmd.Dir = cfg.WorkDir` (when non-empty) in the hook process builder in `cmd/swm/internal/hookexec/hookexec.go`
+- [x] 1.3 Add table-driven test scenarios in `cmd/swm/internal/hookexec/hookexec_test.go` asserting hook runs in the correct working directory when `WorkDir` is set
+- [x] 1.4 Add test scenario asserting hook inherits process cwd when `WorkDir` is empty
+
+## 2. Call sites — Populate WorkDir (cmd/swm)
+
+- [x] 2.1 `cmd/swm/internal/cli/story/create.go`: set `WorkDir = codeRoot` on both `pre-story-create` and `post-story-create` `RunConfig` values
+- [x] 2.2 `cmd/swm/internal/cli/story/remove.go`: set `WorkDir = codeRoot` on `pre-story-remove` and `post-story-remove`; set `WorkDir = worktreePath` on `pre-worktree-remove`; set `WorkDir = repoPath` on `post-worktree-remove`
+- [x] 2.3 `cmd/swm/internal/cli/workspace/open.go`: set `WorkDir = repoPath` on `pre-worktree-create`; set `WorkDir = worktreePath` on `post-worktree-create`, `pre-workspace-open`, and `post-workspace-open`
+- [x] 2.4 `cmd/swm/internal/cli/clone.go`: set `WorkDir = codeRoot` on `pre-clone`; set `WorkDir = repoPath` on `post-clone`
+
+## 3. Tests — Verify working directory per event (cmd/swm)
+
+- [x] 3.1 Add or extend integration/unit tests in `workspace/open_test.go` confirming `post-worktree-create` hooks receive the worktree as cwd
+- [x] 3.2 Add or extend tests in `story/remove_test.go` confirming `pre-worktree-remove` receives worktree cwd and `post-worktree-remove` receives repo cwd
+
+## 4. Documentation — cmd/swm README
+
+- [x] 4.1 Add a `## Hook System` section to `cmd/swm/README.md` covering: all 12 supported events with their working directory, tier resolution order (global → per-repo → per-story), environment variables (`SWM_HOOK`, `SWM_STORY`, `SWM_PROJECT_HOST`, `SWM_PROJECT_PATH`, `SWM_WORKTREE_PATH`, `SWM_REPO_PATH`), and stdin JSON contract
+
+## 5. Documentation — Root README
+
+- [x] 5.1 Add a brief hook system mention to the root `README.md` with a link to `cmd/swm/README.md#hook-system`

--- a/openspec/specs/hook-executor/spec.md
+++ b/openspec/specs/hook-executor/spec.md
@@ -95,7 +95,8 @@ Each call site SHALL populate `WorkDir` according to the event:
 - `post-worktree-remove`: `repoPath` (worktree gone; repo still present)
 - `pre-clone`: `codeRoot` (repo does not exist yet)
 - `post-clone`: `repoPath` (newly cloned repo)
-- `pre-workspace-open`, `post-workspace-open`: `worktreePath`
+- `pre-workspace-open`: `codeRoot`
+- `post-workspace-open`: `worktreePath`
 
 #### Scenario: post-worktree-create hook runs inside the worktree
 - **WHEN** `swm workspace open` creates a worktree and runs `post-worktree-create` hooks

--- a/openspec/specs/hook-executor/spec.md
+++ b/openspec/specs/hook-executor/spec.md
@@ -1,5 +1,5 @@
 ### Requirement: Hook executor package
-`cmd/swm/internal/hookexec` SHALL provide a `Run(ctx context.Context, cfg RunConfig) error` function that discovers and executes plain executables for a named lifecycle event. `RunConfig` SHALL carry: `event` (string), `codeRoot` (string), `storyName` (string), `projectHost` (string, optional), `projectPath` (string, optional — segments joined by `/`), `worktreePath` (string, optional), `repoPath` (string, optional).
+`cmd/swm/internal/hookexec` SHALL provide a `Run(ctx context.Context, cfg RunConfig) error` function that discovers and executes plain executables for a named lifecycle event. `RunConfig` SHALL carry: `event` (string), `codeRoot` (string), `storyName` (string), `projectHost` (string, optional), `projectPath` (string, optional — segments joined by `/`), `worktreePath` (string, optional), `repoPath` (string, optional), `workDir` (string, optional — working directory for hook processes).
 
 #### Scenario: No hooks configured — exits cleanly
 - **WHEN** `hookexec.Run` is called and none of the three hook tier directories exist
@@ -73,3 +73,42 @@ The executor SHALL support the following event names: `pre-story-create`, `post-
 #### Scenario: All defined events are supported
 - **WHEN** `hookexec.Run` is called with any of the defined event names
 - **THEN** the function discovers and executes hooks for that event without error (even if no hooks exist)
+
+### Requirement: Hook working directory
+When `RunConfig.WorkDir` is non-empty, the executor SHALL set `cmd.Dir` to `WorkDir` for every hook process it spawns. When `WorkDir` is empty, the hook process SHALL inherit the working directory of the swm process.
+
+#### Scenario: Hook runs in the specified working directory
+- **WHEN** `hookexec.Run` is called with `WorkDir` set to a valid directory path
+- **THEN** each hook executable runs with that directory as its working directory (i.e. `$PWD` equals `WorkDir`)
+
+#### Scenario: Hook inherits cwd when WorkDir is empty
+- **WHEN** `hookexec.Run` is called with an empty `WorkDir`
+- **THEN** hook executables inherit the working directory of the swm process
+
+### Requirement: Hook working directory per event
+Each call site SHALL populate `WorkDir` according to the event:
+
+- `pre-story-create`, `post-story-create`, `pre-story-remove`, `post-story-remove`: `codeRoot`
+- `pre-worktree-create`: `repoPath` (repo exists; worktree not yet created)
+- `post-worktree-create`: `worktreePath` (worktree was just created)
+- `pre-worktree-remove`: `worktreePath` (last chance to act inside the worktree)
+- `post-worktree-remove`: `repoPath` (worktree gone; repo still present)
+- `pre-clone`: `codeRoot` (repo does not exist yet)
+- `post-clone`: `repoPath` (newly cloned repo)
+- `pre-workspace-open`, `post-workspace-open`: `worktreePath`
+
+#### Scenario: post-worktree-create hook runs inside the worktree
+- **WHEN** `swm workspace open` creates a worktree and runs `post-worktree-create` hooks
+- **THEN** the hook's working directory is the newly created worktree path
+
+#### Scenario: post-worktree-remove hook runs inside the repo
+- **WHEN** `swm story remove` removes a worktree and runs `post-worktree-remove` hooks
+- **THEN** the hook's working directory is the canonical repository path, allowing operations such as `git worktree prune`
+
+#### Scenario: pre-worktree-remove hook runs inside the worktree
+- **WHEN** `swm story remove` is about to remove a worktree and runs `pre-worktree-remove` hooks
+- **THEN** the hook's working directory is the worktree path, allowing final cleanup inside it
+
+#### Scenario: story-level hooks run at code root
+- **WHEN** `swm story create` or `swm story remove` runs story-level hooks
+- **THEN** the hook's working directory is `codeRoot`, since no single repository context applies

--- a/openspec/specs/project-documentation/spec.md
+++ b/openspec/specs/project-documentation/spec.md
@@ -18,14 +18,18 @@ The repository root SHALL contain a `README.md` that gives a first-time visitor 
 
 #### Scenario: Root README covers minimum required sections
 - **WHEN** a visitor reads `README.md` at the repo root
-- **THEN** it SHALL contain: project name and one-line description, use-case summary, architecture overview (host + plugin model), quick-start install instructions, link to contributing guide, and links to per-module READMEs
+- **THEN** it SHALL contain: project name and one-line description, use-case summary, architecture overview (host + plugin model), quick-start install instructions, a brief hook system mention with a link to the hook system reference in `cmd/swm/README.md`, link to contributing guide, and links to per-module READMEs
 
 ### Requirement: Host CLI has a module-level README
 `cmd/swm/README.md` SHALL document the host CLI in sufficient detail for a new user to install, configure, and run it.
 
 #### Scenario: Host README covers CLI usage
 - **WHEN** a user reads `cmd/swm/README.md`
-- **THEN** it SHALL cover: available commands, configuration file format (TOML), plugin discovery order, and hook system overview
+- **THEN** it SHALL cover: available commands, configuration file format (TOML), plugin discovery order, and a Hook System section containing: all supported event names, the working directory each event runs in, tier resolution order (global → per-repo → per-story), the environment variables passed to each hook (`SWM_HOOK`, `SWM_STORY`, `SWM_PROJECT_HOST`, `SWM_PROJECT_PATH`, `SWM_WORKTREE_PATH`, `SWM_REPO_PATH`), and the stdin JSON contract
+
+#### Scenario: Hook System section is reachable via anchor
+- **WHEN** a reader follows a link to `cmd/swm/README.md#hook-system`
+- **THEN** they land directly on the Hook System section
 
 ### Requirement: Go SDK has a module-level README
 `sdk/go/README.md` SHALL document the Go SDK for plugin authors.


### PR DESCRIPTION
Each hook event now receives an explicit WorkDir so the hook
process's $PWD matches the operation context rather than
inheriting wherever swm was invoked from.

WorkDir per event:
- pre/post-story-{create,remove}: code_root (no repo context)
- pre-worktree-create:            repo path (worktree not yet created)
- post-worktree-create:           worktree path (just created)
- pre-worktree-remove:            worktree path (last chance inside it)
- post-worktree-remove:           repo path (for git worktree prune etc.)
- pre-clone:                      code_root (repo does not exist yet)
- post-clone:                     repo path (newly cloned)
- pre/post-workspace-open:        code_root / worktree path

Implementation: add WorkDir string to hookexec.RunConfig; executor
sets cmd.Dir when non-empty; all call sites (clone.go, story/create.go,
story/remove.go, workspace/open.go) populate the field.

Also adds a Hook System reference table (with working directory
column, env vars, and stdin JSON contract) to cmd/swm/README.md
and a brief mention with anchor link in the root README.