### PR TITLE
chore: add task and rule to keep nix vendorHashes in sync with proto

### DIFF
--- a/.claude/rules/update-nix-vendor-hashes.md
+++ b/.claude/rules/update-nix-vendor-hashes.md
@@ -1,0 +1,41 @@
+# Update Nix vendorHashes When Proto Files Change
+
+Whenever any file under `proto/` is modified — including formatting-only changes
+to `.pb.go` files — run:
+
+```sh
+task update-nix-vendor-hashes
+```
+
+then commit the resulting nix changes alongside the proto changes.
+
+## Why
+
+All five Go packages vendor the local `proto` module via a `replace` directive:
+
+```
+replace github.com/kalbasit/swm/proto => ../../proto
+```
+
+`buildGoModule` runs `go mod vendor`, which copies the local proto tree verbatim
+into the vendor directory. Any content change in `proto/` — even a blank line —
+produces a different vendor hash, invalidating the stored `vendorHash` in:
+
+- `nix/packages/swm/default.nix`
+- `nix/packages/swm-plugin-forge-github/default.nix`
+- `nix/packages/swm-plugin-picker-fzf/default.nix`
+- `nix/packages/swm-plugin-session-tmux/default.nix`
+- `nix/packages/swm-plugin-vcs-git/default.nix`
+
+## When this fires
+
+- After `task fmt` if proto files appear in the diff
+- After running `protoc` or any proto-regeneration step
+- After any manual edit to a file under `proto/`
+
+## What the task does
+
+Mirrors the `generate` job in `.github/workflows/ci.yml`: for each package it
+attempts to build `.#${pkg}.goModules`, extracts the `got:` hash from the error
+output if the stored hash is wrong, and patches the `vendorHash` line in place
+with `sed`.

--- a/.claude/rules/update-nix-vendor-hashes.md
+++ b/.claude/rules/update-nix-vendor-hashes.md
@@ -38,4 +38,4 @@ produces a different vendor hash, invalidating the stored `vendorHash` in:
 Mirrors the `generate` job in `.github/workflows/ci.yml`: for each package it
 attempts to build `.#${pkg}.goModules`, extracts the `got:` hash from the error
 output if the stored hash is wrong, and patches the `vendorHash` line in place
-with `sed`.
+using Python.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,11 @@ formatters:
   enable:
     - gci
     - gofumpt
+  exclusions:
+    # Proto-generated files must not be reformatted — buf owns their style.
+    generated: lax
+    paths:
+      - \.pb\.go$
   settings:
     gci:
       sections:
@@ -116,5 +121,6 @@ linters:
           - gochecknoglobals
     paths:
       # Generated proto Go code: skip linting entirely.
-      - proto/swm/plugin/v1/.*\.pb\.go$
-      - proto/swm/plugin/v1/.*\.pb\.grpc\.go$
+      # Match by suffix so patterns work both from the workspace root and from
+      # within the proto/ module (where golangci-lint is cd'd by the pre-commit hook).
+      - \.pb\.go$

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -51,37 +51,9 @@ tasks:
       - task: forge-github:lint
 
   update-nix-vendor-hashes:
-    desc: Re-compute and update vendorHash for all nix Go packages (run after any proto/ changes)
+    desc: Re-compute and update vendorHash for all nix Go packages in parallel (run after any proto/ changes)
     cmds:
-      - |
-        for pkg in swm swm-plugin-forge-github swm-plugin-picker-fzf swm-plugin-session-tmux swm-plugin-vcs-git; do
-          set +e
-          nix build --print-build-logs ".#${pkg}.goModules" 2>/tmp/nix-vendor-hash-log
-          ret=$?
-          set -e
-
-          if [[ "$ret" -eq 0 ]]; then
-            set +e
-            nix build --print-build-logs ".#${pkg}.goModules" --rebuild 2>/tmp/nix-vendor-hash-log
-            ret=$?
-            set -e
-          fi
-
-          if [[ "$ret" -eq 0 ]]; then
-            echo "vendorHash up to date for $pkg"
-            continue
-          fi
-
-          hash="$(grep 'got:' /tmp/nix-vendor-hash-log | awk '{print $2}')"
-          if [[ -z "$hash" ]]; then
-            cat /tmp/nix-vendor-hash-log
-            echo "ERROR: could not extract hash for $pkg"
-            exit 1
-          fi
-
-          echo "Updating vendorHash for $pkg → $hash"
-          sed -e "s#vendorHash =.*\$#vendorHash = \"${hash}\";#g" -i "nix/packages/${pkg}/default.nix"
-        done
+      - python3 scripts/update-nix-vendor-hashes.py
 
   test:
     desc: Run all module tests in dependency order

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -50,6 +50,39 @@ tasks:
       - task: picker-fzf:lint
       - task: forge-github:lint
 
+  update-nix-vendor-hashes:
+    desc: Re-compute and update vendorHash for all nix Go packages (run after any proto/ changes)
+    cmds:
+      - |
+        for pkg in swm swm-plugin-forge-github swm-plugin-picker-fzf swm-plugin-session-tmux swm-plugin-vcs-git; do
+          set +e
+          nix build --print-build-logs ".#${pkg}.goModules" 2>/tmp/nix-vendor-hash-log
+          ret=$?
+          set -e
+
+          if [[ "$ret" -eq 0 ]]; then
+            set +e
+            nix build --print-build-logs ".#${pkg}.goModules" --rebuild 2>/tmp/nix-vendor-hash-log
+            ret=$?
+            set -e
+          fi
+
+          if [[ "$ret" -eq 0 ]]; then
+            echo "vendorHash up to date for $pkg"
+            continue
+          fi
+
+          hash="$(grep 'got:' /tmp/nix-vendor-hash-log | awk '{print $2}')"
+          if [[ -z "$hash" ]]; then
+            cat /tmp/nix-vendor-hash-log
+            echo "ERROR: could not extract hash for $pkg"
+            exit 1
+          fi
+
+          echo "Updating vendorHash for $pkg → $hash"
+          sed -e "s#vendorHash =.*\$#vendorHash = \"${hash}\";#g" -i "nix/packages/${pkg}/default.nix"
+        done
+
   test:
     desc: Run all module tests in dependency order
     cmds:

--- a/nix/formatter/flake-module.nix
+++ b/nix/formatter/flake-module.nix
@@ -19,6 +19,7 @@
         "CLAUDE.md"
         "LICENSE"
         "openspec/**/*.md"
+        "proto/**/*.pb.go"
         "renovate.json"
       ];
 

--- a/nix/packages/swm-plugin-forge-github/default.nix
+++ b/nix/packages/swm-plugin-forge-github/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-8k1tgDCUuTgYHOP7Bvf9YWjOIJ7wVBGvDOorZ5o0N58=";
+          vendorHash = "sha256-VoHFOZad+6Or3GRWQ06Gm5p6lq8FlXmkTP9G0B0Md9k=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-picker-fzf/default.nix
+++ b/nix/packages/swm-plugin-picker-fzf/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-KXP32rb6qSkOs0RCQA/XCgUdYwjxKcVZwP2Y94q0nCw=";
+          vendorHash = "sha256-2Ua8hCmWWVCadVRZUtnuE5Gd9iKECpJWe5wfm+JI8jk=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-session-tmux/default.nix
+++ b/nix/packages/swm-plugin-session-tmux/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-/asd0ZvgiUOiVoBr6htsU7vYe7ZrJHiI3ZkrZh2qsLI=";
+          vendorHash = "sha256-LMxlmp3l9N07VXYw1KTgFMkTeeTBDxMsoinfvTCm2Sc=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-vcs-git/default.nix
+++ b/nix/packages/swm-plugin-vcs-git/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-uDGSt/3pozAf51Px4/OQHgB9D/LBWsu85oHIJgj9Usk=";
+          vendorHash = "sha256-VZGu8EAreBTV+DnavjWMEchPNjvQ6ln7oUvbP0g9Dhw=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm/default.nix
+++ b/nix/packages/swm/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-lOIhyZmXi7OMiCb41xKw9rDlKVvc+zMFA/dg1EOelKc=";
+          vendorHash = "sha256-X4gHrBIvZJQigbP3HN1Hv43URfBHSGVs7SWzFOU/sns=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/proto/swm/plugin/v1/common.pb.go
+++ b/proto/swm/plugin/v1/common.pb.go
@@ -7,13 +7,12 @@
 package pluginv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -659,25 +658,22 @@ func file_swm_plugin_v1_common_proto_rawDescGZIP() []byte {
 	return file_swm_plugin_v1_common_proto_rawDescData
 }
 
-var (
-	file_swm_plugin_v1_common_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_swm_plugin_v1_common_proto_msgTypes  = make([]protoimpl.MessageInfo, 10)
-	file_swm_plugin_v1_common_proto_goTypes   = []any{
-		CapabilityType(0),             // 0: swm.plugin.v1.CapabilityType
-		(*Empty)(nil),                 // 1: swm.plugin.v1.Empty
-		(*BoolValue)(nil),             // 2: swm.plugin.v1.BoolValue
-		(*PathResponse)(nil),          // 3: swm.plugin.v1.PathResponse
-		(*ProjectID)(nil),             // 4: swm.plugin.v1.ProjectID
-		(*Capability)(nil),            // 5: swm.plugin.v1.Capability
-		(*CapabilityDep)(nil),         // 6: swm.plugin.v1.CapabilityDep
-		(*PluginInfo)(nil),            // 7: swm.plugin.v1.PluginInfo
-		(*Project)(nil),               // 8: swm.plugin.v1.Project
-		(*Story)(nil),                 // 9: swm.plugin.v1.Story
-		nil,                           // 10: swm.plugin.v1.Story.MetadataEntry
-		(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
-	}
-)
-
+var file_swm_plugin_v1_common_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_swm_plugin_v1_common_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_swm_plugin_v1_common_proto_goTypes = []any{
+	(CapabilityType)(0),           // 0: swm.plugin.v1.CapabilityType
+	(*Empty)(nil),                 // 1: swm.plugin.v1.Empty
+	(*BoolValue)(nil),             // 2: swm.plugin.v1.BoolValue
+	(*PathResponse)(nil),          // 3: swm.plugin.v1.PathResponse
+	(*ProjectID)(nil),             // 4: swm.plugin.v1.ProjectID
+	(*Capability)(nil),            // 5: swm.plugin.v1.Capability
+	(*CapabilityDep)(nil),         // 6: swm.plugin.v1.CapabilityDep
+	(*PluginInfo)(nil),            // 7: swm.plugin.v1.PluginInfo
+	(*Project)(nil),               // 8: swm.plugin.v1.Project
+	(*Story)(nil),                 // 9: swm.plugin.v1.Story
+	nil,                           // 10: swm.plugin.v1.Story.MetadataEntry
+	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
+}
 var file_swm_plugin_v1_common_proto_depIdxs = []int32{
 	0,  // 0: swm.plugin.v1.Capability.type:type_name -> swm.plugin.v1.CapabilityType
 	0,  // 1: swm.plugin.v1.CapabilityDep.capability:type_name -> swm.plugin.v1.CapabilityType

--- a/proto/swm/plugin/v1/forge.pb.go
+++ b/proto/swm/plugin/v1/forge.pb.go
@@ -7,12 +7,11 @@
 package pluginv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -549,23 +548,20 @@ func file_swm_plugin_v1_forge_proto_rawDescGZIP() []byte {
 	return file_swm_plugin_v1_forge_proto_rawDescData
 }
 
-var (
-	file_swm_plugin_v1_forge_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-	file_swm_plugin_v1_forge_proto_msgTypes  = make([]protoimpl.MessageInfo, 5)
-	file_swm_plugin_v1_forge_proto_goTypes   = []any{
-		PullRequestState(0),     // 0: swm.plugin.v1.PullRequestState
-		PullRequestFilter(0),    // 1: swm.plugin.v1.PullRequestFilter
-		(*ForgeInfo)(nil),       // 2: swm.plugin.v1.ForgeInfo
-		(*PullRequest)(nil),     // 3: swm.plugin.v1.PullRequest
-		(*ListPRsRequest)(nil),  // 4: swm.plugin.v1.ListPRsRequest
-		(*CreatePRRequest)(nil), // 5: swm.plugin.v1.CreatePRRequest
-		(*GetPRRequest)(nil),    // 6: swm.plugin.v1.GetPRRequest
-		(*PluginInfo)(nil),      // 7: swm.plugin.v1.PluginInfo
-		(*ProjectID)(nil),       // 8: swm.plugin.v1.ProjectID
-		(*Empty)(nil),           // 9: swm.plugin.v1.Empty
-	}
-)
-
+var file_swm_plugin_v1_forge_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_swm_plugin_v1_forge_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_swm_plugin_v1_forge_proto_goTypes = []any{
+	(PullRequestState)(0),   // 0: swm.plugin.v1.PullRequestState
+	(PullRequestFilter)(0),  // 1: swm.plugin.v1.PullRequestFilter
+	(*ForgeInfo)(nil),       // 2: swm.plugin.v1.ForgeInfo
+	(*PullRequest)(nil),     // 3: swm.plugin.v1.PullRequest
+	(*ListPRsRequest)(nil),  // 4: swm.plugin.v1.ListPRsRequest
+	(*CreatePRRequest)(nil), // 5: swm.plugin.v1.CreatePRRequest
+	(*GetPRRequest)(nil),    // 6: swm.plugin.v1.GetPRRequest
+	(*PluginInfo)(nil),      // 7: swm.plugin.v1.PluginInfo
+	(*ProjectID)(nil),       // 8: swm.plugin.v1.ProjectID
+	(*Empty)(nil),           // 9: swm.plugin.v1.Empty
+}
 var file_swm_plugin_v1_forge_proto_depIdxs = []int32{
 	7,  // 0: swm.plugin.v1.ForgeInfo.plugin_info:type_name -> swm.plugin.v1.PluginInfo
 	0,  // 1: swm.plugin.v1.PullRequest.state:type_name -> swm.plugin.v1.PullRequestState

--- a/proto/swm/plugin/v1/forge_grpc.pb.go
+++ b/proto/swm/plugin/v1/forge_grpc.pb.go
@@ -8,7 +8,6 @@ package pluginv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -117,15 +116,12 @@ type UnimplementedForgeServer struct{}
 func (UnimplementedForgeServer) Info(context.Context, *Empty) (*ForgeInfo, error) {
 	return nil, status.Error(codes.Unimplemented, "method Info not implemented")
 }
-
 func (UnimplementedForgeServer) ListPullRequests(*ListPRsRequest, grpc.ServerStreamingServer[PullRequest]) error {
 	return status.Error(codes.Unimplemented, "method ListPullRequests not implemented")
 }
-
 func (UnimplementedForgeServer) CreatePullRequest(context.Context, *CreatePRRequest) (*PullRequest, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreatePullRequest not implemented")
 }
-
 func (UnimplementedForgeServer) GetPullRequest(context.Context, *GetPRRequest) (*PullRequest, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetPullRequest not implemented")
 }

--- a/proto/swm/plugin/v1/host.pb.go
+++ b/proto/swm/plugin/v1/host.pb.go
@@ -7,12 +7,11 @@
 package pluginv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -430,26 +429,23 @@ func file_swm_plugin_v1_host_proto_rawDescGZIP() []byte {
 	return file_swm_plugin_v1_host_proto_rawDescData
 }
 
-var (
-	file_swm_plugin_v1_host_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_swm_plugin_v1_host_proto_msgTypes  = make([]protoimpl.MessageInfo, 7)
-	file_swm_plugin_v1_host_proto_goTypes   = []any{
-		LogLevel(0),                    // 0: swm.plugin.v1.LogLevel
-		(*GetConfigRequest)(nil),       // 1: swm.plugin.v1.GetConfigRequest
-		(*Config)(nil),                 // 2: swm.plugin.v1.Config
-		(*ListProjectsRequest)(nil),    // 3: swm.plugin.v1.ListProjectsRequest
-		(*LogRequest)(nil),             // 4: swm.plugin.v1.LogRequest
-		(*CallCapabilityRequest)(nil),  // 5: swm.plugin.v1.CallCapabilityRequest
-		(*CallCapabilityResponse)(nil), // 6: swm.plugin.v1.CallCapabilityResponse
-		nil,                            // 7: swm.plugin.v1.LogRequest.FieldsEntry
-		CapabilityType(0),              // 8: swm.plugin.v1.CapabilityType
-		(*Empty)(nil),                  // 9: swm.plugin.v1.Empty
-		(*PathResponse)(nil),           // 10: swm.plugin.v1.PathResponse
-		(*Project)(nil),                // 11: swm.plugin.v1.Project
-		(*Story)(nil),                  // 12: swm.plugin.v1.Story
-	}
-)
-
+var file_swm_plugin_v1_host_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_swm_plugin_v1_host_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_swm_plugin_v1_host_proto_goTypes = []any{
+	(LogLevel)(0),                  // 0: swm.plugin.v1.LogLevel
+	(*GetConfigRequest)(nil),       // 1: swm.plugin.v1.GetConfigRequest
+	(*Config)(nil),                 // 2: swm.plugin.v1.Config
+	(*ListProjectsRequest)(nil),    // 3: swm.plugin.v1.ListProjectsRequest
+	(*LogRequest)(nil),             // 4: swm.plugin.v1.LogRequest
+	(*CallCapabilityRequest)(nil),  // 5: swm.plugin.v1.CallCapabilityRequest
+	(*CallCapabilityResponse)(nil), // 6: swm.plugin.v1.CallCapabilityResponse
+	nil,                            // 7: swm.plugin.v1.LogRequest.FieldsEntry
+	(CapabilityType)(0),            // 8: swm.plugin.v1.CapabilityType
+	(*Empty)(nil),                  // 9: swm.plugin.v1.Empty
+	(*PathResponse)(nil),           // 10: swm.plugin.v1.PathResponse
+	(*Project)(nil),                // 11: swm.plugin.v1.Project
+	(*Story)(nil),                  // 12: swm.plugin.v1.Story
+}
 var file_swm_plugin_v1_host_proto_depIdxs = []int32{
 	0,  // 0: swm.plugin.v1.LogRequest.level:type_name -> swm.plugin.v1.LogLevel
 	7,  // 1: swm.plugin.v1.LogRequest.fields:type_name -> swm.plugin.v1.LogRequest.FieldsEntry

--- a/proto/swm/plugin/v1/host_grpc.pb.go
+++ b/proto/swm/plugin/v1/host_grpc.pb.go
@@ -8,7 +8,6 @@ package pluginv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -145,23 +144,18 @@ type UnimplementedHostServer struct{}
 func (UnimplementedHostServer) GetConfig(context.Context, *GetConfigRequest) (*Config, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetConfig not implemented")
 }
-
 func (UnimplementedHostServer) GetCodeRoot(context.Context, *Empty) (*PathResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetCodeRoot not implemented")
 }
-
 func (UnimplementedHostServer) ListProjects(*ListProjectsRequest, grpc.ServerStreamingServer[Project]) error {
 	return status.Error(codes.Unimplemented, "method ListProjects not implemented")
 }
-
 func (UnimplementedHostServer) GetCurrentStory(context.Context, *Empty) (*Story, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetCurrentStory not implemented")
 }
-
 func (UnimplementedHostServer) Log(context.Context, *LogRequest) (*Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method Log not implemented")
 }
-
 func (UnimplementedHostServer) CallCapability(context.Context, *CallCapabilityRequest) (*CallCapabilityResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CallCapability not implemented")
 }

--- a/proto/swm/plugin/v1/picker.pb.go
+++ b/proto/swm/plugin/v1/picker.pb.go
@@ -7,12 +7,11 @@
 package pluginv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -205,17 +204,14 @@ func file_swm_plugin_v1_picker_proto_rawDescGZIP() []byte {
 	return file_swm_plugin_v1_picker_proto_rawDescData
 }
 
-var (
-	file_swm_plugin_v1_picker_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_swm_plugin_v1_picker_proto_goTypes  = []any{
-		(*PickerInfo)(nil), // 0: swm.plugin.v1.PickerInfo
-		(*PickItem)(nil),   // 1: swm.plugin.v1.PickItem
-		(*PickResult)(nil), // 2: swm.plugin.v1.PickResult
-		(*PluginInfo)(nil), // 3: swm.plugin.v1.PluginInfo
-		(*Empty)(nil),      // 4: swm.plugin.v1.Empty
-	}
-)
-
+var file_swm_plugin_v1_picker_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_swm_plugin_v1_picker_proto_goTypes = []any{
+	(*PickerInfo)(nil), // 0: swm.plugin.v1.PickerInfo
+	(*PickItem)(nil),   // 1: swm.plugin.v1.PickItem
+	(*PickResult)(nil), // 2: swm.plugin.v1.PickResult
+	(*PluginInfo)(nil), // 3: swm.plugin.v1.PluginInfo
+	(*Empty)(nil),      // 4: swm.plugin.v1.Empty
+}
 var file_swm_plugin_v1_picker_proto_depIdxs = []int32{
 	3, // 0: swm.plugin.v1.PickerInfo.plugin_info:type_name -> swm.plugin.v1.PluginInfo
 	4, // 1: swm.plugin.v1.Picker.Info:input_type -> swm.plugin.v1.Empty

--- a/proto/swm/plugin/v1/picker_grpc.pb.go
+++ b/proto/swm/plugin/v1/picker_grpc.pb.go
@@ -8,7 +8,6 @@ package pluginv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -87,7 +86,6 @@ type UnimplementedPickerServer struct{}
 func (UnimplementedPickerServer) Info(context.Context, *Empty) (*PickerInfo, error) {
 	return nil, status.Error(codes.Unimplemented, "method Info not implemented")
 }
-
 func (UnimplementedPickerServer) Pick(grpc.BidiStreamingServer[PickItem, PickResult]) error {
 	return status.Error(codes.Unimplemented, "method Pick not implemented")
 }

--- a/proto/swm/plugin/v1/session.pb.go
+++ b/proto/swm/plugin/v1/session.pb.go
@@ -7,12 +7,11 @@
 package pluginv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -615,26 +614,23 @@ func file_swm_plugin_v1_session_proto_rawDescGZIP() []byte {
 	return file_swm_plugin_v1_session_proto_rawDescData
 }
 
-var (
-	file_swm_plugin_v1_session_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
-	file_swm_plugin_v1_session_proto_goTypes  = []any{
-		(*SessionInfo)(nil),            // 0: swm.plugin.v1.SessionInfo
-		(*Workspace)(nil),              // 1: swm.plugin.v1.Workspace
-		(*PaneGroup)(nil),              // 2: swm.plugin.v1.PaneGroup
-		(*CurrentContextResponse)(nil), // 3: swm.plugin.v1.CurrentContextResponse
-		(*OpenWorkspaceRequest)(nil),   // 4: swm.plugin.v1.OpenWorkspaceRequest
-		(*CloseWorkspaceRequest)(nil),  // 5: swm.plugin.v1.CloseWorkspaceRequest
-		(*OpenPaneGroupRequest)(nil),   // 6: swm.plugin.v1.OpenPaneGroupRequest
-		(*SwitchToRequest)(nil),        // 7: swm.plugin.v1.SwitchToRequest
-		(*SwitchToResponse)(nil),       // 8: swm.plugin.v1.SwitchToResponse
-		nil,                            // 9: swm.plugin.v1.OpenWorkspaceRequest.WorktreePathsEntry
-		(*PluginInfo)(nil),             // 10: swm.plugin.v1.PluginInfo
-		(*ProjectID)(nil),              // 11: swm.plugin.v1.ProjectID
-		(*Empty)(nil),                  // 12: swm.plugin.v1.Empty
-		(*BoolValue)(nil),              // 13: swm.plugin.v1.BoolValue
-	}
-)
-
+var file_swm_plugin_v1_session_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_swm_plugin_v1_session_proto_goTypes = []any{
+	(*SessionInfo)(nil),            // 0: swm.plugin.v1.SessionInfo
+	(*Workspace)(nil),              // 1: swm.plugin.v1.Workspace
+	(*PaneGroup)(nil),              // 2: swm.plugin.v1.PaneGroup
+	(*CurrentContextResponse)(nil), // 3: swm.plugin.v1.CurrentContextResponse
+	(*OpenWorkspaceRequest)(nil),   // 4: swm.plugin.v1.OpenWorkspaceRequest
+	(*CloseWorkspaceRequest)(nil),  // 5: swm.plugin.v1.CloseWorkspaceRequest
+	(*OpenPaneGroupRequest)(nil),   // 6: swm.plugin.v1.OpenPaneGroupRequest
+	(*SwitchToRequest)(nil),        // 7: swm.plugin.v1.SwitchToRequest
+	(*SwitchToResponse)(nil),       // 8: swm.plugin.v1.SwitchToResponse
+	nil,                            // 9: swm.plugin.v1.OpenWorkspaceRequest.WorktreePathsEntry
+	(*PluginInfo)(nil),             // 10: swm.plugin.v1.PluginInfo
+	(*ProjectID)(nil),              // 11: swm.plugin.v1.ProjectID
+	(*Empty)(nil),                  // 12: swm.plugin.v1.Empty
+	(*BoolValue)(nil),              // 13: swm.plugin.v1.BoolValue
+}
 var file_swm_plugin_v1_session_proto_depIdxs = []int32{
 	10, // 0: swm.plugin.v1.SessionInfo.plugin_info:type_name -> swm.plugin.v1.PluginInfo
 	11, // 1: swm.plugin.v1.PaneGroup.project_id:type_name -> swm.plugin.v1.ProjectID

--- a/proto/swm/plugin/v1/session_grpc.pb.go
+++ b/proto/swm/plugin/v1/session_grpc.pb.go
@@ -8,7 +8,6 @@ package pluginv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -169,31 +168,24 @@ type UnimplementedSessionServer struct{}
 func (UnimplementedSessionServer) Info(context.Context, *Empty) (*SessionInfo, error) {
 	return nil, status.Error(codes.Unimplemented, "method Info not implemented")
 }
-
 func (UnimplementedSessionServer) OpenWorkspace(context.Context, *OpenWorkspaceRequest) (*Workspace, error) {
 	return nil, status.Error(codes.Unimplemented, "method OpenWorkspace not implemented")
 }
-
 func (UnimplementedSessionServer) CloseWorkspace(context.Context, *CloseWorkspaceRequest) (*Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method CloseWorkspace not implemented")
 }
-
 func (UnimplementedSessionServer) ListWorkspaces(*Empty, grpc.ServerStreamingServer[Workspace]) error {
 	return status.Error(codes.Unimplemented, "method ListWorkspaces not implemented")
 }
-
 func (UnimplementedSessionServer) OpenPaneGroup(context.Context, *OpenPaneGroupRequest) (*PaneGroup, error) {
 	return nil, status.Error(codes.Unimplemented, "method OpenPaneGroup not implemented")
 }
-
 func (UnimplementedSessionServer) SwitchTo(context.Context, *SwitchToRequest) (*SwitchToResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SwitchTo not implemented")
 }
-
 func (UnimplementedSessionServer) IsInsideWorkspace(context.Context, *Empty) (*BoolValue, error) {
 	return nil, status.Error(codes.Unimplemented, "method IsInsideWorkspace not implemented")
 }
-
 func (UnimplementedSessionServer) CurrentContext(context.Context, *Empty) (*CurrentContextResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CurrentContext not implemented")
 }

--- a/proto/swm/plugin/v1/vcs.pb.go
+++ b/proto/swm/plugin/v1/vcs.pb.go
@@ -7,12 +7,11 @@
 package pluginv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -581,24 +580,21 @@ func file_swm_plugin_v1_vcs_proto_rawDescGZIP() []byte {
 	return file_swm_plugin_v1_vcs_proto_rawDescData
 }
 
-var (
-	file_swm_plugin_v1_vcs_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
-	file_swm_plugin_v1_vcs_proto_goTypes  = []any{
-		(*VCSInfo)(nil),               // 0: swm.plugin.v1.VCSInfo
-		(*CloneRequest)(nil),          // 1: swm.plugin.v1.CloneRequest
-		(*CloneResponse)(nil),         // 2: swm.plugin.v1.CloneResponse
-		(*ParseRemoteURLRequest)(nil), // 3: swm.plugin.v1.ParseRemoteURLRequest
-		(*CreateWorktreeRequest)(nil), // 4: swm.plugin.v1.CreateWorktreeRequest
-		(*RemoveWorktreeRequest)(nil), // 5: swm.plugin.v1.RemoveWorktreeRequest
-		(*DetectAtPathRequest)(nil),   // 6: swm.plugin.v1.DetectAtPathRequest
-		(*ListBranchesRequest)(nil),   // 7: swm.plugin.v1.ListBranchesRequest
-		(*Branch)(nil),                // 8: swm.plugin.v1.Branch
-		(*PluginInfo)(nil),            // 9: swm.plugin.v1.PluginInfo
-		(*ProjectID)(nil),             // 10: swm.plugin.v1.ProjectID
-		(*Empty)(nil),                 // 11: swm.plugin.v1.Empty
-	}
-)
-
+var file_swm_plugin_v1_vcs_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_swm_plugin_v1_vcs_proto_goTypes = []any{
+	(*VCSInfo)(nil),               // 0: swm.plugin.v1.VCSInfo
+	(*CloneRequest)(nil),          // 1: swm.plugin.v1.CloneRequest
+	(*CloneResponse)(nil),         // 2: swm.plugin.v1.CloneResponse
+	(*ParseRemoteURLRequest)(nil), // 3: swm.plugin.v1.ParseRemoteURLRequest
+	(*CreateWorktreeRequest)(nil), // 4: swm.plugin.v1.CreateWorktreeRequest
+	(*RemoveWorktreeRequest)(nil), // 5: swm.plugin.v1.RemoveWorktreeRequest
+	(*DetectAtPathRequest)(nil),   // 6: swm.plugin.v1.DetectAtPathRequest
+	(*ListBranchesRequest)(nil),   // 7: swm.plugin.v1.ListBranchesRequest
+	(*Branch)(nil),                // 8: swm.plugin.v1.Branch
+	(*PluginInfo)(nil),            // 9: swm.plugin.v1.PluginInfo
+	(*ProjectID)(nil),             // 10: swm.plugin.v1.ProjectID
+	(*Empty)(nil),                 // 11: swm.plugin.v1.Empty
+}
 var file_swm_plugin_v1_vcs_proto_depIdxs = []int32{
 	9,  // 0: swm.plugin.v1.VCSInfo.plugin_info:type_name -> swm.plugin.v1.PluginInfo
 	10, // 1: swm.plugin.v1.CloneResponse.project_id:type_name -> swm.plugin.v1.ProjectID

--- a/proto/swm/plugin/v1/vcs_grpc.pb.go
+++ b/proto/swm/plugin/v1/vcs_grpc.pb.go
@@ -8,7 +8,6 @@ package pluginv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -156,27 +155,21 @@ type UnimplementedVCSServer struct{}
 func (UnimplementedVCSServer) Info(context.Context, *Empty) (*VCSInfo, error) {
 	return nil, status.Error(codes.Unimplemented, "method Info not implemented")
 }
-
 func (UnimplementedVCSServer) Clone(context.Context, *CloneRequest) (*CloneResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Clone not implemented")
 }
-
 func (UnimplementedVCSServer) ParseRemoteURL(context.Context, *ParseRemoteURLRequest) (*ProjectID, error) {
 	return nil, status.Error(codes.Unimplemented, "method ParseRemoteURL not implemented")
 }
-
 func (UnimplementedVCSServer) CreateWorktree(context.Context, *CreateWorktreeRequest) (*Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateWorktree not implemented")
 }
-
 func (UnimplementedVCSServer) RemoveWorktree(context.Context, *RemoveWorktreeRequest) (*Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveWorktree not implemented")
 }
-
 func (UnimplementedVCSServer) DetectProjectAtPath(context.Context, *DetectAtPathRequest) (*ProjectID, error) {
 	return nil, status.Error(codes.Unimplemented, "method DetectProjectAtPath not implemented")
 }
-
 func (UnimplementedVCSServer) ListBranches(*ListBranchesRequest, grpc.ServerStreamingServer[Branch]) error {
 	return status.Error(codes.Unimplemented, "method ListBranches not implemented")
 }

--- a/scripts/update-nix-vendor-hashes.py
+++ b/scripts/update-nix-vendor-hashes.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Update vendorHash in nix/packages/*/default.nix for all Go packages.
+
+Runs all packages in parallel. For each package:
+  1. Try `nix build .#PKG.goModules` — fails immediately if hash is wrong.
+  2. If it succeeds (possibly from cache), try `--rebuild` to force
+     recomputation against the current source.
+  3. If either attempt fails, extract the correct hash from the error output
+     and patch the vendorHash line in the corresponding nix file.
+"""
+
+import re
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Plugins first — they share proto/sdk/go deps so Nix can reuse fetched
+# store paths across them. swm last since it has a larger fileset.
+PACKAGES = [
+    "swm-plugin-forge-github",
+    "swm-plugin-picker-fzf",
+    "swm-plugin-session-tmux",
+    "swm-plugin-vcs-git",
+    "swm",
+]
+
+
+def _nix_build(pkg: str, extra_args: list[str]) -> tuple[int, str]:
+    """Run `nix build .#PKG.goModules [extra_args]`; return (exit_code, stderr)."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=f".{pkg}.log", delete=False
+    ) as f:
+        logpath = Path(f.name)
+    try:
+        with logpath.open("w") as logfile:
+            result = subprocess.run(
+                ["nix", "build", "--print-build-logs", f".#{pkg}.goModules"]
+                + extra_args,
+                cwd=REPO_ROOT,
+                stdout=subprocess.DEVNULL,
+                stderr=logfile,
+            )
+        return result.returncode, logpath.read_text()
+    finally:
+        logpath.unlink(missing_ok=True)
+
+
+def _extract_hash(log: str) -> str | None:
+    m = re.search(r"got:\s+(\S+)", log)
+    return m.group(1) if m else None
+
+
+def update_package(pkg: str) -> tuple[str, bool, str]:
+    """
+    Ensure the vendorHash for pkg is current.
+
+    Returns (pkg, was_updated, detail_message).
+    Raises RuntimeError on unrecoverable failure.
+    """
+    nix_file = REPO_ROOT / "nix" / "packages" / pkg / "default.nix"
+
+    ret, log = _nix_build(pkg, [])
+
+    if ret == 0:
+        # Build succeeded but may have hit the Nix store cache.  Force a
+        # rebuild so the hash is validated against the current source tree.
+        ret, log = _nix_build(pkg, ["--rebuild"])
+
+    if ret == 0:
+        return pkg, False, "up to date"
+
+    new_hash = _extract_hash(log)
+    if not new_hash:
+        raise RuntimeError(
+            f"nix build failed for {pkg} but no 'got:' hash found in output.\n"
+            f"--- stderr ---\n{log}"
+        )
+
+    content = nix_file.read_text()
+    patched = re.sub(
+        r'vendorHash\s*=\s*"[^"]*";',
+        f'vendorHash = "{new_hash}";',
+        content,
+    )
+    if patched == content:
+        raise RuntimeError(
+            f"vendorHash pattern not found (or already matches) in {nix_file} "
+            f"despite build failure — manual inspection required."
+        )
+
+    nix_file.write_text(patched)
+    return pkg, True, new_hash
+
+
+def main() -> int:
+    print(f"Updating vendorHashes for {len(PACKAGES)} packages in parallel…", flush=True)
+
+    failed: list[str] = []
+    with ThreadPoolExecutor(max_workers=len(PACKAGES)) as pool:
+        futures = {pool.submit(update_package, pkg): pkg for pkg in PACKAGES}
+        for fut in as_completed(futures):
+            pkg = futures[fut]
+            try:
+                _, changed, info = fut.result()
+                tag = "↻" if changed else "✓"
+                print(f"  {tag}  {pkg}: {info}", flush=True)
+            except Exception as exc:  # noqa: BLE001
+                print(f"  ✗  {pkg}: FAILED — {exc}", file=sys.stderr, flush=True)
+                failed.append(pkg)
+
+    if failed:
+        print(f"\nFailed packages: {', '.join(sorted(failed))}", file=sys.stderr)
+        return 1
+
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update-nix-vendor-hashes.py
+++ b/scripts/update-nix-vendor-hashes.py
@@ -13,7 +13,6 @@ Runs all packages in parallel. For each package:
 import re
 import subprocess
 import sys
-import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -32,22 +31,15 @@ PACKAGES = [
 
 def _nix_build(pkg: str, extra_args: list[str]) -> tuple[int, str]:
     """Run `nix build .#PKG.goModules [extra_args]`; return (exit_code, stderr)."""
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=f".{pkg}.log", delete=False
-    ) as f:
-        logpath = Path(f.name)
-    try:
-        with logpath.open("w") as logfile:
-            result = subprocess.run(
-                ["nix", "build", "--print-build-logs", f".#{pkg}.goModules"]
-                + extra_args,
-                cwd=REPO_ROOT,
-                stdout=subprocess.DEVNULL,
-                stderr=logfile,
-            )
-        return result.returncode, logpath.read_text()
-    finally:
-        logpath.unlink(missing_ok=True)
+    result = subprocess.run(
+        ["nix", "build", "--print-build-logs", f".#{pkg}.goModules"] + extra_args,
+        cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    return result.returncode, result.stderr
 
 
 def _extract_hash(log: str) -> str | None:


### PR DESCRIPTION
Adds `task update-nix-vendor-hashes` which mirrors the generate job in
CI: for each package it builds .#${pkg}.goModules, extracts the correct
hash from the error output when there is a mismatch, and patches the
vendorHash in-place. Hashes that are already correct are skipped.

Adds a Claude rule that fires this task whenever any file under proto/
is modified, so the hashes are updated proactively instead of being
caught as a flake check failure.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>