### PR TITLE
fix: default story opens canonical repo path

### DIFF
--- a/cmd/swm/internal/cli/clone_test.go
+++ b/cmd/swm/internal/cli/clone_test.go
@@ -31,7 +31,7 @@ func TestCloneCmd_Success(t *testing.T) {
 	t.Parallel()
 
 	codeRoot := t.TempDir()
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, "_default")
 	vcs := &stubVCS{}
 	mgr := &stubMgr{vcs: vcs}
 
@@ -53,7 +53,7 @@ func TestCloneCmd_AlreadyCloned(t *testing.T) {
 	canonical := filepath.Join(codeRoot, "repositories", "github.com", "kalbasit", "swm")
 	require.NoError(t, os.MkdirAll(filepath.Join(canonical, ".git"), 0o750))
 
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, "_default")
 	vcs := &stubVCS{}
 	mgr := &stubMgr{vcs: vcs}
 
@@ -68,7 +68,7 @@ func TestCloneCmd_CloneError(t *testing.T) {
 	t.Parallel()
 
 	codeRoot := t.TempDir()
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, "_default")
 	vcs := &stubVCS{cloneErr: errNetworkError}
 	mgr := &stubMgr{vcs: vcs}
 

--- a/cmd/swm/internal/cli/pr/create_test.go
+++ b/cmd/swm/internal/cli/pr/create_test.go
@@ -78,7 +78,7 @@ var _ pluginv1.ForgeClient = (*stubForgeClientCreate)(nil)
 //nolint:paralleltest // t.Chdir changes process-wide CWD; not safe to run in parallel
 func TestPRCreate_Success(t *testing.T) {
 	codeRoot := t.TempDir()
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	repoDir := filepath.Join(codeRoot, "repositories", testGitHubHost, "o", "r")
 	require.NoError(t, os.MkdirAll(repoDir, 0o750))
@@ -106,7 +106,7 @@ func TestPRCreate_Success(t *testing.T) {
 //nolint:paralleltest // t.Chdir changes process-wide CWD; not safe to run in parallel
 func TestPRCreate_Draft(t *testing.T) {
 	codeRoot := t.TempDir()
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	repoDir := filepath.Join(codeRoot, "repositories", testGitHubHost, "o", "r")
 	require.NoError(t, os.MkdirAll(repoDir, 0o750))
@@ -134,7 +134,7 @@ func TestPRCreate_Draft(t *testing.T) {
 //nolint:paralleltest // t.Chdir changes process-wide CWD; not safe to run in parallel
 func TestPRCreate_NoForgeForHost(t *testing.T) {
 	codeRoot := t.TempDir()
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	repoDir := filepath.Join(codeRoot, "repositories", "gitlab.com", "o", "r")
 	require.NoError(t, os.MkdirAll(repoDir, 0o750))
@@ -160,7 +160,7 @@ func TestPRCreate_MissingTitle(t *testing.T) {
 	t.Parallel()
 
 	codeRoot := t.TempDir()
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 	mgr := &stubForgeManager{}
 	store := &stubStore{story: &coreStory.Story{Name: testDefaultStory}}
 	cfg := &config.Config{DefaultStory: testDefaultStory}
@@ -175,7 +175,7 @@ func TestPRCreate_MissingTitle(t *testing.T) {
 //nolint:paralleltest // t.Chdir changes process-wide CWD; not safe to run in parallel
 func TestPRCreate_StoryDerivedHeadBranch(t *testing.T) {
 	codeRoot := t.TempDir()
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	repoDir := filepath.Join(codeRoot, "repositories", testGitHubHost, "o", "r")
 	require.NoError(t, os.MkdirAll(repoDir, 0o750))
@@ -207,7 +207,7 @@ func TestPRCreate_StoryDerivedHeadBranch(t *testing.T) {
 //nolint:paralleltest // t.Chdir changes process-wide CWD; not safe to run in parallel
 func TestPRCreate_ExplicitHeadOverridesStory(t *testing.T) {
 	codeRoot := t.TempDir()
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	repoDir := filepath.Join(codeRoot, "repositories", testGitHubHost, "o", "r")
 	require.NoError(t, os.MkdirAll(repoDir, 0o750))

--- a/cmd/swm/internal/cli/story/remove_test.go
+++ b/cmd/swm/internal/cli/story/remove_test.go
@@ -20,7 +20,7 @@ func TestRemoveCmd_Force_NoProjects(t *testing.T) {
 
 	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
 	mgr := &stubManager{}
-	resolver := layout.NewResolver("/code")
+	resolver := layout.NewResolver("/code", "_default")
 
 	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName, testForceFlag})
@@ -34,7 +34,7 @@ func TestRemoveCmd_NotFound(t *testing.T) {
 
 	store := &stubStore{getErr: coreStory.ErrStoryNotFound}
 	mgr := &stubManager{}
-	resolver := layout.NewResolver("/code")
+	resolver := layout.NewResolver("/code", "_default")
 
 	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{"nonexistent", testForceFlag})
@@ -54,7 +54,7 @@ func TestRemoveCmd_Force_WithProjects(t *testing.T) {
 	store := &stubStore{getStory: st}
 	vcs := &stubVCSClient{}
 	mgr := &stubManager{vcs: vcs}
-	resolver := layout.NewResolver("/code")
+	resolver := layout.NewResolver("/code", "_default")
 
 	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName, testForceFlag})
@@ -75,7 +75,7 @@ func TestRemoveCmd_Confirm_Yes_Accepted(t *testing.T) {
 	}
 	store := &stubStore{getStory: st}
 	mgr := &stubManager{vcs: &stubVCSClient{}}
-	resolver := layout.NewResolver("/code")
+	resolver := layout.NewResolver("/code", "_default")
 
 	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
 	cmd.SetIn(strings.NewReader("yes\n"))
@@ -96,7 +96,7 @@ func TestRemoveCmd_Confirm_ScanError_Aborts(t *testing.T) {
 	}
 	store := &stubStore{getStory: st}
 	mgr := &stubManager{vcs: &stubVCSClient{}}
-	resolver := layout.NewResolver("/code")
+	resolver := layout.NewResolver("/code", "_default")
 
 	var out bytes.Buffer
 
@@ -123,7 +123,7 @@ func TestRemoveCmd_WorktreeHookWorkDirs(t *testing.T) {
 	store := &stubStore{getStory: st}
 	vcs := &stubVCSClient{}
 	mgr := &stubManager{vcs: vcs}
-	resolver := layout.NewResolver("/code")
+	resolver := layout.NewResolver("/code", "_default")
 
 	capturedCfgs := make(map[string]hookexec.RunConfig)
 
@@ -157,7 +157,7 @@ func TestRemoveCmd_HooksCalledInOrder(t *testing.T) {
 	store := &stubStore{getStory: st}
 	vcs := &stubVCSClient{}
 	mgr := &stubManager{vcs: vcs}
-	resolver := layout.NewResolver("/code")
+	resolver := layout.NewResolver("/code", "_default")
 
 	var called []string
 

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -49,7 +49,7 @@ func TestOpenCmd_WithPositionalArg(t *testing.T) {
 	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
 	sess := &stubSess{}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -65,7 +65,7 @@ func TestOpenCmd_PositionalArgOverridesEnv(t *testing.T) {
 	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
 	sess := &stubSess{}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -81,7 +81,7 @@ func TestOpenCmd_DefaultStory(t *testing.T) {
 	store := &stubStore{getStory: &coreStory.Story{Name: testDefaultStory}}
 	sess := &stubSess{}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{})
@@ -96,7 +96,7 @@ func TestOpenCmd_StoryNotFound(t *testing.T) {
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
 	store := &stubStore{getErr: coreStory.ErrStoryNotFound}
 	mgr := &stubMgr{}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{"nonexistent"})
@@ -111,7 +111,7 @@ func TestOpenCmd_NoProjects(t *testing.T) {
 	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName, Projects: nil}}
 	sess := &stubSess{}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -136,7 +136,7 @@ func TestOpenCmd_WithPicker_ProjectAlreadyAttached(t *testing.T) {
 	vcs := &stubVCS{}
 	picker := &stubPickerClient{selectedKey: selectedKey}
 	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -166,7 +166,7 @@ func TestOpenCmd_WithPicker_ProjectNotAttached(t *testing.T) {
 	vcs := &stubVCS{}
 	picker := &stubPickerClient{selectedKey: selectedKey}
 	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -197,7 +197,7 @@ func TestOpenCmd_WithPicker_PreWorktreeCreateHookAborts(t *testing.T) {
 	vcs := &stubVCS{}
 	picker := &stubPickerClient{selectedKey: selectedKey}
 	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	hooks := hookexec.RunnerFunc(func(_ context.Context, rc hookexec.RunConfig) error {
 		if rc.Event == eventPreWorktreeCreate {
@@ -230,7 +230,7 @@ func TestOpenCmd_WithPicker_PostWorktreeCreateHookFailureContinues(t *testing.T)
 	vcs := &stubVCS{}
 	picker := &stubPickerClient{selectedKey: selectedKey}
 	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	var postHookCalled bool
 
@@ -271,7 +271,7 @@ func TestOpenCmd_WithPicker_PostWorktreeCreateHookReceivesContext(t *testing.T) 
 	vcs := &stubVCS{}
 	picker := &stubPickerClient{selectedKey: selectedKey}
 	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	var capturedCfg hookexec.RunConfig
 
@@ -308,7 +308,7 @@ func TestOpenCmd_WithPicker_PostWorktreeCreateHookWorkDir(t *testing.T) {
 	vcs := &stubVCS{}
 	picker := &stubPickerClient{selectedKey: selectedKey}
 	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	var capturedCfgs []hookexec.RunConfig
 
@@ -343,7 +343,7 @@ func TestOpenCmd_WithPicker_Cancelled(t *testing.T) {
 	// Picker returns Aborted (user pressed Escape).
 	picker := &stubPickerClient{cancelOnRecv: true}
 	mgr := &stubMgr{sess: sess, vcs: vcs, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -367,7 +367,7 @@ func TestOpenCmd_WithPicker_FailedPrecondition_FallsBack(t *testing.T) {
 	// Picker returns FailedPrecondition (e.g. no TTY available).
 	picker := &stubPickerClient{pickErr: status.Error(codes.FailedPrecondition, "no tty")}
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -398,7 +398,7 @@ func TestOpenCmd_WithPicker_RecvFailedPrecondition_FallsBack(t *testing.T) {
 	// Picker stream opens fine but Recv() returns FailedPrecondition (no TTY).
 	picker := &stubPickerClient{recvErr: status.Error(codes.FailedPrecondition, "no tty")}
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -416,7 +416,7 @@ func TestOpenCmd_WithPicker_InvalidKey_EmptyHost(t *testing.T) {
 	sess := &stubSess{}
 	picker := &stubPickerClient{selectedKey: "/seg1"} // empty host
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -434,7 +434,7 @@ func TestOpenCmd_WithPicker_InvalidKey_EmptySegments(t *testing.T) {
 	sess := &stubSess{}
 	picker := &stubPickerClient{selectedKey: "github.com/"} // empty segments
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -452,7 +452,7 @@ func TestOpenCmd_WithPicker_InvalidKey_EmptySegmentPart(t *testing.T) {
 	sess := &stubSess{}
 	picker := &stubPickerClient{selectedKey: "github.com/seg1//seg3"} // empty middle segment
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -488,7 +488,7 @@ func TestOpenCmd_WithPicker_ExecArgvIsExeced(t *testing.T) {
 	sess := &stubSess{switchToExecArgv: wantArgv}
 	picker := &stubPickerClient{selectedKey: selectedKey}
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop, workspace.WithExecFunc(testExec))
 	cmd.SetArgs([]string{testStoryName})
@@ -509,7 +509,7 @@ func TestOpenCmd_NoPicker_FallsBackToPhase1(t *testing.T) {
 	}}
 	sess := &stubSess{}
 	mgr := &stubMgr{sess: sess} // no picker configured
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName})
@@ -544,7 +544,7 @@ func TestOpenCmd_NoPicker_ExecArgvIsExeced(t *testing.T) {
 
 	sess := &stubSess{switchToExecArgv: wantArgv}
 	mgr := &stubMgr{sess: sess} // no picker configured
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop, workspace.WithExecFunc(testExec))
 	cmd.SetArgs([]string{testStoryName})
@@ -586,7 +586,7 @@ func TestOpenCmd_NoArgNoEnv_StoryPickerShown(t *testing.T) {
 		},
 	}
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
@@ -612,7 +612,7 @@ func TestOpenCmd_PositionalArg_StoryPickerSkipped(t *testing.T) {
 	// Picker is present — but should only be called for project selection, not story selection.
 	picker := &stubPickerClient{cancelOnRecv: true} // abort project picker
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
@@ -633,7 +633,7 @@ func TestOpenCmd_SWMStoryEnv_StoryPickerSkipped(t *testing.T) {
 	sess := &stubSess{}
 	picker := &stubPickerClient{cancelOnRecv: true}
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
@@ -656,7 +656,7 @@ func TestOpenCmd_StoryPickerAborted_ExitsClean(t *testing.T) {
 	sess := &stubSess{}
 	picker := &stubPickerClient{cancelOnRecv: true} // story picker aborted immediately
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
@@ -681,7 +681,7 @@ func TestOpenCmd_StoryPickerFailedPrecondition_FallsBackToDefault(t *testing.T) 
 	// Story picker returns FailedPrecondition (no TTY).
 	picker := &stubPickerClient{pickErr: status.Error(codes.FailedPrecondition, "no tty")}
 	mgr := &stubMgr{sess: sess, picker: picker}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
@@ -723,7 +723,7 @@ func TestOpenCmd_KillPane_TmuxPaneSet_PopulatesOriginFields(t *testing.T) {
 		currentContextResp: &pluginv1.CurrentContextResponse{PaneGroupId: "some-other-pane-group"},
 	}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName, flagKillPane})
@@ -748,7 +748,7 @@ func TestOpenCmd_KillPane_TmuxPaneUnset_OmitsOriginFields(t *testing.T) {
 	}}
 	sess := &stubSess{}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName, flagKillPane})
@@ -777,7 +777,7 @@ func TestOpenCmd_KillPane_CurrentContextFails_StillPopulatesOriginFields(t *test
 		currentContextErr: errFakeHook,
 	}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName, flagKillPane})
@@ -808,7 +808,7 @@ func TestOpenCmd_KillPane_AlreadyInTarget_OmitsOriginFields(t *testing.T) {
 		currentContextResp: &pluginv1.CurrentContextResponse{PaneGroupId: testTargetPaneGroupID},
 	}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName, flagKillPane})
@@ -837,7 +837,7 @@ func TestOpenCmd_KillPane_SameWorkspaceDifferentPaneGroup_PopulatesOriginFields(
 		currentContextResp: &pluginv1.CurrentContextResponse{PaneGroupId: "other-project"},
 	}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName, flagKillPane})
@@ -867,7 +867,7 @@ func TestOpenCmd_KillPane_ZellijPaneSet_PopulatesOriginFields(t *testing.T) {
 		currentContextResp: &pluginv1.CurrentContextResponse{PaneGroupId: "some-other-pane-group"},
 	}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName, flagKillPane})
@@ -890,7 +890,7 @@ func TestOpenCmd_NoKillPane_OmitsOriginFields(t *testing.T) {
 	}}
 	sess := &stubSess{}
 	mgr := &stubMgr{sess: sess}
-	resolver := layout.NewResolver(testCodeRoot)
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
 	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
 	cmd.SetArgs([]string{testStoryName}) // no --kill-pane

--- a/cmd/swm/internal/core/layout/layout.go
+++ b/cmd/swm/internal/core/layout/layout.go
@@ -62,6 +62,10 @@ func (r *Resolver) ProjectIDFromPath(path string) *pluginv1.ProjectID {
 // For the default story the project lives at the canonical repositories/ path,
 // not inside a git worktree under stories/.
 func (r *Resolver) WorktreePath(storyName string, id *pluginv1.ProjectID) string {
+	if id == nil {
+		return ""
+	}
+
 	if storyName == r.defaultStoryName {
 		return r.CanonicalPath(id)
 	}

--- a/cmd/swm/internal/core/layout/layout.go
+++ b/cmd/swm/internal/core/layout/layout.go
@@ -12,12 +12,15 @@ import (
 
 // Resolver computes canonical clone and worktree paths from a code root.
 type Resolver struct {
-	codeRoot string
+	codeRoot         string
+	defaultStoryName string
 }
 
 // NewResolver returns a Resolver anchored at the given code root directory.
-func NewResolver(codeRoot string) *Resolver {
-	return &Resolver{codeRoot: codeRoot}
+// defaultStoryName is the story that maps to the canonical repositories/ path
+// rather than a git worktree (typically "_default").
+func NewResolver(codeRoot, defaultStoryName string) *Resolver {
+	return &Resolver{codeRoot: codeRoot, defaultStoryName: defaultStoryName}
 }
 
 // CanonicalPath returns <code_root>/repositories/<host>/<seg1>/.../<segN>.
@@ -55,8 +58,14 @@ func (r *Resolver) ProjectIDFromPath(path string) *pluginv1.ProjectID {
 	}
 }
 
-// WorktreePath returns <code_root>/stories/<storyName>/<host>/<seg1>/.../<segN>.
+// WorktreePath returns the filesystem path for a project within a story.
+// For the default story the project lives at the canonical repositories/ path,
+// not inside a git worktree under stories/.
 func (r *Resolver) WorktreePath(storyName string, id *pluginv1.ProjectID) string {
+	if storyName == r.defaultStoryName {
+		return r.CanonicalPath(id)
+	}
+
 	parts := append([]string{r.codeRoot, "stories", storyName, id.Host}, id.Segments...)
 
 	return filepath.Join(parts...)

--- a/cmd/swm/internal/core/layout/layout_test.go
+++ b/cmd/swm/internal/core/layout/layout_test.go
@@ -17,7 +17,7 @@ func TestCanonicalPath(t *testing.T) {
 	gitlabDeep := &pluginv1.ProjectID{Host: "gitlab.com", Segments: []string{"foo", "bar", "baz"}}
 	keybaseProject := &pluginv1.ProjectID{Host: "keybase", Segments: []string{"team", "stowix.infra", "fly-secrets"}}
 
-	r := layout.NewResolver("/home/user/code")
+	r := layout.NewResolver("/home/user/code", "_default")
 
 	tests := []struct {
 		name     string
@@ -55,7 +55,7 @@ func TestWorktreePath(t *testing.T) {
 	githubSWM := &pluginv1.ProjectID{Host: "github.com", Segments: []string{"kalbasit", "swm"}}
 	gitlabDeep := &pluginv1.ProjectID{Host: "gitlab.com", Segments: []string{"foo", "bar", "baz"}}
 
-	r := layout.NewResolver("/home/user/code")
+	r := layout.NewResolver("/home/user/code", "_default")
 
 	tests := []struct {
 		name      string
@@ -74,6 +74,12 @@ func TestWorktreePath(t *testing.T) {
 			storyName: "fix-y",
 			project:   gitlabDeep,
 			expected:  "/home/user/code/stories/fix-y/gitlab.com/foo/bar/baz",
+		},
+		{
+			name:      "default story uses canonical path",
+			storyName: "_default",
+			project:   githubSWM,
+			expected:  "/home/user/code/repositories/github.com/kalbasit/swm",
 		},
 	}
 

--- a/cmd/swm/internal/core/layout/layout_test.go
+++ b/cmd/swm/internal/core/layout/layout_test.go
@@ -81,6 +81,12 @@ func TestWorktreePath(t *testing.T) {
 			project:   githubSWM,
 			expected:  "/home/user/code/repositories/github.com/kalbasit/swm",
 		},
+		{
+			name:      "nil project id returns empty string",
+			storyName: "feat-x",
+			project:   nil,
+			expected:  "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/swm/internal/hostsvc/server_test.go
+++ b/cmd/swm/internal/hostsvc/server_test.go
@@ -25,7 +25,7 @@ func setupServer(t *testing.T, cfg *config.Config, codeRoot string) pluginv1.Hos
 
 	storiesDir := t.TempDir()
 	store := story.NewJSONStore(storiesDir)
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, cfg.DefaultStory)
 
 	srv, err := hostsvc.NewServer(cfg, resolver, store)
 	require.NoError(t, err)
@@ -45,10 +45,10 @@ func setupServer(t *testing.T, cfg *config.Config, codeRoot string) pluginv1.Hos
 func TestNewServer_SocketInXDGRuntimeDir(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Config{CodeRoot: t.TempDir()}
+	cfg := &config.Config{CodeRoot: t.TempDir(), DefaultStory: "_default"}
 	storiesDir := t.TempDir()
 	store := story.NewJSONStore(storiesDir)
-	resolver := layout.NewResolver(cfg.CodeRoot)
+	resolver := layout.NewResolver(cfg.CodeRoot, cfg.DefaultStory)
 
 	srv, err := hostsvc.NewServer(cfg, resolver, store)
 	require.NoError(t, err)

--- a/cmd/swm/main.go
+++ b/cmd/swm/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	storiesDir := filepath.Join(xdg.DataHome, "swm", "stories")
 	store := story.NewJSONStore(storiesDir)
-	resolver := layout.NewResolver(cfg.CodeRoot)
+	resolver := layout.NewResolver(cfg.CodeRoot, cfg.DefaultStory)
 
 	hostSrv, err := hostsvc.NewServer(cfg, resolver, store)
 	if err != nil {

--- a/cmd/swm/tests/integration/integration_test.go
+++ b/cmd/swm/tests/integration/integration_test.go
@@ -61,7 +61,7 @@ func setupEnv(t *testing.T) (*config.Config, *layout.Resolver, story.Store, *plu
 	}
 
 	store := story.NewJSONStore(storiesDir)
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	srv, err := hostsvc.NewServer(cfg, resolver, store)
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestWorkspaceOpenWithPicker(t *testing.T) {
 	}
 
 	store := story.NewJSONStore(storiesDir)
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	srv, err := hostsvc.NewServer(cfg, resolver, store)
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func setupPickerEnv(t *testing.T) (*config.Config, *layout.Resolver, story.Store
 	}
 
 	st := story.NewJSONStore(storiesDir)
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	srv, err := hostsvc.NewServer(cfg, resolver, st)
 	require.NoError(t, err)
@@ -525,7 +525,7 @@ func TestPRListAndCreate(t *testing.T) {
 	}
 
 	st := story.NewJSONStore(storiesDir)
-	resolver := layout.NewResolver(codeRoot)
+	resolver := layout.NewResolver(codeRoot, testDefaultStory)
 
 	srv, err := hostsvc.NewServer(cfg, resolver, st)
 	require.NoError(t, err)


### PR DESCRIPTION
The _default story is the main clone at repositories/, not a git
worktree under stories/. WorktreePath was always building the
stories/ path, so picking _default in workspace open created a
new worktree instead of opening the existing canonical checkout.

Fix: Resolver now takes a defaultStoryName parameter. WorktreePath
returns CanonicalPath when storyName matches, and all callers pass
cfg.DefaultStory (or "_default" in tests).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>