### PR TITLE
feat: integrate laio in session-tmux plugin

### DIFF
--- a/openspec/changes/archive/2026-05-18-laio-plugin-support/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-laio-plugin-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-18-laio-plugin-support/design.md
+++ b/openspec/changes/archive/2026-05-18-laio-plugin-support/design.md
@@ -1,0 +1,85 @@
+## Context
+
+swm's `session-tmux` plugin creates per-story tmux servers at `$XDG_RUNTIME_DIR/swm/tmux/<story>.sock`. When a user configures `pane_group_command`, swm runs that command as the initial shell process of the pane-group's tmux session (via `tmux -S <sock> new-session -d -s <name> -c <path> COMMAND`). laio currently issues all tmux commands without `-S`, so any sessions or windows it creates land on the default tmux server rather than swm's story socket — they are invisible to swm.
+
+An additional correctness bug: the existing spec scenario and test fixture reference `--config`, a flag that does not exist in laio (the correct flag is `--file`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- laio sessions and windows land on the swm-managed per-story socket.
+- Users can write `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"` and have it work end-to-end.
+- Correct the broken `--config` flag in the spec and test fixture.
+
+**Non-Goals:**
+- Zellij socket support in laio.
+- Changing laio's default config-discovery when `--file` is omitted.
+- Modifying how swm names pane groups.
+
+## Decisions
+
+### D1: laio interface — `--socket` flag + `LAIO_TMUX_SOCKET` env var, flag takes priority
+
+A `--socket` flag on `laio start` accepts an absolute path to an external tmux socket. If absent, laio falls back to `LAIO_TMUX_SOCKET`. When either is set, laio prepends `-S <path>` to every tmux command it issues.
+
+**Why over flag-only**: An env var lets wrapper scripts and hooks call laio without threading the socket argument through command templates explicitly. **Why over env-only**: An explicit flag is unambiguous when scripting and is self-documenting in `pane_group_command`.
+
+### D2: laio in-session mode — configure current session when already inside tmux
+
+When `--socket` is provided (or `LAIO_TMUX_SOCKET` set) and laio detects it is running inside a tmux pane (`is_inside_session()` = true), it skips `new-session` and instead configures the current session's windows and panes. All configured windows are created via `new-window` (`force_new_windows = true`); after all commands are flushed, the original window (the one laio was launched in) is killed so focus lands on the correct configured window. This preserves the session name that swm created (`github•com/kalbasit/swm`) so swm's `SwitchTo` continues to work.
+
+**Why not create a new session**: swm records and navigates by the session name it created. A second session with a laio-chosen name would be unreachable via `swm workspace open`.
+
+**Why `is_inside_session()` rather than a new flag**: laio already has this check for interactive use; reusing it avoids bespoke swm-awareness in laio's interface.
+
+**Why `force_new_windows=true` + kill original**: The original window (where laio runs) disappears when laio exits. Without `force_new_windows`, the first configured window maps to the existing original window and closes with laio. By creating every configured window via `new-window` and then killing the original explicitly, all configured windows outlive the laio process.
+
+### D3: swm template variable — `{{tmux_socket}}`
+
+Add `{{tmux_socket}}` → `req.GetWorkspaceId()` to `paneGroupCommand`'s substitution map alongside the existing `{{worktree_path}}`, `{{story_name}}`, and `{{project_id}}` variables. The value is the absolute path of the story's socket, already present in the request.
+
+**Why a template variable over auto-injecting an env var**: template variables are visible in config, auditable, and consistent with the established pattern. Auto-injection would make the env var a hidden side effect.
+
+### D4: Common examples
+
+**Per-project config** (`laio.yaml` lives inside the repo, `path: .` resolves to the
+project directory because the config and the project share the same directory):
+
+```toml
+[plugins.session-tmux]
+pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"
+```
+
+**Global config** (`laio.yaml` lives at a fixed location such as `~/.config/swm/laio.yaml`;
+`path: .` would resolve to the config file's parent, so the worktree path must be passed
+explicitly via laio's Tera `--var` mechanism):
+
+```yaml
+# ~/.config/swm/laio.yaml
+path: "{{ path }}"   # injected by --var path=<worktree_path> below
+```
+
+```toml
+[plugins.session-tmux]
+pane_group_command = "laio start --file ~/.config/swm/laio.yaml --socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
+```
+
+`--skip-attach` is required: laio is running inside the new session already; calling `attach-session` or `switch-client` from within a detached pane would fail or have no effect.
+
+### D6: Bootstrap session in OpenWorkspace — lazy project session creation
+
+`OpenWorkspace` creates a single bootstrap session named after the story (e.g., `feat-x`) to keep the tmux server alive; project sessions (e.g., `github•com/kalbasit/swm`) are created lazily by `OpenPaneGroup`.
+
+**Why not pre-create project sessions**: The original design pre-created one session per worktree in `OpenWorkspace`. This raced with `pane_group_command`: by the time `OpenPaneGroup` ran, the session already existed, so `new-session` was skipped and `pane_group_command` was never invoked as the initial process of the session.
+
+**Why the story name for the bootstrap session**: Project sessions use `host/org/repo` format (e.g., `github•com/kalbasit/swm`), which always contains `/` and `•`. The story name is short and never matches this pattern, so the two namespaces never collide.
+
+### D5: Spec and test fixture correction
+
+Both `openspec/specs/session-tmux/spec.md` (Scenario: Custom pane_group_command) and `tmux_test.go` (TestOpenPaneGroup_WithPaneGroupCommand) use `--config`, which does not exist in laio. Both are updated to `--file` and the example is extended to include `--socket {{tmux_socket}}`.
+
+## Risks / Trade-offs
+
+- **`$TMUX` availability in detached panes**: tmux sets `$TMUX` in every pane's environment including detached sessions; laio's `is_inside_session()` relies on this. If the env var is absent in a particular execution context, laio falls back to creating a new session on the socket (sessions land on the right server, but swm's navigation by session name will not work). Mitigation: add an integration test in laio that simulates the detached pane scenario.
+- **Window lifecycle in in-session mode**: All configured windows are created via `new-window` (`force_new_windows = true`) and the original laio-started window is killed after flush. This differs from the normal flow where the first configured window is the session's initial window; here it is created fresh like all others.
+- **Socket path baked into config**: `{{tmux_socket}}` is expanded at `OpenPaneGroup` call time, so configs remain correct across `$XDG_RUNTIME_DIR` changes. No action needed.

--- a/openspec/changes/archive/2026-05-18-laio-plugin-support/proposal.md
+++ b/openspec/changes/archive/2026-05-18-laio-plugin-support/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+When a user sets `pane_group_command = "laio start ..."` in their swm config, laio issues all tmux commands without `-S`/`-L`, so sessions land on the default tmux server instead of swm's per-story socket (`$XDG_RUNTIME_DIR/swm/tmux/<story>.sock`). The result is sessions invisible to swm. Additionally, the existing spec scenario and test fixture reference a non-existent `--config` flag (laio uses `--file`).
+
+## What Changes
+
+- **swm / session-tmux**: Add `{{tmux_socket}}` as a new template variable in `paneGroupCommand`, resolving to the story's socket path (already available as `req.GetWorkspaceId()`).
+- **swm / session-tmux**: Fix spec scenario and `tmux_test.go` fixture: `--config` → `--file`, append `--socket {{tmux_socket}}` in the example.
+- **laio**: Add `--socket` flag (and honor `LAIO_TMUX_SOCKET` env var) to `laio start`. When set, pass `-S <path>` to every tmux command issued by laio's tmux client.
+
+## Non-goals
+
+- Changing how laio auto-discovers config files when `--file` is omitted.
+- Adding a `--config` alias to laio.
+- Sandboxing or restricting what commands `pane_group_command` can run.
+- Zellij support (laio's secondary multiplexer is out of scope for this integration).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `session-tmux`: The `Custom pane_group_command` scenario gains a new required template variable (`{{tmux_socket}}`), a corrected flag name (`--file` not `--config`), and a new requirement that the socket is injected so pane-group sessions reach the story's tmux server.
+
+## Impact
+
+- **swm** — `plugins/session-tmux/internal/session/tmux.go`: extend `paneGroupCommand` substitution map; update `tmux_test.go` fixture and `openspec/specs/session-tmux/spec.md` scenario.
+- **laio** — `src/app/cli/command_line.rs`: add `--socket` arg to `Start`; `src/muxer/tmux/`: thread socket path through to every tmux `Command` builder so `-S <path>` is prepended when set; honor `LAIO_TMUX_SOCKET` env var as fallback.
+- No proto changes. No new capability surface. Affects the `session` capability surface only.

--- a/openspec/changes/archive/2026-05-18-laio-plugin-support/specs/session-tmux/spec.md
+++ b/openspec/changes/archive/2026-05-18-laio-plugin-support/specs/session-tmux/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: OpenWorkspace creates and attaches
+`session-tmux` SHALL implement `Session.OpenWorkspace({story_name, worktree_paths})` by starting the tmux server socket if it does not exist. When the server is started, a single bootstrap session named after the story SHALL be created to keep the server alive (tmux's `exit-empty on` default exits the server when there are no sessions). Project sessions SHALL NOT be pre-created; they are created lazily by `OpenPaneGroup` so that `pane_group_command` is applied to each one individually. If the socket already exists, the call is idempotent.
+
+#### Scenario: New workspace
+- **WHEN** `OpenWorkspace` is called for a story with no existing socket
+- **THEN** a new tmux server is started on the story's socket, a single bootstrap session named after the story is created, and `Workspace` is returned
+
+#### Scenario: Existing workspace
+- **WHEN** `OpenWorkspace` is called and the story's socket already has a running server
+- **THEN** the call completes without creating duplicate sessions
+
+#### Scenario: Returns Workspace proto
+- **WHEN** `OpenWorkspace` completes successfully
+- **THEN** a `Workspace` message with `name = story_name` and `id = socket_path` is returned
+
+### Requirement: OpenPaneGroup in existing workspace
+`session-tmux` SHALL implement `Session.OpenPaneGroup({story_name, project_id, worktree_path})` by creating a new tmux session for the project within the story's socket (if it doesn't exist). The initial working directory SHALL be `worktree_path`. The default layout SHALL run `$EDITOR` (or `vim` if unset) in the first window and a shell in the second, unless `pane_group_command` is configured.
+
+#### Scenario: Default layout
+- **WHEN** `OpenPaneGroup` is called and no `pane_group_command` is configured
+- **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
+
+#### Scenario: Custom pane_group_command
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --socket <tmux_socket> --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
+
+#### Scenario: Idempotent for existing session
+- **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket
+- **THEN** the existing session is reused and no new session is created

--- a/openspec/changes/archive/2026-05-18-laio-plugin-support/tasks.md
+++ b/openspec/changes/archive/2026-05-18-laio-plugin-support/tasks.md
@@ -1,0 +1,41 @@
+## 1. swm/session-tmux — Fix broken spec scenario and test fixture
+
+- [x] 1.1 In `plugins/session-tmux/internal/session/tmux_test.go` (`TestOpenPaneGroup_WithPaneGroupCommand`): update the `fakeHostClient` TOML fixture from `--config` to `--file` and add `--socket {{tmux_socket}}` to the command; update the `require.Contains` assertion to match the new expected string.
+- [x] 1.2 In `openspec/specs/session-tmux/spec.md` (Scenario: Custom pane_group_command): update the WHEN/THEN text to use `--file` and `--socket {{tmux_socket}}` so the spec matches the actual laio CLI.
+
+## 2. swm/session-tmux — Add `{{tmux_socket}}` template variable
+
+- [x] 2.1 In `plugins/session-tmux/internal/session/tmux.go` (`paneGroupCommand`): add `{{tmux_socket}}` → `req.GetWorkspaceId()` to the substitution map alongside the existing `{{worktree_path}}`, `{{story_name}}`, and `{{project_id}}` entries.
+- [x] 2.2 In `plugins/session-tmux/internal/session/tmux_test.go`: add `TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution` that sets a TOML with `{{tmux_socket}}` in `pane_group_command` and asserts the substituted socket path appears in the logged tmux invocation.
+- [x] 2.3 Run `task fmt && task lint && task test` in `plugins/session-tmux/` and confirm zero failures.
+
+## 3. laio — Socket interface: `--socket` flag and `LAIO_TMUX_SOCKET` env var
+
+- [x] 3.1 In `src/app/cli/command_line.rs` (`Commands::Start`): add `#[clap(long)] socket: Option<String>` field. In `Cli::run()`, resolve the socket value as `socket.or_else(|| std::env::var("LAIO_TMUX_SOCKET").ok())` and thread it into the muxer/session pipeline.
+- [x] 3.2 Expose the resolved socket value through `SessionManager::start()` so it reaches the `Multiplexer::start()` call (add a parameter or context struct as needed to avoid global state).
+- [x] 3.3 Add a unit test in `src/app/cli/` that verifies `--socket /tmp/test.sock` is forwarded to the multiplexer.
+- [x] 3.4 Add a unit test verifying `LAIO_TMUX_SOCKET=/tmp/test.sock` is honoured when `--socket` is absent.
+
+## 4. laio — Thread socket path through tmux client
+
+- [x] 4.1 In the tmux client type (wherever `Command::new("tmux")` is built, e.g. `src/muxer/tmux/`): accept an `Option<String>` socket field. When `Some(path)`, prepend `-S <path>` to every tmux command that is constructed.
+- [x] 4.2 Update `create_session`, `has_session`, `new_window`, `split_window`, `send_keys`, `setenv`, `attach_session`, `switch_client`, and any other tmux command builders to pass through the socket flag.
+- [x] 4.3 Update existing tmux muxer tests to assert that `-S <path>` appears in command strings when a socket is configured.
+
+## 5. laio — In-session mode (configure current session, no new-session)
+
+- [x] 5.1 In `src/muxer/tmux/mux.rs` (`start()`): add an early branch — if `socket` is `Some` and `client.is_inside_session()` is `true`, call `configure_current_session()` instead of the normal `create_session` path and return.
+- [x] 5.2 Implement `configure_current_session(&self, session: &Session, env_vars: &[(&str, &str)], skip_cmds: bool)`: sets env vars on the existing session, creates ALL configured windows via `new-window` (`force_new_windows = true`) so they outlive the laio process, flushes commands, then kills the original window that laio was launched in so focus lands on the correct configured window.
+- [x] 5.3 Add a unit test `mux_start_in_session_mode`: set `is_inside_session()` to return `true`, provide a socket, call `start()`, and assert `new-session` is NOT called but `new-window` IS called for each configured window.
+- [x] 5.4 Run `cargo test` in `laio-cli/` and confirm zero failures.
+
+## 7. swm/session-tmux — Bootstrap session in OpenWorkspace
+
+- [x] 7.1 In `plugins/session-tmux/internal/session/tmux.go` (`OpenWorkspace`): replace per-project session pre-creation with a single bootstrap session named after the story. This keeps the tmux server alive (tmux exits with `exit-empty on` when there are no sessions) without racing with `pane_group_command` — which requires the session to NOT exist yet so it can be the initial process.
+- [x] 7.2 Update/add tests: `TestOpenWorkspace_SetsSWMStory` asserts `new-session` carries `-e SWM_STORY=<story>`; `TestOpenWorkspace_EmptyWorktreePaths` asserts the bootstrap session uses the story name with no `-c`; `TestOpenWorkspace_NoProjectSessionsPreCreated` asserts `github•com` sessions are NOT created during `OpenWorkspace`.
+- [x] 7.3 Run `task fmt && task lint && task test` in `plugins/session-tmux/` and confirm zero failures.
+
+## 6. Sync and documentation
+
+- [x] 6.1 Run `openspec sync-specs --change laio-plugin-support` in the swm repo to promote the delta spec into `openspec/specs/session-tmux/spec.md`.
+- [x] 6.2 Verify end-to-end manually: verified with global config (`~/.config/swm/laio.yaml`) using `--var path={{worktree_path}}` and `path: "{{ path }}"` in the YAML; sessions appear on the story's socket and windows open with the correct worktree CWD.

--- a/openspec/specs/session-tmux/spec.md
+++ b/openspec/specs/session-tmux/spec.md
@@ -73,8 +73,8 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 - **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
 
 #### Scenario: Custom pane_group_command
-- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"` and `OpenPaneGroup` is called
-- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --socket <tmux_socket> --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --tmux-socket <tmux_socket> --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
 
 #### Scenario: Idempotent for existing session
 - **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket

--- a/openspec/specs/session-tmux/spec.md
+++ b/openspec/specs/session-tmux/spec.md
@@ -1,3 +1,7 @@
+## Purpose
+
+The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace (story) gets a dedicated tmux socket, and each pane group (project worktree) gets a named session within that socket. The plugin handles workspace lifecycle (create, attach, close), session navigation (SwitchTo), context detection (IsInsideWorkspace, CurrentContext), and optional per-session layout via `pane_group_command`.
+## Requirements
 ### Requirement: Socket-per-workspace model
 `session-tmux` SHALL map each swm workspace to a dedicated tmux server socket at `$XDG_RUNTIME_DIR/swm/tmux/<story-name>.sock`. Each pane group within a workspace SHALL map to a tmux session (named by sanitizing the full canonical path `host/seg1/.../segN` to be tmux-safe — replacing `.` with `•` (U+2022) and `:` with `：` (U+FF1A), e.g., `github•com/kalbasit/swm` for `github.com/kalbasit/swm`) within that socket. This preserves the v1 tmux isolation model while preventing collisions between same-named repos from different forges or orgs.
 
@@ -14,15 +18,15 @@
 - **THEN** two distinct sessions `github•com/org-a/utils` and `github•com/org-b/utils` are created
 
 ### Requirement: OpenWorkspace creates and attaches
-`session-tmux` SHALL implement `Session.OpenWorkspace({story_name, worktree_paths})` by starting the tmux server socket if it does not exist, creating one session per project in `worktree_paths`, and attaching the current terminal to the workspace. If the socket already exists (workspace is already open), it SHALL attach to the existing workspace without recreating sessions.
+`session-tmux` SHALL implement `Session.OpenWorkspace({story_name, worktree_paths})` by starting the tmux server socket if it does not exist. When the server is started, a single bootstrap session named after the story SHALL be created to keep the server alive (tmux's `exit-empty on` default exits the server when there are no sessions). Project sessions SHALL NOT be pre-created; they are created lazily by `OpenPaneGroup` so that `pane_group_command` is applied to each one individually. If the socket already exists, the call is idempotent.
 
 #### Scenario: New workspace
 - **WHEN** `OpenWorkspace` is called for a story with no existing socket
-- **THEN** a new tmux server is started on the story's socket, one session is created per project, and the terminal is attached
+- **THEN** a new tmux server is started on the story's socket, a single bootstrap session named after the story is created, and `Workspace` is returned
 
 #### Scenario: Existing workspace
 - **WHEN** `OpenWorkspace` is called and the story's socket already has a running server
-- **THEN** the terminal is attached to the existing workspace without creating duplicate sessions
+- **THEN** the call completes without creating duplicate sessions
 
 #### Scenario: Returns Workspace proto
 - **WHEN** `OpenWorkspace` completes successfully
@@ -50,6 +54,17 @@
 - **WHEN** a socket file exists but the tmux server is no longer running
 - **THEN** that socket is excluded from the streamed results
 
+### Requirement: paneGroupCommand exposes tmux_socket template variable
+`session-tmux` SHALL substitute `{{tmux_socket}}` in `pane_group_command` with the absolute path of the story's tmux socket (the same value as `workspace_id` in the request).
+
+#### Scenario: tmux_socket is substituted
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock`
+- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --socket /run/user/1000/swm/tmux/feat-x.sock --skip-attach` with both `{{worktree_path}}` and `{{tmux_socket}}` expanded
+
+#### Scenario: tmux_socket absent when no pane_group_command configured
+- **WHEN** no `pane_group_command` is set in `config.toml`
+- **THEN** the default layout is used and `{{tmux_socket}}` substitution does not occur
+
 ### Requirement: OpenPaneGroup in existing workspace
 `session-tmux` SHALL implement `Session.OpenPaneGroup({story_name, project_id, worktree_path})` by creating a new tmux session for the project within the story's socket (if it doesn't exist). The initial working directory SHALL be `worktree_path`. The default layout SHALL run `$EDITOR` (or `vim` if unset) in the first window and a shell in the second, unless `pane_group_command` is configured.
 
@@ -58,12 +73,12 @@
 - **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
 
 #### Scenario: Custom pane_group_command
-- **WHEN** `config.toml` has `pane_group_command = "laio start --config {{worktree_path}}/.swm/laio.yaml"` and `OpenPaneGroup` is called
-- **THEN** the session's first window runs `laio start --config <worktree_path>/.swm/laio.yaml` with `{{worktree_path}}` expanded
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --socket <tmux_socket> --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
 
 #### Scenario: Idempotent for existing session
-- **WHEN** `OpenPaneGroup` is called for a project that already has a session in the workspace
-- **THEN** the existing session is returned without creating a duplicate
+- **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket
+- **THEN** the existing session is reused and no new session is created
 
 ### Requirement: SwitchTo switches active pane group
 `session-tmux` SHALL implement `Session.SwitchTo({workspace_id, pane_group_id, close_origin_workspace_id, close_origin_pane_id})` by running `tmux -S <target_socket> switch-client -t <session-name>` if already inside a tmux session, or building an `exec_argv` of `["tmux", "-S", "<target_socket>", "attach-session", "-t", "<session-name>"]` otherwise.
@@ -149,3 +164,4 @@ The canonical environment variable ownership model for a user session:
 #### Scenario: SWM_STORY present in tmux session
 - **WHEN** a workspace is opened for story `<story-name>`
 - **THEN** `SWM_STORY` is set to `<story-name>` in the tmux session environment
+

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -126,7 +126,7 @@ func (t *Tmux) CurrentContext(ctx context.Context, _ *pluginv1.Empty) (*pluginv1
 func (t *Tmux) Info(_ context.Context, _ *pluginv1.Empty) (*pluginv1.SessionInfo, error) {
 	return &pluginv1.SessionInfo{
 		PluginInfo: &pluginv1.PluginInfo{
-			Name:    "tmux",
+			Name:    "session-tmux",
 			Version: buildVersion,
 		},
 	}, nil

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/adrg/xdg"
@@ -217,6 +216,9 @@ func (t *Tmux) OpenPaneGroup(ctx context.Context, req *pluginv1.OpenPaneGroupReq
 }
 
 // OpenWorkspace creates or reattaches to the tmux server for the given story.
+// A single bootstrap session (named after the story) is created to keep the
+// server alive; project sessions are created lazily by OpenPaneGroup so that
+// pane_group_command is applied to each one individually.
 func (t *Tmux) OpenWorkspace(ctx context.Context, req *pluginv1.OpenWorkspaceRequest) (*pluginv1.Workspace, error) {
 	sock := t.socketPath(req.GetStoryName())
 
@@ -224,31 +226,14 @@ func (t *Tmux) OpenWorkspace(ctx context.Context, req *pluginv1.OpenWorkspaceReq
 		return nil, status.Errorf(codes.Internal, "creating socket dir: %v", err)
 	}
 
-	// Sort keys for deterministic session ordering.
-	keys := make([]string, 0, len(req.GetWorktreePaths()))
-	for k := range req.GetWorktreePaths() {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
-
-	// Probe whether the tmux server is already running.
+	// Start the server if it is not already running. A session named after the
+	// story keeps the server alive (tmux exits with exit-empty=on when there are
+	// no sessions). Project sessions use "host/org/repo" names and never collide
+	// with the short story name used here.
 	if _, err := t.run(ctx, "-S", sock, "list-sessions"); err != nil {
-		// Server not running — start it with the alphabetically first worktree.
-		firstName := req.GetStoryName()
+		bootstrapName := sessionName(req.GetStoryName())
 
-		var firstPath string
-
-		if len(keys) > 0 {
-			firstName = sessionName(keys[0])
-			firstPath = req.GetWorktreePaths()[keys[0]]
-		}
-
-		args := []string{"-S", sock, "new-session", "-d", "-s", firstName, "-e", "SWM_STORY=" + req.GetStoryName()}
-		if firstPath != "" {
-			args = append(args, "-c", firstPath)
-		}
-
+		args := []string{"-S", sock, "new-session", "-d", "-s", bootstrapName, "-e", "SWM_STORY=" + req.GetStoryName()}
 		if _, err := t.run(ctx, args...); err != nil {
 			return nil, err
 		}
@@ -258,19 +243,6 @@ func (t *Tmux) OpenWorkspace(ctx context.Context, req *pluginv1.OpenWorkspaceReq
 	// "swm workspace open" without specifying --story explicitly.
 	if _, err := t.run(ctx, "-S", sock, "set-environment", "-g", "SWM_STORY", req.GetStoryName()); err != nil {
 		return nil, err
-	}
-
-	// Ensure a session exists for every worktree path (sorted order).
-	for _, key := range keys {
-		path := req.GetWorktreePaths()[key]
-		name := sessionName(key)
-
-		if _, err := t.run(ctx, "-S", sock, "has-session", "-t", name); err != nil {
-			// Session absent — create it.
-			if _, err := t.run(ctx, "-S", sock, "new-session", "-d", "-s", name, "-c", path); err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	return &pluginv1.Workspace{
@@ -357,7 +329,7 @@ func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroup
 		return ""
 	}
 
-	resp, err := t.hostClient.GetConfig(ctx, &pluginv1.GetConfigRequest{PluginName: "tmux"})
+	resp, err := t.hostClient.GetConfig(ctx, &pluginv1.GetConfigRequest{PluginName: "session-tmux"})
 	if err != nil {
 		return ""
 	}
@@ -378,6 +350,7 @@ func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroup
 	cmd = strings.ReplaceAll(cmd, "{{worktree_path}}", req.GetWorktreePath())
 	cmd = strings.ReplaceAll(cmd, "{{story_name}}", storyName)
 	cmd = strings.ReplaceAll(cmd, "{{project_id}}", projectID)
+	cmd = strings.ReplaceAll(cmd, "{{tmux_socket}}", req.GetWorkspaceId())
 
 	return cmd
 }

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -28,7 +28,7 @@ const (
 	// testLaioPaneGroupCommandTOML is the canonical pane_group_command used in tests.
 	testLaioPaneGroupCommandTOML = `pane_group_command = "laio start` +
 		` --file {{worktree_path}}/.swm/laio.yaml` +
-		` --socket {{tmux_socket}} --skip-attach"`
+		` --tmux-socket {{tmux_socket}} --skip-attach"`
 )
 
 var faketmuxBin string
@@ -66,7 +66,7 @@ func TestInfo(t *testing.T) {
 	tmux, _ := newTmux(t)
 	info, err := tmux.Info(context.Background(), &pluginv1.Empty{})
 	require.NoError(t, err)
-	require.Equal(t, "tmux", info.GetPluginInfo().GetName())
+	require.Equal(t, "session-tmux", info.GetPluginInfo().GetName())
 }
 
 func TestOpenWorkspace(t *testing.T) {
@@ -377,7 +377,7 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	wantCmd := "laio start --file /tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml" +
-		" --socket " + sockPath + " --skip-attach"
+		" --tmux-socket " + sockPath + " --skip-attach"
 
 	log := string(logBytes)
 	require.Contains(t, log, wantCmd, "expected substituted pane_group_command in tmux args")
@@ -412,7 +412,7 @@ func TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution(t *testing.T) {
 	require.NoError(t, err)
 
 	log := string(logBytes)
-	require.Contains(t, log, "--socket "+sockPath,
+	require.Contains(t, log, "--tmux-socket "+sockPath,
 		"{{tmux_socket}} must be substituted with the workspace socket path")
 }
 

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -24,6 +24,11 @@ const (
 	testWorktree      = "/tmp/wt"
 	testPaneGroup     = testRepo
 	testPaneGroupFull = "github•com/kalbasit/swm"
+
+	// testLaioPaneGroupCommandTOML is the canonical pane_group_command used in tests.
+	testLaioPaneGroupCommandTOML = `pane_group_command = "laio start` +
+		` --file {{worktree_path}}/.swm/laio.yaml` +
+		` --socket {{tmux_socket}} --skip-attach"`
 )
 
 var faketmuxBin string
@@ -266,12 +271,12 @@ func TestOpenWorkspace_SetsSWMStory(t *testing.T) {
 	require.Contains(t, log, "set-environment -g SWM_STORY my-feature",
 		"tmux set-environment must be called to propagate SWM_STORY into the workspace")
 
-	// The initial new-session must also carry -e so the very first shell sees it
+	// The bootstrap new-session must carry -e so the very first shell sees it
 	// before set-environment -g has been called.
 	require.Contains(t, log, "new-session",
-		"expected a new-session invocation")
+		"expected a new-session invocation for the bootstrap session")
 	require.Contains(t, log, "-e SWM_STORY=my-feature",
-		"initial new-session must pass SWM_STORY via -e so the first shell sees it immediately")
+		"bootstrap new-session must pass SWM_STORY via -e so the first shell sees it immediately")
 }
 
 func TestOpenWorkspace_EmptyWorktreePaths(t *testing.T) {
@@ -303,14 +308,14 @@ func TestOpenWorkspace_EmptyWorktreePaths(t *testing.T) {
 		}
 	}
 
-	require.NotEmpty(t, firstNewSession, "expected a new-session invocation in log")
+	require.NotEmpty(t, firstNewSession, "expected a bootstrap new-session invocation in log")
 	require.Contains(t, firstNewSession, "-s story-only",
-		"initial session name must be the story name when no worktree paths are provided")
+		"bootstrap session name must be the story name when no worktree paths are provided")
 	require.NotContains(t, firstNewSession, "-c ",
-		"no -c flag should be present when there are no worktree paths")
+		"no -c flag should be present for the bootstrap session")
 }
 
-func TestOpenWorkspace_DeterministicInitialSession(t *testing.T) {
+func TestOpenWorkspace_NoProjectSessionsPreCreated(t *testing.T) {
 	// Cannot be parallel — uses FAKETMUX_LOG env var.
 	logFile := filepath.Join(t.TempDir(), "tmux.log")
 	t.Setenv("FAKETMUX_LOG", logFile)
@@ -330,25 +335,15 @@ func TestOpenWorkspace_DeterministicInitialSession(t *testing.T) {
 	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
 	require.NoError(t, err)
 
-	lines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	log := string(logBytes)
 
-	// Find the first "new-session" invocation. This is the call that starts the
-	// tmux server; it must use the alphabetically first key "github.com/a-repo"
-	// (session name "a-repo"). Non-deterministic map iteration could produce
-	// "m-repo" or "z-repo" instead.
-	var firstNewSession string
-
-	for _, line := range lines {
-		if strings.Contains(line, "new-session") {
-			firstNewSession = line
-
-			break
-		}
-	}
-
-	require.NotEmpty(t, firstNewSession, "expected at least one new-session invocation in log")
-	require.Contains(t, firstNewSession, "-s github•com/a-repo",
-		"initial session must use full sanitized path of alphabetically first key")
+	// Only the bootstrap session (story name) must appear — never a project key.
+	// Sessions for project worktrees are created by OpenPaneGroup so that
+	// pane_group_command is applied to each one individually.
+	require.Contains(t, log, "-s feat-order",
+		"bootstrap session must use the story name")
+	require.NotContains(t, log, "github•com",
+		"OpenWorkspace must not pre-create sessions for project worktree paths")
 }
 
 func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
@@ -360,7 +355,7 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 	sockPath := filepath.Join(socketDir, "feat-x.sock")
 
 	client := &fakeHostClient{
-		toml: []byte(`pane_group_command = "laio start --config {{worktree_path}}/.swm/laio.yaml"`),
+		toml: []byte(testLaioPaneGroupCommandTOML),
 	}
 
 	tmux := session.NewWithBinAndClient(faketmuxBin, socketDir, client)
@@ -381,9 +376,44 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
 	require.NoError(t, err)
 
+	wantCmd := "laio start --file /tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml" +
+		" --socket " + sockPath + " --skip-attach"
+
 	log := string(logBytes)
-	require.Contains(t, log, "laio start --config /tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml",
-		"expected substituted pane_group_command in tmux args")
+	require.Contains(t, log, wantCmd, "expected substituted pane_group_command in tmux args")
+}
+
+func TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution(t *testing.T) {
+	// Cannot be parallel — uses t.Setenv.
+	socketDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	sockPath := filepath.Join(socketDir, "feat-sock.sock")
+
+	client := &fakeHostClient{
+		toml: []byte(testLaioPaneGroupCommandTOML),
+	}
+
+	tmux := session.NewWithBinAndClient(faketmuxBin, socketDir, client)
+
+	if err := os.WriteFile(sockPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: "/tmp/stories/feat-sock/github.com/kalbasit/swm",
+	})
+	require.NoError(t, err)
+
+	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+
+	log := string(logBytes)
+	require.Contains(t, log, "--socket "+sockPath,
+		"{{tmux_socket}} must be substituted with the workspace socket path")
 }
 
 func TestOpenPaneGroup_InvalidProjectID(t *testing.T) {


### PR DESCRIPTION
Two bugs prevented pane_group_command from ever running:

1. paneGroupCommand fetched config under key "tmux" but
   the host stores it under "session-tmux", silently
   dropping the command.

2. OpenWorkspace pre-created project sessions before
   OpenPaneGroup ran; has-session returned true, so
   new-session (with pane_group_command as initial
   process) was never called.

Fix (1): use the correct plugin key "session-tmux".
Fix (2): replace the eager session loop with a single
bootstrap session named after the story to keep the
server alive (tmux exits when no sessions exist by
default). Project sessions are created lazily by
OpenPaneGroup so pane_group_command is always invoked
as the initial command.

Add {{tmux_socket}} to the pane_group_command
substitution map, resolving to the story's socket path.
This allows:
  pane_group_command = "laio start \
    --file {{worktree_path}}/.swm/laio.yaml \
    --tmux-socket {{tmux_socket}} --skip-attach"
causing laio to configure the existing session in-place
on the swm-managed socket rather than the default server.

Update spec, archive openspec change laio-plugin-support.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>