### PR TITLE
docs: document laio integration for session-tmux

### DIFF
--- a/openspec/changes/archive/2026-05-17-document-laio-integration/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-17-document-laio-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-17-document-laio-integration/design.md
+++ b/openspec/changes/archive/2026-05-17-document-laio-integration/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The laio tmux layout manager was integrated into swm's session-tmux plugin (archived change
+`2026-05-18-laio-plugin-support`). The integration added `{{tmux_socket}}` as a
+`pane_group_command` template variable and specified `--socket` / `LAIO_TMUX_SOCKET` as the
+mechanism for directing laio at swm's per-story tmux socket. None of this is visible to users
+via documentation: the session-tmux README's template-variable table ends at `{{project_id}}`,
+no worked example for laio exists, and the `examples/` directory is absent.
+
+This change is documentation-only: no code, no proto, no tests.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Document `{{tmux_socket}}` alongside the existing template variables.
+- Show both integration patterns (per-project config and global config) with ready-to-copy snippets.
+- Provide a minimal but realistic `laio.yaml` sample that works with swm's socket model.
+
+**Non-Goals**
+
+- Changing any runtime behaviour.
+- Documenting laio itself (defer to laio's own docs for yaml semantics beyond what swm-specific notes require).
+- Adding laio docs to the root README or host CLI README.
+
+## Decisions
+
+### D1: Location of the laio.yaml sample — `plugins/session-tmux/examples/laio.yaml`
+
+An `examples/` subdirectory under the plugin keeps the sample co-located with the plugin README
+that references it, and avoids polluting the repo root or `docs/`. The file is purely
+informational and not included in any build.
+
+**Alternatives considered:**
+- `docs/examples/laio.yaml` — separates the sample from the plugin README; cross-linking is
+  awkward.
+- Inline in the README as a fenced code block only — loses discoverability; users cannot
+  copy-paste a real file path into `--file`.
+
+### D2: Content of `laio.yaml` sample — show `path:` variable + `force_new_windows: true`
+
+The sample must demonstrate the two non-obvious constraints:
+1. `path: "{{ path }}"` — laio's own Tera variable that swm passes via `--var path={{worktree_path}}`.
+2. No `attach: true` or `switch-client` in the config — laio runs detached inside an already-attached
+   session, so any attach attempt is a no-op or error. The sample omits `attach` to use laio's
+   default (no-attach when `--skip-attach` is passed).
+
+### D3: Template-variable table placement — extend existing table in session-tmux README
+
+The existing `Configuration` section already has a `pane_group_command` row. Adding a new
+"Template variables" sub-section immediately after the config table is cleaner than scattering
+variable docs across the README.
+
+### D4: Two patterns in the README, not one
+
+Both the per-project pattern (`{{worktree_path}}/.swm/laio.yaml`) and the global pattern
+(`~/.config/swm/laio.yaml` + `--var path=...`) are needed because they differ in a non-obvious
+way: the per-project pattern requires `path: .` in laio.yaml (laio resolves `.` relative to
+the config file, which co-locates with the project), while the global pattern requires
+`path: "{{ path }}"` with an explicit `--var` injection.
+
+## Risks / Trade-offs
+
+- **laio version compatibility**: `--socket` and `--skip-attach` are flags from the laio version
+  used in the integration. If laio renames them in a future release, the documentation will be
+  wrong. Mitigation: note the minimum laio version in the README.
+- **`force_new_windows` semantics**: the sample uses `force_new_windows: true` to match the
+  in-session flow; omitting it causes laio to try to reuse the initial window in a way that
+  leaves an extra unnamed window. This is a laio internals detail, not a swm concern, but the
+  sample must get it right.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-05-17-document-laio-integration/proposal.md
+++ b/openspec/changes/archive/2026-05-17-document-laio-integration/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The laio integration was implemented (see archived change `2026-05-18-laio-plugin-support`) but
+never documented: the session-tmux README omits the `{{tmux_socket}}` template variable entirely,
+and no sample `laio.yaml` or wiring example exists anywhere in the repo. Users cannot discover
+how to configure this without reading internal specs or test code.
+
+## What Changes
+
+- Add `{{tmux_socket}}` to the template-variable table in `plugins/session-tmux/README.md`.
+- Add a "Laio integration" section to `plugins/session-tmux/README.md` with two worked examples:
+  per-project config (`{{worktree_path}}/.swm/laio.yaml`) and global config (fixed path + `--var`).
+- Add a sample `plugins/session-tmux/examples/laio.yaml` showing a realistic multi-window layout
+  that works with swm's socket model (using laio's `path:` variable and `force_new_windows`).
+
+## Non-goals
+
+- Changing any runtime behaviour of `pane_group_command` or `{{tmux_socket}}` expansion.
+- Adding laio documentation to the root README or the host CLI README.
+- Documenting Zellij or other multiplexers.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+_(none — documentation-only change, no spec-level requirement changes)_
+
+## Impact
+
+- `plugins/session-tmux/README.md` — extended with new section and updated template-variable table.
+- `plugins/session-tmux/examples/laio.yaml` — new sample file (no build impact).

--- a/openspec/changes/archive/2026-05-17-document-laio-integration/specs/project-documentation/spec.md
+++ b/openspec/changes/archive/2026-05-17-document-laio-integration/specs/project-documentation/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: session-tmux README documents template variables
+
+The `plugins/session-tmux/README.md` SHALL include a template-variable reference table listing
+all variables available for substitution in `pane_group_command`.
+
+#### Scenario: Template-variable table is present and complete
+- **WHEN** a user reads `plugins/session-tmux/README.md`
+- **THEN** it SHALL contain a table listing `{{worktree_path}}`, `{{story_name}}`,
+  `{{project_id}}`, and `{{tmux_socket}}` with a description of each
+
+---
+
+### Requirement: session-tmux README documents laio integration
+
+The `plugins/session-tmux/README.md` SHALL include a "Laio integration" section that shows
+how to wire [laio](https://github.com/stephane-klein/laio) into `pane_group_command`.
+
+#### Scenario: Per-project laio config example is present
+- **WHEN** a user reads the laio integration section
+- **THEN** it SHALL contain a `config.toml` snippet using
+  `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"`
+
+#### Scenario: Global laio config example is present
+- **WHEN** a user reads the laio integration section
+- **THEN** it SHALL contain a `config.toml` snippet using a fixed `--file` path with
+  `--var path={{worktree_path}}` and a corresponding `laio.yaml` fragment showing
+  `path: "{{ path }}"`
+
+#### Scenario: --skip-attach requirement is explained
+- **WHEN** a user reads the laio integration section
+- **THEN** it SHALL explain that `--skip-attach` is required because laio runs inside an
+  already-attached session
+
+---
+
+### Requirement: session-tmux plugin ships a sample laio.yaml
+
+`plugins/session-tmux/examples/laio.yaml` SHALL exist and contain a working multi-window
+laio configuration that is compatible with swm's socket model.
+
+#### Scenario: Sample laio.yaml file exists
+- **WHEN** the repository is inspected
+- **THEN** `plugins/session-tmux/examples/laio.yaml` SHALL exist
+
+#### Scenario: Sample laio.yaml uses the path variable
+- **WHEN** a user reads `plugins/session-tmux/examples/laio.yaml`
+- **THEN** it SHALL use `path: "{{ path }}"` to accept the worktree path via `--var path=<value>`

--- a/openspec/changes/archive/2026-05-17-document-laio-integration/tasks.md
+++ b/openspec/changes/archive/2026-05-17-document-laio-integration/tasks.md
@@ -1,0 +1,11 @@
+## 1. Update session-tmux README
+
+- [x] 1.1 Add a "Template variables" sub-section to the Configuration section listing `{{worktree_path}}`, `{{story_name}}`, `{{project_id}}`, and `{{tmux_socket}}` with descriptions
+- [x] 1.2 Add a "Laio integration" section with the per-project config example (`{{worktree_path}}/.swm/laio.yaml`)
+- [x] 1.3 Add the global config example to the "Laio integration" section (`~/.config/swm/laio.yaml` + `--var path={{worktree_path}}`)
+- [x] 1.4 Add an explanation of why `--skip-attach` is required
+
+## 2. Add sample laio.yaml
+
+- [x] 2.1 Create `plugins/session-tmux/examples/laio.yaml` with a multi-window layout using `path: "{{ path }}"` and compatible with swm's socket model (no attach, `force_new_windows: true`)
+- [x] 2.2 Link to `examples/laio.yaml` from the "Laio integration" section of the README

--- a/openspec/specs/project-documentation/spec.md
+++ b/openspec/specs/project-documentation/spec.md
@@ -48,3 +48,47 @@ Each directory under `plugins/` SHALL contain a `README.md` covering that plugin
 #### Scenario: All four bundled plugins have READMEs
 - **WHEN** the repository is inspected
 - **THEN** `plugins/forge-github/README.md`, `plugins/picker-fzf/README.md`, `plugins/session-tmux/README.md`, and `plugins/vcs-git/README.md` SHALL each exist
+
+### Requirement: session-tmux README documents template variables
+
+The `plugins/session-tmux/README.md` SHALL include a template-variable reference table listing
+all variables available for substitution in `pane_group_command`.
+
+#### Scenario: Template-variable table is present and complete
+- **WHEN** a user reads `plugins/session-tmux/README.md`
+- **THEN** it SHALL contain a table listing `{{worktree_path}}`, `{{story_name}}`,
+  `{{project_id}}`, and `{{tmux_socket}}` with a description of each
+
+### Requirement: session-tmux README documents laio integration
+
+The `plugins/session-tmux/README.md` SHALL include a "Laio integration" section that shows
+how to wire [laio](https://github.com/stephane-klein/laio) into `pane_group_command`.
+
+#### Scenario: Per-project laio config example is present
+- **WHEN** a user reads the laio integration section
+- **THEN** it SHALL contain a `config.toml` snippet using
+  `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"`
+
+#### Scenario: Global laio config example is present
+- **WHEN** a user reads the laio integration section
+- **THEN** it SHALL contain a `config.toml` snippet using a fixed `--file` path with
+  `--var path={{worktree_path}}` and a corresponding `laio.yaml` fragment showing
+  `path: "{{ path }}"`
+
+#### Scenario: --skip-attach requirement is explained
+- **WHEN** a user reads the laio integration section
+- **THEN** it SHALL explain that `--skip-attach` is required because laio runs inside an
+  already-attached session
+
+### Requirement: session-tmux plugin ships a sample laio.yaml
+
+`plugins/session-tmux/examples/laio.yaml` SHALL exist and contain a working multi-window
+laio configuration that is compatible with swm's socket model.
+
+#### Scenario: Sample laio.yaml file exists
+- **WHEN** the repository is inspected
+- **THEN** `plugins/session-tmux/examples/laio.yaml` SHALL exist
+
+#### Scenario: Sample laio.yaml uses the path variable
+- **WHEN** a user reads `plugins/session-tmux/examples/laio.yaml`
+- **THEN** it SHALL use `path: "{{ path }}"` to accept the worktree path via `--var path=<value>`

--- a/openspec/specs/project-documentation/spec.md
+++ b/openspec/specs/project-documentation/spec.md
@@ -62,17 +62,17 @@ all variables available for substitution in `pane_group_command`.
 ### Requirement: session-tmux README documents laio integration
 
 The `plugins/session-tmux/README.md` SHALL include a "Laio integration" section that shows
-how to wire [laio](https://github.com/stephane-klein/laio) into `pane_group_command`.
+how to wire [laio](https://laio.sh/) into `pane_group_command`.
 
 #### Scenario: Per-project laio config example is present
 - **WHEN** a user reads the laio integration section
 - **THEN** it SHALL contain a `config.toml` snippet using
-  `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"`
+  `pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --skip-attach"`
 
 #### Scenario: Global laio config example is present
 - **WHEN** a user reads the laio integration section
 - **THEN** it SHALL contain a `config.toml` snippet using a fixed `--file` path with
-  `--var path={{worktree_path}}` and a corresponding `laio.yaml` fragment showing
+  `--var path='{{worktree_path}}'` and a corresponding `laio.yaml` fragment showing
   `path: "{{ path }}"`
 
 #### Scenario: --skip-attach requirement is explained

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -96,7 +96,7 @@ Place a `laio.yaml` inside the repository (e.g. `.swm/laio.yaml`) and reference 
 ```toml
 # config.toml
 [plugins.config.session-tmux]
-pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"
+pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach"
 ```
 
 `path: .` in the laio.yaml resolves relative to the config file, which lives inside the
@@ -122,7 +122,7 @@ windows:
 ```toml
 # config.toml
 [plugins.config.session-tmux]
-pane_group_command = "laio start --file ~/.config/swm/laio.yaml --socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
+pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
 ```
 
 See [`examples/laio.yaml`](examples/laio.yaml) for a complete annotated sample.

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -51,12 +51,12 @@ pane_group_command = "nvim"
 
 When `pane_group_command` is non-empty, these variables are expanded before the command runs:
 
-| Variable            | Expands to                                                                          |
-| ------------------- | ----------------------------------------------------------------------------------- |
-| `{{worktree_path}}` | Absolute path to the project's worktree                                             |
-| `{{story_name}}`    | Name of the active story                                                            |
-| `{{project_id}}`    | Project identifier (`<host>/<path>`, e.g. `github.com/kalbasit/swm`)                |
-| `{{tmux_socket}}`   | Absolute path to the story's tmux socket (`$XDG_RUNTIME_DIR/swm/tmux/<story-name>`) |
+| Variable            | Expands to                                                                               |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| `{{worktree_path}}` | Absolute path to the project's worktree                                                  |
+| `{{story_name}}`    | Name of the active story                                                                 |
+| `{{project_id}}`    | Project identifier (`<host>/<path>`, e.g. `github.com/kalbasit/swm`)                     |
+| `{{tmux_socket}}`   | Absolute path to the story's tmux socket (`$XDG_RUNTIME_DIR/swm/tmux/<story-name>.sock`) |
 
 ## Usage
 
@@ -73,13 +73,13 @@ echo $SWM_STORY
 Tmux sockets are placed at:
 
 ```
-$XDG_RUNTIME_DIR/swm/tmux/<story-name>
+$XDG_RUNTIME_DIR/swm/tmux/<story-name>.sock
 ```
 
 You can connect to a story's server directly with:
 
 ```sh
-tmux -S "$XDG_RUNTIME_DIR/swm/tmux/<story-name>" attach
+tmux -S "$XDG_RUNTIME_DIR/swm/tmux/<story-name>.sock" attach
 ```
 
 ## Laio integration
@@ -96,7 +96,7 @@ Place a `laio.yaml` inside the repository (e.g. `.swm/laio.yaml`) and reference 
 ```toml
 # config.toml
 [plugins.config.session-tmux]
-pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach"
+pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --skip-attach"
 ```
 
 `path: .` in the laio.yaml resolves relative to the config file, which lives inside the
@@ -122,7 +122,7 @@ windows:
 ```toml
 # config.toml
 [plugins.config.session-tmux]
-pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
+pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket '{{tmux_socket}}' --skip-attach --var path='{{worktree_path}}'"
 ```
 
 See [`examples/laio.yaml`](examples/laio.yaml) for a complete annotated sample.

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -47,6 +47,17 @@ session = "tmux"
 pane_group_command = "nvim"
 ```
 
+### Template variables
+
+When `pane_group_command` is non-empty, these variables are expanded before the command runs:
+
+| Variable            | Expands to                                                                          |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| `{{worktree_path}}` | Absolute path to the project's worktree                                             |
+| `{{story_name}}`    | Name of the active story                                                            |
+| `{{project_id}}`    | Project identifier (`<host>/<path>`, e.g. `github.com/kalbasit/swm`)                |
+| `{{tmux_socket}}`   | Absolute path to the story's tmux socket (`$XDG_RUNTIME_DIR/swm/tmux/<story-name>`) |
+
 ## Usage
 
 ```sh
@@ -70,6 +81,58 @@ You can connect to a story's server directly with:
 ```sh
 tmux -S "$XDG_RUNTIME_DIR/swm/tmux/<story-name>" attach
 ```
+
+## Laio integration
+
+[laio](https://laio.sh/) is a tmux layout manager that reads a YAML config to
+create windows and panes. When used with swm, laio must target swm's per-story socket so its
+sessions land on the correct tmux server.
+
+### Per-project config
+
+Place a `laio.yaml` inside the repository (e.g. `.swm/laio.yaml`) and reference it via
+`{{worktree_path}}`:
+
+```toml
+# config.toml
+[plugins.config.session-tmux]
+pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"
+```
+
+`path: .` in the laio.yaml resolves relative to the config file, which lives inside the
+worktree, so no extra path injection is needed.
+
+### Global config
+
+Keep a single `laio.yaml` at a fixed path and inject the worktree path via laio's Tera
+`--var` mechanism:
+
+```yaml
+# ~/.config/swm/laio.yaml
+path: "{{ path }}" # injected by --var below
+windows:
+  - name: editor
+    panes:
+      - shell_command: nvim
+  - name: shell
+    panes:
+      - shell_command: ""
+```
+
+```toml
+# config.toml
+[plugins.config.session-tmux]
+pane_group_command = "laio start --file ~/.config/swm/laio.yaml --socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
+```
+
+See [`examples/laio.yaml`](examples/laio.yaml) for a complete annotated sample.
+
+### Why `--skip-attach` is required
+
+laio is invoked inside an already-attached tmux session (the one swm just created and switched
+into). Calling `attach-session` or `switch-client` from inside a detached pane would either
+fail silently or have no effect. `--skip-attach` tells laio to configure the session without
+trying to attach.
 
 ## Limitations
 

--- a/plugins/session-tmux/examples/laio.yaml
+++ b/plugins/session-tmux/examples/laio.yaml
@@ -3,12 +3,12 @@
 # Usage (global config pattern — inject worktree path via --var):
 #
 #   [plugins.config.session-tmux]
-#   pane_group_command = "laio start --file ~/.config/swm/laio.yaml --socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
+#   pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
 #
 # Usage (per-project pattern — place this file at <repo>/.swm/laio.yaml):
 #
 #   [plugins.config.session-tmux]
-#   pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"
+#   pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach"
 #
 #   With the per-project pattern, change `path: "{{ path }}"` below to `path: .`
 #   so laio resolves the path relative to the config file (which lives in the worktree).

--- a/plugins/session-tmux/examples/laio.yaml
+++ b/plugins/session-tmux/examples/laio.yaml
@@ -3,12 +3,12 @@
 # Usage (global config pattern — inject worktree path via --var):
 #
 #   [plugins.config.session-tmux]
-#   pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
+#   pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket '{{tmux_socket}}' --skip-attach --var path='{{worktree_path}}'"
 #
 # Usage (per-project pattern — place this file at <repo>/.swm/laio.yaml):
 #
 #   [plugins.config.session-tmux]
-#   pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach"
+#   pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --skip-attach"
 #
 #   With the per-project pattern, change `path: "{{ path }}"` below to `path: .`
 #   so laio resolves the path relative to the config file (which lives in the worktree).

--- a/plugins/session-tmux/examples/laio.yaml
+++ b/plugins/session-tmux/examples/laio.yaml
@@ -1,0 +1,42 @@
+# Sample laio.yaml for use with swm's session-tmux plugin (https://laio.sh/).
+#
+# Usage (global config pattern — inject worktree path via --var):
+#
+#   [plugins.config.session-tmux]
+#   pane_group_command = "laio start --file ~/.config/swm/laio.yaml --socket {{tmux_socket}} --skip-attach --var path={{worktree_path}}"
+#
+# Usage (per-project pattern — place this file at <repo>/.swm/laio.yaml):
+#
+#   [plugins.config.session-tmux]
+#   pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"
+#
+#   With the per-project pattern, change `path: "{{ path }}"` below to `path: .`
+#   so laio resolves the path relative to the config file (which lives in the worktree).
+#
+# Why --skip-attach:
+#   laio runs inside the already-attached swm session. Any attach attempt
+#   from inside a detached pane would fail or be a no-op.
+#
+# Why force_new_windows:
+#   swm creates the tmux session before laio runs, leaving one unnamed initial
+#   window. force_new_windows: true ensures every configured window is created
+#   fresh rather than reusing that initial window.
+
+# Worktree path injected by swm via --var path=<worktree_path>.
+# Change to `path: .` for per-project configs placed inside the repo.
+path: "{{ path }}"
+
+force_new_windows: true
+
+windows:
+  - name: editor
+    panes:
+      - shell_command: "${EDITOR:-nvim} ."
+
+  - name: shell
+    panes:
+      - shell_command: ""
+
+  - name: test
+    panes:
+      - shell_command: ""


### PR DESCRIPTION
The laio layout manager was integrated via pane_group_command but
never documented. Users had no way to discover the {{tmux_socket}}
template variable or how to wire laio's --socket flag.

Adds a Template variables table to the Configuration section,
a Laio integration section with per-project and global config
examples, and a sample examples/laio.yaml.