### PR TITLE
docs: fix inaccurate CLI usage across README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ swm story create my-feature --branch fix/my-feature
 **3. Open the workspace**
 
 ```sh
-swm workspace open --story my-feature
+swm workspace open my-feature
 ```
 
 What happens depends on whether a picker plugin (fzf) is configured:
@@ -135,10 +135,10 @@ After the first open, the selected project is attached to the story permanently.
 Run the same command from any terminal to re-attach:
 
 ```sh
-swm workspace open --story my-feature
+swm workspace open my-feature
 ```
 
-You can also skip `--story` if you export `SWM_STORY` in your shell profile:
+You can also omit the story name if you export `SWM_STORY` in your shell profile:
 
 ```sh
 export SWM_STORY=my-feature

--- a/cmd/swm/README.md
+++ b/cmd/swm/README.md
@@ -24,6 +24,12 @@ swm story create <name> [--branch <branch>]
 Creates a new story. Defaults the branch to `feat/<name>`.
 
 ```sh
+swm story list
+```
+
+Lists all stories and their attached projects.
+
+```sh
 swm story remove <name> [-f | --force]
 ```
 
@@ -32,10 +38,22 @@ Removes a story and all its worktrees. Prompts for confirmation unless `--force`
 ### `swm workspace`
 
 ```sh
-swm workspace open
+swm workspace open [story-name] [--kill-pane]
 ```
 
-Opens the workspace for the current story (as determined by `$SWM_STORY` or the default story). Launches the session plugin.
+Opens the workspace for a story. Story resolution order:
+
+1. `[story-name]` positional argument (if provided).
+2. `$SWM_STORY` environment variable.
+3. Default story from config (`default_story`).
+
+If a picker plugin is configured and no story is specified, an interactive list is shown. `--kill-pane` closes the originating tmux pane after switching.
+
+```sh
+swm workspace list
+```
+
+Lists all active workspaces and their attached projects.
 
 ### `swm pr`
 
@@ -63,7 +81,7 @@ swm reads `$XDG_CONFIG_HOME/swm/config.toml` (default: `~/.config/swm/config.tom
 # Root directory for all code. Repositories land at code_root/repositories/<host>/<org>/<repo>.
 code_root = "~/code"
 
-# Story used when no --story flag or $SWM_STORY env var is set.
+# Story used when no story name argument or $SWM_STORY env var is set.
 default_story = "_default"
 
 [plugins]

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -11,7 +11,7 @@ Implements the `session` capability surface using [tmux](https://github.com/tmux
 | Workspace   | Dedicated tmux server (one socket per story) |
 | Pane group  | tmux session within that server              |
 
-Each story gets its own tmux socket at `$XDG_RUNTIME_DIR/swm/tmux/<story>`, so stories are fully isolated — killing one story's tmux server has no effect on others. `$XDG_RUNTIME_DIR` is set automatically on Linux by systemd/PAM (typically `/run/user/<uid>`). If it is not set in your environment, export it before running swm (e.g. `export XDG_RUNTIME_DIR=/run/user/$(id -u)`).
+Each story gets its own tmux socket at `$XDG_RUNTIME_DIR/swm/tmux/<story>.sock`, so stories are fully isolated — killing one story's tmux server has no effect on others. `$XDG_RUNTIME_DIR` is set automatically on Linux by systemd/PAM (typically `/run/user/<uid>`). If it is not set in your environment, export it before running swm (e.g. `export XDG_RUNTIME_DIR=/run/user/$(id -u)`).
 
 ## Requirements
 


### PR DESCRIPTION
Several README files referenced --story as a flag on `swm workspace
open`, but it does not exist — story name is a positional argument.
The config comment also referred to a non-existent --story flag.
Additionally, `swm story list`, `swm workspace list`, `--kill-pane`,
and the story resolution order were missing from cmd/swm/README.md,
and the session-tmux socket path was missing the .sock suffix.

- README.md: `--story my-feature` → positional `my-feature`; update
  prose to match
- cmd/swm/README.md: add swm story list; expand swm workspace section
  with positional arg, --kill-pane, resolution order, and workspace
  list; fix default_story config comment
- plugins/session-tmux/README.md: add missing .sock suffix to the
  socket path in the Purpose section

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>