### PR TITLE
feat: use gh auth token for forge-github authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ vcs     = "git"
 picker  = "fzf"
 forges  = ["github"]
 
-[plugins.config.forge-github]
-token_path = "~/.config/swm/github_token"
+# forge-github authenticates via `gh auth token` by default (no config needed
+# if you have the GitHub CLI installed and logged in). Set token_path only to
+# override with an explicit file.
+# [plugins.config.forge-github]
+# token_path = "~/.config/swm/github_token"
 ```
 
 See [`cmd/swm/README.md`](cmd/swm/README.md) for the full configuration reference.

--- a/cmd/swm/README.md
+++ b/cmd/swm/README.md
@@ -106,8 +106,10 @@ forges = ["github"]
 "forge-github"  = "/usr/local/bin/swm-plugin-forge-github"
 
 # Per-plugin configuration. Key is the full plugin name.
-[plugins.config.forge-github]
-token_path = "~/.config/swm/github_token"
+# forge-github: token_path is optional. When absent, the plugin uses
+# `gh auth token` (GitHub CLI) or ~/.github_token as fallbacks.
+# [plugins.config.forge-github]
+# token_path = "~/.config/swm/github_token"
 
 [plugins.config.session-tmux]
 pane_group_command = ""   # optional custom command run when opening a pane group

--- a/openspec/changes/archive/2026-05-18-use-gh-for-auth/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-use-gh-for-auth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-18-use-gh-for-auth/design.md
+++ b/openspec/changes/archive/2026-05-18-use-gh-for-auth/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`forge-github` currently authenticates by reading a token from a file (`~/.github_token` by default, or a path in plugin config). This requires users to create and maintain a separate credential file even when the GitHub CLI (`gh`) is already installed and authenticated on the same machine.
+
+The change introduces `gh auth token` as the default credential source, falling back to the file-based approach for users without `gh` or who prefer an explicit override.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `gh auth token` the default token source when no `token_path` is configured
+- Retain `token_path` config as an explicit override (takes priority over `gh`)
+- Retain `~/.github_token` as a last-resort file fallback (for environments without `gh`)
+- Surface a clear, actionable error when all sources fail
+
+**Non-Goals:**
+- Installing or managing `gh` on behalf of the user
+- Supporting interactive OAuth device-flow within swm
+- Changing auth for any plugin other than `forge-github`
+- Parsing `gh` config files directly (fragile, tied to `gh` internals)
+
+## Decisions
+
+### Decision 1: Invoke `gh` via subprocess (`exec.Command`)
+
+**Chosen**: `exec.Command("gh", "auth", "token")` — run the `gh` CLI and capture stdout.
+
+**Alternatives considered**:
+- Parse `~/.config/gh/hosts.yml` directly — rejected: ties us to `gh` internal format, breaks across `gh` versions, and is fragile with keychain-backed storage.
+- Use `go-gh` library — rejected: adds a significant dependency for a one-liner subprocess call; `gh auth token` is the stable public interface.
+
+**Rationale**: `gh auth token` is `gh`'s documented, stable interface for emitting the active token. A subprocess call is a single line of code and picks up any future `gh` keychain/OAuth changes for free.
+
+### Decision 2: Resolution order — config override first, then `gh`, then file fallback
+
+**Chosen**:
+1. `token_path` in plugin config → read file at that path (unchanged behavior)
+2. `gh auth token` subprocess → use if `gh` is on `$PATH` and exits 0
+3. `~/.github_token` file → last resort; maintains backwards compatibility
+
+**Rationale**: Explicit configuration always wins (principle of least surprise). `gh` is the new default for unconfigured installations. The file fallback preserves compatibility for CI environments and users who set up the file before `gh` existed.
+
+### Decision 3: Soft dependency on `gh` — no hard error if absent
+
+If `exec.LookPath("gh")` fails or `gh auth token` exits non-zero, silently fall through to the file fallback. Only emit a `FailedPrecondition` error if all three sources fail, with a message that mentions both `gh auth login` and the `token_path` config option.
+
+**Rationale**: Avoids breaking existing users who do not have `gh` installed.
+
+### Decision 4: Testability via injected executor
+
+Extract the subprocess call behind a `func(ctx context.Context) (string, error)` field on `GitHub` (defaulting to `ghAuthToken`). Tests inject a stub that returns a controlled token without spawning a real process.
+
+**Rationale**: Avoids `exec.Command` in unit tests while keeping the production path simple.
+
+## Risks / Trade-offs
+
+- **`gh` not on `$PATH`** → falls through to file fallback; no regression for existing users.
+- **`gh` authenticated to a different account** → token belongs to whichever account `gh` is logged in as. Same risk exists today with the file. Documented as user responsibility.
+- **Subprocess overhead** → `gh auth token` is fast (reads a local file/keychain). Called only at RPC time, same as the file read today.
+- **Test isolation** → injected executor function prevents subprocess calls in unit tests; integration tests can set `FORGE_GITHUB_API_URL` against a fake server as today.
+
+## Migration Plan
+
+- Additive change: no config migration needed.
+- Users with `token_path` configured see no behaviour change.
+- Users without any config now get credentials from `gh` automatically (if installed), or fall back to `~/.github_token` as before.
+- No rollback complexity — if a release is reverted, the file fallback still works.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-05-18-use-gh-for-auth/proposal.md
+++ b/openspec/changes/archive/2026-05-18-use-gh-for-auth/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Users must manually create and maintain a `~/.github_token` file (or configure `token_path`) to authenticate `forge-github`, duplicating credentials already managed by the GitHub CLI (`gh`). Delegating to `gh auth token` removes this friction and lets swm reuse the credential store that developers already keep current.
+
+## What Changes
+
+- `forge-github` resolves the GitHub token using the following priority order:
+  1. Explicit `token_path` in plugin config (unchanged behavior for users who opt in)
+  2. `gh auth token` subprocess call (new default when `token_path` is not set)
+  3. `~/.github_token` file (retained as last-resort fallback for environments without `gh`)
+- The "missing token" error message is updated to mention `gh auth login` as the recommended fix.
+- No proto changes.
+
+## Non-goals
+
+- Installing or managing the `gh` CLI on behalf of the user.
+- Supporting OAuth device-flow or other interactive auth flows directly in swm.
+- Changing auth for any plugin other than `forge-github`.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- **forge-github** — The token-loading requirement changes: `gh auth token` becomes the default source when `token_path` is not configured. The fallback chain and error messaging are updated. Affects `openspec/specs/forge-github/spec.md` (token loading requirement and "Missing token" scenarios).
+
+## Impact
+
+- `plugins/forge-github/internal/forge/github.go` — `tokenFromConfig` method rewritten to invoke `gh auth token` via `exec.Command` when `token_path` is absent.
+- `openspec/specs/forge-github/spec.md` — "forge-github token loading" requirement and its scenarios updated to reflect the new resolution order.
+- Runtime dependency: `gh` CLI on `$PATH` (soft — plugin degrades to file fallback if absent).
+- No proto changes; no version bump required.

--- a/openspec/changes/archive/2026-05-18-use-gh-for-auth/specs/forge-github/spec.md
+++ b/openspec/changes/archive/2026-05-18-use-gh-for-auth/specs/forge-github/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: forge-github token loading
+The plugin SHALL resolve the GitHub token using the following priority order:
+1. If `token_path` is configured (via `host.GetConfig`), read the token from that file. Leading/trailing whitespace SHALL be trimmed. If the file is missing or empty, return a `FailedPrecondition` error immediately — do not fall through to other sources.
+2. Run `gh auth token` as a subprocess. If `gh` is on `$PATH` and exits 0, use the trimmed stdout as the token.
+3. Read the token from `~/.github_token`. Leading/trailing whitespace SHALL be trimmed.
+
+If all three sources fail, the plugin SHALL return a gRPC `FailedPrecondition` error whose message mentions both `gh auth login` and the `token_path` config option as remediation steps.
+
+The token SHALL be resolved at call time (not at startup).
+
+#### Scenario: Token loaded from configured path
+- **WHEN** `token_path = "~/.secrets/gh_token"` is set in config and the file contains a valid token
+- **THEN** the plugin uses that token for GitHub API requests
+
+#### Scenario: Configured path takes priority over gh
+- **WHEN** `token_path` is set and `gh auth token` would also return a token
+- **THEN** the plugin uses the token from the configured file path
+
+#### Scenario: Configured path missing returns error immediately
+- **WHEN** `token_path` is configured but the file does not exist
+- **THEN** the plugin returns a gRPC `FailedPrecondition` error without attempting `gh` or the default file
+
+#### Scenario: gh auth token used as default
+- **WHEN** `token_path` is not configured and `gh` is on `$PATH` and authenticated
+- **THEN** the plugin uses the token returned by `gh auth token`
+
+#### Scenario: gh not installed falls through to file
+- **WHEN** `token_path` is not configured and `gh` is not on `$PATH`
+- **THEN** the plugin attempts to read `~/.github_token`
+
+#### Scenario: gh exits non-zero falls through to file
+- **WHEN** `token_path` is not configured and `gh auth token` exits with a non-zero status
+- **THEN** the plugin attempts to read `~/.github_token`
+
+#### Scenario: Default file fallback used
+- **WHEN** `token_path` is not configured, `gh` is unavailable or unauthenticated, and `~/.github_token` exists
+- **THEN** the plugin reads the token from `~/.github_token`
+
+#### Scenario: All sources fail returns actionable error
+- **WHEN** `token_path` is not configured, `gh auth token` fails, and `~/.github_token` does not exist or is empty
+- **THEN** the plugin returns a gRPC `FailedPrecondition` error that mentions `gh auth login` and the `token_path` config option

--- a/openspec/changes/archive/2026-05-18-use-gh-for-auth/tasks.md
+++ b/openspec/changes/archive/2026-05-18-use-gh-for-auth/tasks.md
@@ -1,0 +1,16 @@
+## 1. Refactor token resolution in plugins/forge-github
+
+- [x] 1.1 Add a `ghTokenFn func(ctx context.Context) (string, error)` field to the `GitHub` struct (`plugins/forge-github/internal/forge/github.go`) and wire the default implementation (`ghAuthToken`) in `New` and `NewWithBaseURL`
+- [x] 1.2 Implement `ghAuthToken(ctx context.Context) (string, error)`: use `exec.LookPath("gh")` to check availability, then run `exec.CommandContext(ctx, "gh", "auth", "token")` and return trimmed stdout on exit 0, or a sentinel error on failure
+- [x] 1.3 Rewrite `tokenFromConfig` to implement the three-step resolution order: (1) explicit `token_path` → read file and return, never fall through; (2) call `ghTokenFn`; (3) read `~/.github_token`; if all fail, return `FailedPrecondition` with an error message mentioning `gh auth login` and the `token_path` config option
+
+## 2. Unit tests in plugins/forge-github
+
+- [x] 2.1 Write table-driven tests for `tokenFromConfig` covering: configured path hit, configured path missing (no fallthrough), `gh` token used as default, `gh` not installed falls through to file, `gh` exits non-zero falls through to file, file fallback used, all sources fail returns actionable error
+- [x] 2.2 Wire the injected `ghTokenFn` stub into test cases via `NewWithBaseURL` or a test helper that sets the field directly (table-driven, no subprocess spawned)
+
+## 3. Verify
+
+- [x] 3.1 Run `task fmt` in `plugins/forge-github` and confirm exit 0
+- [x] 3.2 Run `task lint` in `plugins/forge-github` and confirm exit 0
+- [x] 3.3 Run `task test` and confirm all tests pass

--- a/openspec/specs/forge-github/spec.md
+++ b/openspec/specs/forge-github/spec.md
@@ -69,12 +69,43 @@ The plugin manager SHALL support a `forges` list in config. For each named forge
 - **THEN** the RPC returns a gRPC `NotFound` error
 
 ### Requirement: forge-github token loading
-The plugin SHALL read the GitHub token from the file path configured at `plugins.config.forge-github.token_path` (obtained via `host.GetConfig`). If `token_path` is not configured, the plugin SHALL default to `~/.github_token`. The file SHALL be read at call time (not at startup). Leading/trailing whitespace SHALL be trimmed.
+The plugin SHALL resolve the GitHub token using the following priority order:
+1. If `token_path` is configured (via `host.GetConfig`), read the token from that file. Leading/trailing whitespace SHALL be trimmed. If the file is missing or empty, return a `FailedPrecondition` error immediately — do not fall through to other sources.
+2. Run `gh auth token` as a subprocess. If `gh` is on `$PATH` and exits 0, use the trimmed stdout as the token.
+3. Read the token from `~/.github_token`. Leading/trailing whitespace SHALL be trimmed.
+
+If all three sources fail, the plugin SHALL return a gRPC `FailedPrecondition` error whose message mentions both `gh auth login` and the `token_path` config option as remediation steps.
+
+The token SHALL be resolved at call time (not at startup).
 
 #### Scenario: Token loaded from configured path
 - **WHEN** `token_path = "~/.secrets/gh_token"` is set in config and the file contains a valid token
 - **THEN** the plugin uses that token for GitHub API requests
 
-#### Scenario: Default token path used
-- **WHEN** `token_path` is not configured and `~/.github_token` exists
+#### Scenario: Configured path takes priority over gh
+- **WHEN** `token_path` is set and `gh auth token` would also return a token
+- **THEN** the plugin uses the token from the configured file path
+
+#### Scenario: Configured path missing returns error immediately
+- **WHEN** `token_path` is configured but the file does not exist
+- **THEN** the plugin returns a gRPC `FailedPrecondition` error without attempting `gh` or the default file
+
+#### Scenario: gh auth token used as default
+- **WHEN** `token_path` is not configured and `gh` is on `$PATH` and authenticated
+- **THEN** the plugin uses the token returned by `gh auth token`
+
+#### Scenario: gh not installed falls through to file
+- **WHEN** `token_path` is not configured and `gh` is not on `$PATH`
+- **THEN** the plugin attempts to read `~/.github_token`
+
+#### Scenario: gh exits non-zero falls through to file
+- **WHEN** `token_path` is not configured and `gh auth token` exits with a non-zero status
+- **THEN** the plugin attempts to read `~/.github_token`
+
+#### Scenario: Default file fallback used
+- **WHEN** `token_path` is not configured, `gh` is unavailable or unauthenticated, and `~/.github_token` exists
 - **THEN** the plugin reads the token from `~/.github_token`
+
+#### Scenario: All sources fail returns actionable error
+- **WHEN** `token_path` is not configured, `gh auth token` fails, and `~/.github_token` does not exist or is empty
+- **THEN** the plugin returns a gRPC `FailedPrecondition` error that mentions `gh auth login` and the `token_path` config option

--- a/plugins/forge-github/README.md
+++ b/plugins/forge-github/README.md
@@ -8,33 +8,49 @@ Implements the `forge` capability surface for GitHub. It claims the `github.com`
 
 ## Requirements
 
-- A GitHub personal access token with `repo` scope (or a fine-grained token with pull-request read/write permissions on the target repositories).
 - Network access to `api.github.com`.
+- A GitHub credential available via one of the methods below.
+
+## Authentication
+
+The plugin resolves a GitHub token using the following priority order:
+
+1. **`token_path` config key** — if set, the token is read from that file. Missing or empty file is a hard error (no fallback).
+2. **`gh auth token`** — if the [GitHub CLI](https://cli.github.com/) is on `$PATH` and authenticated, its token is used automatically. This is the default for most developer machines.
+3. **`~/.github_token` file** — last-resort fallback for environments without `gh`.
+
+### Recommended: use the GitHub CLI
+
+```sh
+# Install gh (https://cli.github.com/), then:
+gh auth login
+```
+
+No swm configuration needed — the plugin picks up `gh`'s credentials automatically.
+
+### Alternative: token file
+
+```sh
+echo "ghp_yourtoken" > ~/.github_token
+chmod 600 ~/.github_token
+```
+
+Or point to a custom path via config:
+
+```toml
+[plugins.config.forge-github]
+token_path = "~/.config/swm/github_token"
+```
 
 ## Configuration
 
 Configure under `[plugins.config.forge-github]` in `config.toml`:
 
-| Key          | Type   | Default                      | Description                                                    |
-| ------------ | ------ | ---------------------------- | -------------------------------------------------------------- |
-| `token_path` | string | `~/.config/swm/github_token` | Path to a file containing the GitHub token (newline-stripped). |
+| Key          | Type   | Default | Description                                                                                          |
+| ------------ | ------ | ------- | ---------------------------------------------------------------------------------------------------- |
+| `token_path` | string | —       | Path to a file containing the GitHub token. Takes priority over `gh auth`. Tilde (`~/`) is expanded. |
 
-### Example
-
-```toml
-[plugins]
-forges = ["github"]
-
-[plugins.config.forge-github]
-token_path = "~/.config/swm/github_token"
-```
-
-Create the token file:
-
-```sh
-echo "ghp_yourtoken" > ~/.config/swm/github_token
-chmod 600 ~/.config/swm/github_token
-```
+`token_path` is optional. When absent, the plugin uses `gh auth token` or `~/.github_token`.
 
 ## Usage
 
@@ -51,5 +67,5 @@ swm pr create --title "feat: add thing" --body "Closes #123" --draft
 ## Limitations
 
 - Only `github.com` is claimed. GitHub Enterprise Server is not supported in this release.
-- The plugin reads a static token from a file; OAuth device flow is not supported yet.
+- OAuth device flow is not supported; use `gh auth login` or a personal access token.
 - At most one forge plugin can claim a given host; if you need multiple GitHub identities, use separate swm installations.

--- a/plugins/forge-github/internal/forge/github.go
+++ b/plugins/forge-github/internal/forge/github.go
@@ -2,6 +2,7 @@
 package forge
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -248,9 +249,18 @@ func ghAuthToken(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	out, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
+	var stderr bytes.Buffer
+
+	cmd := exec.CommandContext(ctx, "gh", "auth", "token")
+	cmd.Stderr = &stderr
+
+	out, err := cmd.Output()
 	if err != nil {
-		return "", err
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("gh auth token: %w: %s", err, msg)
+		}
+
+		return "", fmt.Errorf("gh auth token: %w", err)
 	}
 
 	token := strings.TrimSpace(string(out))
@@ -309,7 +319,8 @@ func (g *GitHub) tokenFromConfig(ctx context.Context) (string, error) {
 		return tokenFromFile(expanded)
 	}
 
-	// Step 2: gh auth token.
+	// Step 2: gh auth token. Resolved at call time (not cached) for consistency
+	// with the file-read path and to avoid stale tokens after `gh auth refresh`.
 	if token, err := g.ghTokenFn(ctx); err == nil {
 		return token, nil
 	}

--- a/plugins/forge-github/internal/forge/github.go
+++ b/plugins/forge-github/internal/forge/github.go
@@ -3,10 +3,12 @@ package forge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -22,26 +24,66 @@ import (
 // buildVersion is set via -ldflags at build time.
 var buildVersion = "dev" //nolint:gochecknoglobals // set via ldflags at link time
 
+var errGHAuthTokenEmpty = errors.New("gh auth token: empty output")
+
 type githubConfig struct {
 	TokenPath string `toml:"token_path"`
+}
+
+// Option configures a GitHub forge server.
+type Option func(*GitHub)
+
+// WithGHTokenFn overrides the function used to obtain a token via the gh CLI.
+func WithGHTokenFn(fn func(ctx context.Context) (string, error)) Option {
+	return func(g *GitHub) {
+		g.ghTokenFn = fn
+	}
+}
+
+// WithUserHomeDirFn overrides the function used to locate the user's home directory.
+func WithUserHomeDirFn(fn func() (string, error)) Option {
+	return func(g *GitHub) {
+		g.userHomeDirFn = fn
+	}
 }
 
 // GitHub implements pluginv1.ForgeServer for github.com.
 type GitHub struct {
 	pluginv1.UnimplementedForgeServer
-	hostClient pluginv1.HostClient
+	hostClient    pluginv1.HostClient
+	ghTokenFn     func(ctx context.Context) (string, error)
+	userHomeDirFn func() (string, error)
 	// baseURL, when non-empty, overrides the GitHub API base URL (for tests).
 	baseURL string
 }
 
 // New returns a GitHub forge server backed by the given host client.
-func New(hostClient pluginv1.HostClient) *GitHub {
-	return &GitHub{hostClient: hostClient}
+func New(hostClient pluginv1.HostClient, opts ...Option) *GitHub {
+	g := &GitHub{
+		hostClient:    hostClient,
+		ghTokenFn:     ghAuthToken,
+		userHomeDirFn: os.UserHomeDir,
+	}
+	for _, o := range opts {
+		o(g)
+	}
+
+	return g
 }
 
 // NewWithBaseURL returns a GitHub forge server with a custom API base URL (for tests).
-func NewWithBaseURL(hostClient pluginv1.HostClient, baseURL string) *GitHub {
-	return &GitHub{hostClient: hostClient, baseURL: baseURL}
+func NewWithBaseURL(hostClient pluginv1.HostClient, baseURL string, opts ...Option) *GitHub {
+	g := &GitHub{
+		hostClient:    hostClient,
+		baseURL:       baseURL,
+		ghTokenFn:     ghAuthToken,
+		userHomeDirFn: os.UserHomeDir,
+	}
+	for _, o := range opts {
+		o(g)
+	}
+
+	return g
 }
 
 // ownerRepo extracts the owner and repo from a ProjectID's segments.
@@ -159,6 +201,20 @@ func (g *GitHub) ListPullRequests(req *pluginv1.ListPRsRequest, stream pluginv1.
 	return nil
 }
 
+// expandPath expands a leading ~/ using userHomeDirFn.
+func (g *GitHub) expandPath(path string) (string, error) {
+	if strings.HasPrefix(path, "~/") {
+		home, err := g.userHomeDirFn()
+		if err != nil {
+			return "", fmt.Errorf("resolving home directory: %w", err)
+		}
+
+		return filepath.Join(home, path[2:]), nil
+	}
+
+	return path, nil
+}
+
 // newGitHubClient returns a GitHub API client authenticated with the user's token.
 func (g *GitHub) newGitHubClient(ctx context.Context) (*github.Client, error) {
 	token, err := g.tokenFromConfig(ctx)
@@ -186,7 +242,46 @@ func (g *GitHub) newGitHubClient(ctx context.Context) (*github.Client, error) {
 	return client, nil
 }
 
-// tokenFromConfig reads the GitHub token path from host config, then reads and returns the token.
+// ghAuthToken retrieves a GitHub token via the gh CLI.
+func ghAuthToken(ctx context.Context) (string, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return "", err
+	}
+
+	out, err := exec.CommandContext(ctx, "gh", "auth", "token").Output()
+	if err != nil {
+		return "", err
+	}
+
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", errGHAuthTokenEmpty
+	}
+
+	return token, nil
+}
+
+// tokenFromFile reads and returns a trimmed token from an absolute file path.
+func tokenFromFile(absPath string) (string, error) {
+	raw, err := os.ReadFile(absPath) //nolint:gosec // G304: path comes from trusted plugin config or default
+	if err != nil {
+		return "", status.Errorf(codes.FailedPrecondition, "reading GitHub token from %q: %v", absPath, err)
+	}
+
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", status.Errorf(codes.FailedPrecondition, "GitHub token file %q is empty", absPath)
+	}
+
+	return token, nil
+}
+
+// tokenFromConfig resolves the GitHub token using the following priority order:
+//  1. Explicit token_path in config — reads file and returns; never falls through on error.
+//  2. gh auth token subprocess — default when token_path is absent.
+//  3. ~/.github_token file — last-resort fallback.
+//
+// Returns FailedPrecondition if all sources fail.
 func (g *GitHub) tokenFromConfig(ctx context.Context) (string, error) {
 	if g.hostClient == nil {
 		return "", status.Error(codes.FailedPrecondition, "no host client: GitHub token unavailable")
@@ -204,31 +299,30 @@ func (g *GitHub) tokenFromConfig(ctx context.Context) (string, error) {
 		}
 	}
 
-	tokenPath := cfg.TokenPath
-	if tokenPath == "" {
-		tokenPath = "~/.github_token" //nolint:gosec // G101: default token file path, not a credential
-	}
-
-	if strings.HasPrefix(tokenPath, "~/") {
-		home, err := os.UserHomeDir()
+	// Step 1: explicit token_path — takes priority; never falls through on error.
+	if cfg.TokenPath != "" {
+		expanded, err := g.expandPath(cfg.TokenPath)
 		if err != nil {
-			return "", fmt.Errorf("resolving home directory: %w", err)
+			return "", err
 		}
 
-		tokenPath = filepath.Join(home, tokenPath[2:])
+		return tokenFromFile(expanded)
 	}
 
-	raw, err := os.ReadFile(tokenPath) //nolint:gosec // G304: path comes from trusted plugin config
-	if err != nil {
-		return "", status.Errorf(codes.FailedPrecondition, "reading GitHub token from %q: %v", tokenPath, err)
+	// Step 2: gh auth token.
+	if token, err := g.ghTokenFn(ctx); err == nil {
+		return token, nil
 	}
 
-	token := strings.TrimSpace(string(raw))
-	if token == "" {
-		return "", status.Errorf(codes.FailedPrecondition, "GitHub token file %q is empty", tokenPath)
+	// Step 3: ~/.github_token fallback.
+	if home, err := g.userHomeDirFn(); err == nil {
+		if token, err := tokenFromFile(filepath.Join(home, ".github_token")); err == nil {
+			return token, nil
+		}
 	}
 
-	return token, nil
+	return "", status.Error(codes.FailedPrecondition,
+		"no GitHub token found: run `gh auth login` to authenticate, or set token_path in the forge-github plugin config")
 }
 
 // ghPRToProto converts a go-github PullRequest to a proto PullRequest message.

--- a/plugins/forge-github/internal/forge/github_test.go
+++ b/plugins/forge-github/internal/forge/github_test.go
@@ -3,6 +3,7 @@ package forge_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +21,8 @@ import (
 
 	"github.com/kalbasit/swm/plugins/forge-github/internal/forge"
 )
+
+var errGHNotAvailable = errors.New("gh not available")
 
 const (
 	testGitHubHost = "github.com"
@@ -382,4 +385,96 @@ func TestGitHub_TokenMissing_FailedPrecondition(t *testing.T) {
 
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestGitHub_TokenResolution(t *testing.T) {
+	t.Parallel()
+
+	successFn := func(_ context.Context) (string, error) { return testToken, nil }
+	failFn := func(_ context.Context) (string, error) { return "", errGHNotAvailable }
+
+	tests := []struct {
+		name            string
+		configTOML      string
+		ghTokenFn       func(context.Context) (string, error)
+		homeToken       string     // if non-empty, write to <tmpHome>/.github_token
+		wantErrCode     codes.Code // 0 means success
+		wantErrContains string
+	}{
+		{
+			name:      "gh token used as default",
+			ghTokenFn: successFn,
+		},
+		{
+			name:      "gh not installed falls through to file",
+			ghTokenFn: failFn,
+			homeToken: testToken,
+		},
+		{
+			name:      "file fallback used when gh exits non-zero",
+			ghTokenFn: failFn,
+			homeToken: testToken,
+		},
+		{
+			name:            "all sources fail returns actionable error",
+			ghTokenFn:       failFn,
+			wantErrCode:     codes.FailedPrecondition,
+			wantErrContains: "gh auth login",
+		},
+		{
+			name:        "configured path missing does not fall through to gh or file",
+			configTOML:  `token_path = "/nonexistent/token"`,
+			ghTokenFn:   successFn,
+			homeToken:   testToken,
+			wantErrCode: codes.FailedPrecondition,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Provide a fake server returning empty PR list for success cases.
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintln(w, "[]") //nolint:errcheck // test mock, response write failure is non-critical
+			}))
+			t.Cleanup(server.Close)
+
+			// Set up a temp home dir with an optional .github_token file.
+			tmpHome := t.TempDir()
+			if tc.homeToken != "" {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(tmpHome, ".github_token"),
+					[]byte(tc.homeToken),
+					0o600,
+				))
+			}
+
+			homeFn := func() (string, error) { return tmpHome, nil }
+
+			hc := &fakeHostClient{toml: []byte(tc.configTOML)}
+			g := forge.NewWithBaseURL(
+				hc, server.URL+"/",
+				forge.WithGHTokenFn(tc.ghTokenFn),
+				forge.WithUserHomeDirFn(homeFn),
+			)
+
+			stream := &fakeListStream{ctx: context.Background()}
+			err := g.ListPullRequests(&pluginv1.ListPRsRequest{
+				ProjectId: &pluginv1.ProjectID{Host: testGitHubHost, Segments: []string{testOwner, testRepo}},
+			}, stream)
+
+			if tc.wantErrCode == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Equal(t, tc.wantErrCode, status.Code(err))
+
+				if tc.wantErrContains != "" {
+					require.Contains(t, err.Error(), tc.wantErrContains)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Previously the forge-github plugin required a token file
(~/.github_token or a configured token_path). Developers who
already use the GitHub CLI had to maintain a separate credential
file that duplicated what gh already stores.

The plugin now resolves the GitHub token in priority order:
1. Explicit token_path in config (unchanged behaviour for users
   who opt in; hard error if the file is missing, no fallthrough).
2. `gh auth token` subprocess — default for machines with the
   GitHub CLI installed and authenticated.
3. ~/.github_token file — last-resort fallback, preserving
   backwards compatibility for CI and pre-gh setups.

The gh call is injected via a ghTokenFn field (defaulting to
ghAuthToken) so unit tests remain fully parallel and subprocess-
free. A WithGHTokenFn and WithUserHomeDirFn option pair allows
complete control over both sources in tests.

READMEs for the repo root, cmd/swm, and the forge-github plugin
are updated to reflect the new default and document token_path
as an optional override rather than a requirement.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>