### PR TITLE
feat: make story branch name template configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ This writes a story record (`$XDG_DATA_HOME/swm/stories/my-feature.json`) with a
 swm story create my-feature --branch fix/my-feature
 ```
 
+The default `feat/<name>` pattern is configurable via `branch_name_template` in `config.toml` — see the [full configuration reference](cmd/swm/README.md#configuration).
+
 **3. Open the workspace**
 
 ```sh

--- a/cmd/swm/README.md
+++ b/cmd/swm/README.md
@@ -84,6 +84,17 @@ code_root = "~/code"
 # Story used when no story name argument or $SWM_STORY env var is set.
 default_story = "_default"
 
+[story]
+# Go text/template for the default branch name when `swm story create` is run
+# without --branch. The only variable is .Name (the story name). When absent or
+# empty, "feat/{{.Name}}" is used, producing "feat/<name>".
+#
+# Examples:
+#   branch_name_template = "feat/{{.Name}}"      # default → feat/my-story
+#   branch_name_template = "{{.Name}}"           # bare name → my-story
+#   branch_name_template = "users/alice/{{.Name}}" # personal prefix → users/alice/my-story
+# branch_name_template = "feat/{{.Name}}"
+
 [plugins]
 # Name of the session plugin to load (matches the plugin binary suffix).
 session = "tmux"

--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -62,7 +62,7 @@ func NewRootCmd(
 	})
 
 	storyGroup := &cobra.Command{Use: "story", Short: "Manage stories"}
-	storyGroup.AddCommand(story.NewCreateCmd(store, cfg.CodeRoot, hooks))
+	storyGroup.AddCommand(story.NewCreateCmd(store, cfg.CodeRoot, hooks, cfg.Story.BranchNameTemplate))
 	storyGroup.AddCommand(story.NewListCmd(store, cfg.DefaultStory))
 	storyGroup.AddCommand(story.NewRemoveCmd(store, mgr, resolver, hooks))
 	root.AddCommand(storyGroup)

--- a/cmd/swm/internal/cli/story/branch.go
+++ b/cmd/swm/internal/cli/story/branch.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"text/template"
-)
 
-const defaultBranchNameTemplate = "feat/{{.Name}}"
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
+)
 
 var errEmptyBranchName = errors.New("branch_name_template produced an empty branch name")
 
@@ -22,7 +22,7 @@ type branchNameData struct {
 // or evaluates to an empty string.
 func branchFromTemplate(tpl, storyName string) (string, error) {
 	if tpl == "" {
-		tpl = defaultBranchNameTemplate
+		tpl = config.DefaultBranchNameTemplate
 	}
 
 	t, err := template.New("branch").Parse(tpl)

--- a/cmd/swm/internal/cli/story/branch.go
+++ b/cmd/swm/internal/cli/story/branch.go
@@ -1,0 +1,44 @@
+package story
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"text/template"
+)
+
+const defaultBranchNameTemplate = "feat/{{.Name}}"
+
+var errEmptyBranchName = errors.New("branch_name_template produced an empty branch name")
+
+// branchNameData is the template data available in branch_name_template.
+type branchNameData struct {
+	Name string
+}
+
+// branchFromTemplate evaluates tpl as a Go text/template with .Name set to
+// storyName and returns the result. An empty tpl uses the default template
+// "feat/{{.Name}}". Returns an error if the template is syntactically invalid
+// or evaluates to an empty string.
+func branchFromTemplate(tpl, storyName string) (string, error) {
+	if tpl == "" {
+		tpl = defaultBranchNameTemplate
+	}
+
+	t, err := template.New("branch").Parse(tpl)
+	if err != nil {
+		return "", fmt.Errorf("invalid branch_name_template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, branchNameData{Name: storyName}); err != nil {
+		return "", fmt.Errorf("evaluating branch_name_template: %w", err)
+	}
+
+	result := buf.String()
+	if result == "" {
+		return "", errEmptyBranchName
+	}
+
+	return result, nil
+}

--- a/cmd/swm/internal/cli/story/branch_test.go
+++ b/cmd/swm/internal/cli/story/branch_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kalbasit/swm/cmd/swm/internal/cli/story"
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
 )
 
 func TestBranchFromTemplate(t *testing.T) {
@@ -20,7 +21,7 @@ func TestBranchFromTemplate(t *testing.T) {
 	}{
 		{
 			name:      "default template",
-			tpl:       "feat/{{.Name}}",
+			tpl:       config.DefaultBranchNameTemplate,
 			storyName: testStoryName,
 			want:      "feat/" + testStoryName,
 		},
@@ -52,7 +53,7 @@ func TestBranchFromTemplate(t *testing.T) {
 			name:      "empty template uses default feat prefix",
 			tpl:       "",
 			storyName: testStoryName,
-			want:      "feat/" + testStoryName,
+			want:      "feat/" + testStoryName, // falls back to config.DefaultBranchNameTemplate
 		},
 		{
 			name:      "template that evaluates to empty string",

--- a/cmd/swm/internal/cli/story/branch_test.go
+++ b/cmd/swm/internal/cli/story/branch_test.go
@@ -1,0 +1,80 @@
+package story_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/cli/story"
+)
+
+func TestBranchFromTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		tpl       string
+		storyName string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "default template",
+			tpl:       "feat/{{.Name}}",
+			storyName: testStoryName,
+			want:      "feat/" + testStoryName,
+		},
+		{
+			name:      "custom prefix template",
+			tpl:       "fix/{{.Name}}",
+			storyName: testBugName,
+			want:      "fix/" + testBugName,
+		},
+		{
+			name:      "template with no prefix",
+			tpl:       "{{.Name}}",
+			storyName: testStoryName,
+			want:      testStoryName,
+		},
+		{
+			name:      "template with suffix",
+			tpl:       "{{.Name}}/wip",
+			storyName: "my-story",
+			want:      "my-story/wip",
+		},
+		{
+			name:      "invalid template syntax",
+			tpl:       "{{.Name",
+			storyName: testStoryName,
+			wantErr:   true,
+		},
+		{
+			name:      "empty template uses default feat prefix",
+			tpl:       "",
+			storyName: testStoryName,
+			want:      "feat/" + testStoryName,
+		},
+		{
+			name:      "template that evaluates to empty string",
+			tpl:       "{{if false}}{{.Name}}{{end}}",
+			storyName: testStoryName,
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := story.BranchFromTemplate(tc.tpl, tc.storyName)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cmd/swm/internal/cli/story/create.go
+++ b/cmd/swm/internal/cli/story/create.go
@@ -12,7 +12,12 @@ import (
 )
 
 // NewCreateCmd returns the `swm story create` command.
-func NewCreateCmd(store coreStory.Store, codeRoot string, hooks hookexec.Runner) *cobra.Command {
+func NewCreateCmd(
+	store coreStory.Store,
+	codeRoot string,
+	hooks hookexec.Runner,
+	branchNameTemplate string,
+) *cobra.Command {
 	var branch string
 
 	cmd := &cobra.Command{
@@ -24,7 +29,12 @@ func NewCreateCmd(store coreStory.Store, codeRoot string, hooks hookexec.Runner)
 			ctx := cmd.Context()
 
 			if branch == "" {
-				branch = "feat/" + name
+				derived, err := branchFromTemplate(branchNameTemplate, name)
+				if err != nil {
+					return err
+				}
+
+				branch = derived
 			}
 
 			preCfg := hookexec.RunConfig{
@@ -59,7 +69,7 @@ func NewCreateCmd(store coreStory.Store, codeRoot string, hooks hookexec.Runner)
 		},
 	}
 
-	cmd.Flags().StringVar(&branch, "branch", "", "branch name (default: feat/<name>)")
+	cmd.Flags().StringVar(&branch, "branch", "", "branch name (default: derived from config branch_name_template)")
 
 	return cmd
 }

--- a/cmd/swm/internal/cli/story/create_test.go
+++ b/cmd/swm/internal/cli/story/create_test.go
@@ -10,10 +10,9 @@ import (
 	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
 
 	"github.com/kalbasit/swm/cmd/swm/internal/cli/story"
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
 	"github.com/kalbasit/swm/cmd/swm/internal/hookexec"
 )
-
-const defaultTemplate = "feat/{{.Name}}"
 
 var errHookFailed = errors.New("hook failed")
 
@@ -21,7 +20,7 @@ func TestCreateCmd_BasicCreation(t *testing.T) {
 	t.Parallel()
 
 	store := &stubStore{}
-	cmd := story.NewCreateCmd(store, "", hookexec.Noop, defaultTemplate)
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, config.DefaultBranchNameTemplate)
 
 	cmd.SetArgs([]string{testStoryName})
 	require.NoError(t, cmd.Execute())
@@ -33,7 +32,7 @@ func TestCreateCmd_CustomBranch(t *testing.T) {
 	t.Parallel()
 
 	store := &stubStore{}
-	cmd := story.NewCreateCmd(store, "", hookexec.Noop, defaultTemplate)
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, config.DefaultBranchNameTemplate)
 
 	cmd.SetArgs([]string{"JIRA-42", "--branch", "fix/JIRA-42-crash"})
 	require.NoError(t, cmd.Execute())
@@ -112,7 +111,7 @@ func TestCreateCmd_Duplicate(t *testing.T) {
 	t.Parallel()
 
 	store := &stubStore{createErr: coreStory.ErrStoryExists}
-	cmd := story.NewCreateCmd(store, "", hookexec.Noop, defaultTemplate)
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, config.DefaultBranchNameTemplate)
 
 	cmd.SetArgs([]string{testStoryName})
 	require.Error(t, cmd.Execute())
@@ -134,7 +133,7 @@ func TestCreateCmd_PreHookAborts(t *testing.T) {
 		return nil
 	})
 
-	cmd := story.NewCreateCmd(store, "/code", captureHook, defaultTemplate)
+	cmd := story.NewCreateCmd(store, "/code", captureHook, config.DefaultBranchNameTemplate)
 	cmd.SetArgs([]string{testStoryName})
 
 	err := cmd.Execute()
@@ -157,7 +156,7 @@ func TestCreateCmd_HooksCalledInOrder(t *testing.T) {
 		return nil
 	})
 
-	cmd := story.NewCreateCmd(store, "/code", captureHook, defaultTemplate)
+	cmd := story.NewCreateCmd(store, "/code", captureHook, config.DefaultBranchNameTemplate)
 	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())

--- a/cmd/swm/internal/cli/story/create_test.go
+++ b/cmd/swm/internal/cli/story/create_test.go
@@ -13,13 +13,15 @@ import (
 	"github.com/kalbasit/swm/cmd/swm/internal/hookexec"
 )
 
+const defaultTemplate = "feat/{{.Name}}"
+
 var errHookFailed = errors.New("hook failed")
 
 func TestCreateCmd_BasicCreation(t *testing.T) {
 	t.Parallel()
 
 	store := &stubStore{}
-	cmd := story.NewCreateCmd(store, "", hookexec.Noop)
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, defaultTemplate)
 
 	cmd.SetArgs([]string{testStoryName})
 	require.NoError(t, cmd.Execute())
@@ -31,7 +33,7 @@ func TestCreateCmd_CustomBranch(t *testing.T) {
 	t.Parallel()
 
 	store := &stubStore{}
-	cmd := story.NewCreateCmd(store, "", hookexec.Noop)
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, defaultTemplate)
 
 	cmd.SetArgs([]string{"JIRA-42", "--branch", "fix/JIRA-42-crash"})
 	require.NoError(t, cmd.Execute())
@@ -39,11 +41,78 @@ func TestCreateCmd_CustomBranch(t *testing.T) {
 	require.Equal(t, "fix/JIRA-42-crash", store.lastCreatedBranch)
 }
 
+func TestCreateCmd_TemplateFromConfig(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, "fix/{{.Name}}")
+
+	cmd.SetArgs([]string{testBugName})
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, testBugName, store.lastCreatedName)
+	require.Equal(t, "fix/"+testBugName, store.lastCreatedBranch)
+}
+
+func TestCreateCmd_BranchFlagOverridesTemplate(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, "fix/{{.Name}}")
+
+	cmd.SetArgs([]string{testBugName, "--branch", "custom/branch"})
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, "custom/branch", store.lastCreatedBranch)
+}
+
+func TestCreateCmd_InvalidTemplateErrors(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, "{{.Name")
+
+	cmd.SetArgs([]string{testStoryName})
+	err := cmd.Execute()
+	require.Error(t, err)
+	// No store write should have happened.
+	require.Empty(t, store.lastCreatedName)
+}
+
+func TestCreateCmd_EmptyTemplateUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, "")
+
+	cmd.SetArgs([]string{testStoryName})
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, "feat/"+testStoryName, store.lastCreatedBranch)
+}
+
+func TestCreateCmd_InvalidTemplate_NoHooksRun(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+
+	var hooksCalled []string
+
+	captureHook := hookexec.RunnerFunc(func(_ context.Context, cfg hookexec.RunConfig) error {
+		hooksCalled = append(hooksCalled, cfg.Event)
+
+		return nil
+	})
+
+	cmd := story.NewCreateCmd(store, "/code", captureHook, "{{.Name")
+	cmd.SetArgs([]string{testStoryName})
+
+	require.Error(t, cmd.Execute())
+	require.Empty(t, hooksCalled)
+}
+
 func TestCreateCmd_Duplicate(t *testing.T) {
 	t.Parallel()
 
 	store := &stubStore{createErr: coreStory.ErrStoryExists}
-	cmd := story.NewCreateCmd(store, "", hookexec.Noop)
+	cmd := story.NewCreateCmd(store, "", hookexec.Noop, defaultTemplate)
 
 	cmd.SetArgs([]string{testStoryName})
 	require.Error(t, cmd.Execute())
@@ -65,7 +134,7 @@ func TestCreateCmd_PreHookAborts(t *testing.T) {
 		return nil
 	})
 
-	cmd := story.NewCreateCmd(store, "/code", captureHook)
+	cmd := story.NewCreateCmd(store, "/code", captureHook, defaultTemplate)
 	cmd.SetArgs([]string{testStoryName})
 
 	err := cmd.Execute()
@@ -88,7 +157,7 @@ func TestCreateCmd_HooksCalledInOrder(t *testing.T) {
 		return nil
 	})
 
-	cmd := story.NewCreateCmd(store, "/code", captureHook)
+	cmd := story.NewCreateCmd(store, "/code", captureHook, defaultTemplate)
 	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())

--- a/cmd/swm/internal/cli/story/export_test.go
+++ b/cmd/swm/internal/cli/story/export_test.go
@@ -1,0 +1,4 @@
+package story
+
+// BranchFromTemplate exposes branchFromTemplate for black-box tests.
+var BranchFromTemplate = branchFromTemplate

--- a/cmd/swm/internal/cli/story/testhelpers_test.go
+++ b/cmd/swm/internal/cli/story/testhelpers_test.go
@@ -17,6 +17,7 @@ const (
 	testKalbasitOrg = "kalbasit"
 	testSWMRepo     = "swm"
 	testStoryName   = "feat-x"
+	testBugName     = "my-bug"
 	testForceFlag   = "--force"
 )
 

--- a/cmd/swm/internal/config/config.go
+++ b/cmd/swm/internal/config/config.go
@@ -17,11 +17,20 @@ type Plugins struct {
 	Config map[string]map[string]any `toml:"config"`
 }
 
+// Story contains story-creation settings.
+type Story struct {
+	// BranchNameTemplate is a Go text/template string evaluated with .Name set
+	// to the story name. It controls the default branch name produced by
+	// "swm story create". When empty, "feat/{{.Name}}" is used.
+	BranchNameTemplate string `toml:"branch_name_template"`
+}
+
 // Config is the parsed representation of $XDG_CONFIG_HOME/swm/config.toml.
 type Config struct {
 	CodeRoot     string  `toml:"code_root"`
 	DefaultStory string  `toml:"default_story"`
 	Plugins      Plugins `toml:"plugins"`
+	Story        Story   `toml:"story"`
 
 	// HooksConfigHome overrides the XDG config home used for hook discovery.
 	// When empty, the system XDG config home is used. Set in tests to avoid
@@ -34,5 +43,8 @@ func Defaults() *Config {
 	return &Config{
 		CodeRoot:     "~/code",
 		DefaultStory: "_default",
+		Story: Story{
+			BranchNameTemplate: "feat/{{.Name}}",
+		},
 	}
 }

--- a/cmd/swm/internal/config/config.go
+++ b/cmd/swm/internal/config/config.go
@@ -17,6 +17,10 @@ type Plugins struct {
 	Config map[string]map[string]any `toml:"config"`
 }
 
+// DefaultBranchNameTemplate is the branch_name_template used when no value is
+// configured (absent or empty in config.toml).
+const DefaultBranchNameTemplate = "feat/{{.Name}}"
+
 // Story contains story-creation settings.
 type Story struct {
 	// BranchNameTemplate is a Go text/template string evaluated with .Name set
@@ -44,7 +48,7 @@ func Defaults() *Config {
 		CodeRoot:     "~/code",
 		DefaultStory: "_default",
 		Story: Story{
-			BranchNameTemplate: "feat/{{.Name}}",
+			BranchNameTemplate: DefaultBranchNameTemplate,
 		},
 	}
 }

--- a/cmd/swm/internal/config/config_test.go
+++ b/cmd/swm/internal/config/config_test.go
@@ -138,7 +138,7 @@ func TestLoad_StoryBranchNameTemplate_Default(t *testing.T) {
 
 	cfg, err := config.Load(path)
 	require.NoError(t, err)
-	require.Equal(t, "feat/{{.Name}}", cfg.Story.BranchNameTemplate)
+	require.Equal(t, config.DefaultBranchNameTemplate, cfg.Story.BranchNameTemplate)
 }
 
 func TestLoad_StoryBranchNameTemplate_Explicit(t *testing.T) {

--- a/cmd/swm/internal/config/config_test.go
+++ b/cmd/swm/internal/config/config_test.go
@@ -129,6 +129,54 @@ func TestResolveConfigPath_EnvVarEmpty(t *testing.T) {
 	require.Equal(t, filepath.Join("/home/user/.config", "swm", "config.toml"), got)
 }
 
+func TestLoad_StoryBranchNameTemplate_Default(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`code_root = "/code"`), 0o600))
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "feat/{{.Name}}", cfg.Story.BranchNameTemplate)
+}
+
+func TestLoad_StoryBranchNameTemplate_Explicit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+code_root = "/code"
+
+[story]
+branch_name_template = "fix/{{.Name}}"
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "fix/{{.Name}}", cfg.Story.BranchNameTemplate)
+}
+
+func TestLoad_StoryBranchNameTemplate_EmptyString(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+code_root = "/code"
+
+[story]
+branch_name_template = ""
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err)
+	require.Empty(t, cfg.Story.BranchNameTemplate)
+}
+
 func TestLoad_BadTOML(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/config/load.go
+++ b/cmd/swm/internal/config/load.go
@@ -36,10 +36,7 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 
-	cfg := &Config{
-		CodeRoot:     "~/code",
-		DefaultStory: "_default",
-	}
+	cfg := Defaults()
 
 	if err := toml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parsing config file: %w", err)

--- a/openspec/changes/archive/2026-05-18-branch-name-configurable/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-branch-name-configurable/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-18-branch-name-configurable/design.md
+++ b/openspec/changes/archive/2026-05-18-branch-name-configurable/design.md
@@ -55,14 +55,21 @@ branch_name_template = "feat/{{.Name}}"
   group future story settings.
 - Inside `[plugins]` — wrong abstraction; this is a host concern, not a plugin concern.
 
-### 3. Compile template at `Defaults()` / load time, not at call time
+### 3. Parse template per call in `branchFromTemplate`, not at config-load time
 
-**Decision**: Parse the template string once when config is loaded (in `load.go`
-or just before first use in `create.go`). Store the compiled `*template.Template`
-in memory; don't re-parse on every `swm story create`.
+**Decision**: Parse the template string inside `branchFromTemplate` on each
+invocation rather than once at config-load or command-construction time.
 
-This surfaces syntax errors early (config load, not story creation) and avoids
-repeated allocations.
+**Alternatives considered**:
+- Parse at config load (`load.go`) — requires storing a `*template.Template` in
+  `Config`, which is a Go-specific type and complicates the config struct.
+- Parse in `NewCreateCmd` — `NewCreateCmd` returns `*cobra.Command` (no error
+  return), so a parse failure would have to be deferred to `RunE` anyway via a
+  captured closure error; gains nothing over parsing in `branchFromTemplate`.
+
+Parsing per-call keeps `branchFromTemplate` a pure, easily-testable function
+with no external state. For a CLI binary the allocation overhead is negligible —
+`swm story create` is invoked once per user action.
 
 ### 4. Default value: `"feat/{{.Name}}"`
 

--- a/openspec/changes/archive/2026-05-18-branch-name-configurable/design.md
+++ b/openspec/changes/archive/2026-05-18-branch-name-configurable/design.md
@@ -1,0 +1,95 @@
+## Context
+
+`swm story create <name>` defaults the branch to `"feat/" + name` (hardcoded in
+`cmd/swm/internal/cli/story/create.go:27`). There is a `--branch` override but no
+project-wide or user-wide way to change the default pattern. Teams following
+different conventions (e.g. `fix/`, `wael/`, `WM-123/`) must supply `--branch`
+on every invocation.
+
+`Config` (in `cmd/swm/internal/config/config.go`) currently has no story-scoped
+settings. Configuration is loaded from `$XDG_CONFIG_HOME/swm/config.toml` via
+`pelletier/go-toml/v2` and the host passes a `*Config` down to subcommands via
+`root.go`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow users to set a default branch-name pattern in `config.toml`.
+- Support arbitrary templates — not just prefix-style — so `{{.Name}}` can appear
+  anywhere in the pattern.
+- Preserve exact backward compatibility: no config → same `feat/<name>` default.
+- Fail fast with a clear error when the template is syntactically invalid or
+  produces an empty string.
+
+**Non-Goals:**
+- Template variables beyond `.Name` (timestamps, git user, etc.).
+- Per-project or per-story template overrides.
+- Proto / plugin-protocol changes.
+
+## Decisions
+
+### 1. Use `text/template` (stdlib) — not `strings.ReplaceAll` or `fmt.Sprintf`
+
+**Decision**: Use `text/template` with a single data struct `{ Name string }`.
+
+**Alternatives considered**:
+- `strings.ReplaceAll(tpl, "{name}", name)` — simpler but invents a custom
+  syntax users must learn; no tooling support.
+- `fmt.Sprintf`-style `%s` — breaks if the template contains a literal `%`.
+- External template library (e.g. Handlebars) — unnecessary dep for a simple feature.
+
+`text/template` is stdlib, has well-known `{{.Name}}` syntax, and compiling
+the template at config-load time gives instant syntax errors.
+
+### 2. Introduce a `[story]` TOML sub-section inside `Config`
+
+**Decision**: Add a `Story` struct with `BranchNameTemplate string` to `Config`.
+
+```toml
+[story]
+branch_name_template = "feat/{{.Name}}"
+```
+
+**Alternatives considered**:
+- Top-level `branch_name_template` key — pollutes the root namespace; hard to
+  group future story settings.
+- Inside `[plugins]` — wrong abstraction; this is a host concern, not a plugin concern.
+
+### 3. Compile template at `Defaults()` / load time, not at call time
+
+**Decision**: Parse the template string once when config is loaded (in `load.go`
+or just before first use in `create.go`). Store the compiled `*template.Template`
+in memory; don't re-parse on every `swm story create`.
+
+This surfaces syntax errors early (config load, not story creation) and avoids
+repeated allocations.
+
+### 4. Default value: `"feat/{{.Name}}"`
+
+This evaluates identically to the current hardcoded `"feat/" + name`, so no
+existing behaviour changes for users without a config file.
+
+## Risks / Trade-offs
+
+- [Template injection] Config is user-supplied; a malformed template can produce
+  unexpected branch names → Mitigation: validate template produces a non-empty
+  string; run git-safe character checks are out of scope (branch validation is
+  the VCS plugin's responsibility).
+- [New struct field in Config] Downstream code that constructs `Config` directly
+  in tests needs no changes because the zero value of `Story{}` will use the
+  `Defaults()` path → no test breakage expected.
+- [TOML key addition] Existing config files without `[story]` silently use the
+  default — no migration needed.
+
+## Migration Plan
+
+1. Add `Story` struct and `BranchNameTemplate` field to `Config`; update
+   `Defaults()` to set `"feat/{{.Name}}"`.
+2. Teach `NewCreateCmd` to accept the compiled template (or the raw string) and
+   evaluate it instead of `"feat/" + name`.
+3. Wire the config value through `root.go` → `story.NewCreateCmd`.
+4. No rollback needed: the field is optional and defaults to the current value.
+
+## Open Questions
+
+_(none — all decisions resolved above)_

--- a/openspec/changes/archive/2026-05-18-branch-name-configurable/proposal.md
+++ b/openspec/changes/archive/2026-05-18-branch-name-configurable/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+The default branch name for new stories is hardcoded to `feat/<name>` in
+`cmd/swm/internal/cli/story/create.go`. Teams that follow different branch
+naming conventions (e.g. `fix/<name>`, `wael/<name>`, or `WM-123/<name>`)
+must pass `--branch` on every `swm story create` invocation — there is no
+way to configure a project-wide or user-wide default template.
+
+## What Changes
+
+- Add a `branch_name_template` field to the `[story]` TOML section of
+  `$XDG_CONFIG_HOME/swm/config.toml` that accepts a Go `text/template`
+  string with access to the story name (`.Name`).
+- Default value: `feat/{{.Name}}` (backward-compatible — existing behaviour
+  is preserved when no config is set).
+- `swm story create` evaluates the template to derive the default branch
+  name; the `--branch` flag still overrides it unconditionally.
+- Template rendering errors surface as a clear user-facing error before any
+  store write occurs.
+
+## Non-goals
+
+- Changing how the branch name is stored or used after creation (no proto
+  changes; `BranchName` in the story JSON is still a plain string).
+- Dynamic tokens beyond story name (e.g. timestamps, git user) — out of
+  scope for v2.0.
+- Per-project or per-story override of the template.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- **`workflow-commands`** — the default branch name derivation in
+  `swm story create` changes from a hardcoded `"feat/"+name` string to a
+  configurable template evaluated from `Config.Story.BranchNameTemplate`.
+  A delta spec is required.
+
+## Impact
+
+- `cmd/swm/internal/config/config.go` — add `Story` sub-struct with
+  `BranchNameTemplate string` field; update `Defaults()` to set
+  `"feat/{{.Name}}"`.
+- `cmd/swm/internal/cli/story/create.go` — replace `"feat/" + name` with
+  template evaluation; propagate config via `root.go`.
+- No plugin protocol (proto) changes.
+- No forge/session/vcs/picker/hook capability surfaces affected.

--- a/openspec/changes/archive/2026-05-18-branch-name-configurable/specs/workflow-commands/spec.md
+++ b/openspec/changes/archive/2026-05-18-branch-name-configurable/specs/workflow-commands/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: swm story create
+`swm story create <name> [--branch <branch>]` SHALL create a new story JSON file via the story store. If `--branch` is omitted, the branch name SHALL be derived by evaluating the `branch_name_template` value from `config.toml` `[story]` section against the story name. The template MUST use Go `text/template` syntax with a single data variable `.Name` (the story name). When no template is configured, the default template `feat/{{.Name}}` SHALL be used, producing `feat/<name>` (backward-compatible). The command SHALL error if a story with the same name already exists. No worktrees are created (lazy). No plugins are invoked.
+
+If the configured template is syntactically invalid, the command SHALL return an error before any hook or store operation. If the evaluated template produces an empty string, the command SHALL return an error.
+
+Before creating the story JSON the command SHALL run `hookexec.Run` for event `pre-story-create` with the story name set. If any `pre-story-create` hook returns non-zero the command SHALL abort and exit non-zero. After creating the story JSON the command SHALL run `hookexec.Run` for event `post-story-create`; failures are logged but do not affect the exit code.
+
+#### Scenario: Basic story creation
+- **WHEN** `swm story create feat-x` is run with no config template set
+- **THEN** `$XDG_DATA_HOME/swm/stories/feat-x.json` is created with `name="feat-x"`, `branch_name="feat/feat-x"`, and the command exits 0
+
+#### Scenario: Custom branch name via --branch flag
+- **WHEN** `swm story create JIRA-42 --branch fix/JIRA-42-crash` is run
+- **THEN** the story JSON has `branch_name="fix/JIRA-42-crash"`
+
+#### Scenario: Template from config used when --branch omitted
+- **WHEN** `config.toml` sets `branch_name_template = "fix/{{.Name}}"` and `swm story create my-bug` is run without `--branch`
+- **THEN** the story JSON has `branch_name="fix/my-bug"` and the command exits 0
+
+#### Scenario: --branch flag overrides configured template
+- **WHEN** `config.toml` sets `branch_name_template = "fix/{{.Name}}"` and `swm story create my-bug --branch custom/branch` is run
+- **THEN** the story JSON has `branch_name="custom/branch"` (template is not evaluated)
+
+#### Scenario: Invalid template in config yields error
+- **WHEN** `config.toml` sets `branch_name_template = "{{.Name"` (unclosed action) and `swm story create feat-x` is run
+- **THEN** the command exits non-zero with an error message referencing the template parse failure, and no story JSON is created
+
+#### Scenario: Template evaluating to empty string yields error
+- **WHEN** `config.toml` sets `branch_name_template = ""` and `swm story create feat-x` is run
+- **THEN** the command exits non-zero with an error message indicating the branch name cannot be empty, and no story JSON is created
+
+#### Scenario: Duplicate name
+- **WHEN** `swm story create feat-x` is run and a story named `feat-x` already exists
+- **THEN** the command exits non-zero with an appropriate error
+
+#### Scenario: pre-story-create hook aborts creation
+- **WHEN** a `pre-story-create` hook exits non-zero
+- **THEN** the story JSON is NOT created and the command exits non-zero
+
+#### Scenario: post-story-create hook fails — logged, command succeeds
+- **WHEN** all `pre-story-create` hooks pass and a `post-story-create` hook exits non-zero
+- **THEN** the story JSON is created, the failure is logged, and the command exits 0
+
+## ADDED Requirements
+
+### Requirement: branch_name_template config field
+The `[story]` TOML section of `$XDG_CONFIG_HOME/swm/config.toml` SHALL support an optional `branch_name_template` string field. When present and non-empty it MUST be a valid Go `text/template` string. When absent or empty the host SHALL behave as if `"feat/{{.Name}}"` were specified. The template is evaluated with a single data struct exposing `.Name` (the story name string).
+
+#### Scenario: Config with no story section uses default template
+- **WHEN** `config.toml` contains no `[story]` section
+- **THEN** the default template `feat/{{.Name}}` is used for branch name derivation
+
+#### Scenario: Config with branch_name_template overrides default
+- **WHEN** `config.toml` sets `[story] branch_name_template = "wael/{{.Name}}"`
+- **THEN** `swm story create foo` produces a story with `branch_name="wael/foo"`
+
+#### Scenario: Malformed template detected at story create time
+- **WHEN** `config.toml` sets `branch_name_template = "{{.Name"` (parse error)
+- **THEN** `swm story create` returns a non-zero exit code with a descriptive error before running any hooks or writing any files

--- a/openspec/changes/archive/2026-05-18-branch-name-configurable/tasks.md
+++ b/openspec/changes/archive/2026-05-18-branch-name-configurable/tasks.md
@@ -1,0 +1,22 @@
+## 1. Config — add Story section with BranchNameTemplate
+
+- [x] 1.1 `cmd/swm` — Add `Story` struct with `BranchNameTemplate string \`toml:"branch_name_template"\`` field and embed it in `Config` as `Story Story \`toml:"story"\``; update `Defaults()` to set `BranchNameTemplate: "feat/{{.Name}}"`.
+- [x] 1.2 `cmd/swm` — Add config tests: missing `[story]` section produces default `"feat/{{.Name}}"`, explicit value is parsed correctly, empty string in TOML falls through to default via `Defaults()` merge.
+
+## 2. Template evaluation helper (TDD)
+
+- [x] 2.1 `cmd/swm` — Write failing tests in `cmd/swm/internal/cli/story/` for a `branchFromTemplate(tpl, name string) (string, error)` helper: (a) valid template `"feat/{{.Name}}"` + `"feat-x"` → `"feat/feat-x"`, (b) custom template `"fix/{{.Name}}"` + `"my-bug"` → `"fix/my-bug"`, (c) invalid template syntax → error, (d) template producing empty string → error.
+- [x] 2.2 `cmd/swm` — Implement `branchFromTemplate` (unexported) in `cmd/swm/internal/cli/story/create.go` or a new `branch.go` file; make all tests from 2.1 pass.
+
+## 3. Wire template into swm story create (TDD)
+
+- [x] 3.1 `cmd/swm` — Extend `NewCreateCmd` signature to accept `branchNameTemplate string` (raw template string); update call site in `root.go` to pass `cfg.Story.BranchNameTemplate`.
+- [x] 3.2 `cmd/swm` — Update `create_test.go`: (a) no `--branch` + default template → `"feat/<name>"`, (b) no `--branch` + custom template → derived name, (c) `--branch` flag takes precedence over template, (d) invalid template → non-zero exit before hooks run, (e) template producing empty string → non-zero exit before hooks run.
+- [x] 3.3 `cmd/swm` — Replace `branch = "feat/" + name` in `RunE` with `branch, err = branchFromTemplate(branchNameTemplate, name)`; return the error immediately (before hooks) on failure; make all tests from 3.2 pass.
+- [x] 3.4 `cmd/swm` — Update `--branch` flag description to read `"branch name (default: derived from config branch_name_template)"`.
+
+## 4. Verification
+
+- [x] 4.1 Run `task fmt` and fix any formatting issues.
+- [x] 4.2 Run `task lint` and fix any lint issues.
+- [x] 4.3 Run `task test` and confirm all tests pass (unit + integration).

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -26,8 +26,12 @@ Before creating the story JSON the command SHALL run `hookexec.Run` for event `p
 - **THEN** the command exits non-zero with an error message referencing the template parse failure, and no story JSON is created
 
 #### Scenario: Template evaluating to empty string yields error
-- **WHEN** `config.toml` sets `branch_name_template = ""` and `swm story create feat-x` is run
+- **WHEN** `config.toml` sets `branch_name_template = "{{if false}}{{.Name}}{{end}}"` (a syntactically valid template that renders to nothing) and `swm story create feat-x` is run
 - **THEN** the command exits non-zero with an error message indicating the branch name cannot be empty, and no story JSON is created
+
+#### Scenario: Empty branch_name_template uses default
+- **WHEN** `config.toml` sets `branch_name_template = ""` and `swm story create feat-x` is run
+- **THEN** the story JSON has `branch_name="feat/feat-x"` and the command exits 0 (falls back to default `feat/{{.Name}}`)
 
 #### Scenario: Duplicate name
 - **WHEN** `swm story create feat-x` is run and a story named `feat-x` already exists

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -1,19 +1,37 @@
 ### Requirement: swm story create
-`swm story create <name> [--branch <branch>]` SHALL create a new story JSON file via the story store. If `--branch` is omitted, the branch name SHALL default to `feat/<name>`. The command SHALL error if a story with the same name already exists. No worktrees are created (lazy). No plugins are invoked.
+`swm story create <name> [--branch <branch>]` SHALL create a new story JSON file via the story store. If `--branch` is omitted, the branch name SHALL be derived by evaluating the `branch_name_template` value from `config.toml` `[story]` section against the story name. The template MUST use Go `text/template` syntax with a single data variable `.Name` (the story name). When no template is configured, the default template `feat/{{.Name}}` SHALL be used, producing `feat/<name>` (backward-compatible). The command SHALL error if a story with the same name already exists. No worktrees are created (lazy). No plugins are invoked.
+
+If the configured template is syntactically invalid, the command SHALL return an error before any hook or store operation. If the evaluated template produces an empty string, the command SHALL return an error.
 
 Before creating the story JSON the command SHALL run `hookexec.Run` for event `pre-story-create` with the story name set. If any `pre-story-create` hook returns non-zero the command SHALL abort and exit non-zero. After creating the story JSON the command SHALL run `hookexec.Run` for event `post-story-create`; failures are logged but do not affect the exit code.
 
 #### Scenario: Basic story creation
-- **WHEN** `swm story create feat-x` is run
+- **WHEN** `swm story create feat-x` is run with no config template set
 - **THEN** `$XDG_DATA_HOME/swm/stories/feat-x.json` is created with `name="feat-x"`, `branch_name="feat/feat-x"`, and the command exits 0
 
-#### Scenario: Custom branch name
+#### Scenario: Custom branch name via --branch flag
 - **WHEN** `swm story create JIRA-42 --branch fix/JIRA-42-crash` is run
 - **THEN** the story JSON has `branch_name="fix/JIRA-42-crash"`
 
+#### Scenario: Template from config used when --branch omitted
+- **WHEN** `config.toml` sets `branch_name_template = "fix/{{.Name}}"` and `swm story create my-bug` is run without `--branch`
+- **THEN** the story JSON has `branch_name="fix/my-bug"` and the command exits 0
+
+#### Scenario: --branch flag overrides configured template
+- **WHEN** `config.toml` sets `branch_name_template = "fix/{{.Name}}"` and `swm story create my-bug --branch custom/branch` is run
+- **THEN** the story JSON has `branch_name="custom/branch"` (template is not evaluated)
+
+#### Scenario: Invalid template in config yields error
+- **WHEN** `config.toml` sets `branch_name_template = "{{.Name"` (unclosed action) and `swm story create feat-x` is run
+- **THEN** the command exits non-zero with an error message referencing the template parse failure, and no story JSON is created
+
+#### Scenario: Template evaluating to empty string yields error
+- **WHEN** `config.toml` sets `branch_name_template = ""` and `swm story create feat-x` is run
+- **THEN** the command exits non-zero with an error message indicating the branch name cannot be empty, and no story JSON is created
+
 #### Scenario: Duplicate name
-- **WHEN** `swm story create feat-x` is run and `feat-x.json` already exists
-- **THEN** the command exits non-zero with an error message referencing the story name
+- **WHEN** `swm story create feat-x` is run and a story named `feat-x` already exists
+- **THEN** the command exits non-zero with an appropriate error
 
 #### Scenario: pre-story-create hook aborts creation
 - **WHEN** a `pre-story-create` hook exits non-zero
@@ -22,6 +40,21 @@ Before creating the story JSON the command SHALL run `hookexec.Run` for event `p
 #### Scenario: post-story-create hook fails — logged, command succeeds
 - **WHEN** all `pre-story-create` hooks pass and a `post-story-create` hook exits non-zero
 - **THEN** the story JSON is created, the failure is logged, and the command exits 0
+
+### Requirement: branch_name_template config field
+The `[story]` TOML section of `$XDG_CONFIG_HOME/swm/config.toml` SHALL support an optional `branch_name_template` string field. When present and non-empty it MUST be a valid Go `text/template` string. When absent or empty the host SHALL behave as if `"feat/{{.Name}}"` were specified. The template is evaluated with a single data struct exposing `.Name` (the story name string).
+
+#### Scenario: Config with no story section uses default template
+- **WHEN** `config.toml` contains no `[story]` section
+- **THEN** the default template `feat/{{.Name}}` is used for branch name derivation
+
+#### Scenario: Config with branch_name_template overrides default
+- **WHEN** `config.toml` sets `[story] branch_name_template = "wael/{{.Name}}"`
+- **THEN** `swm story create foo` produces a story with `branch_name="wael/foo"`
+
+#### Scenario: Malformed template detected at story create time
+- **WHEN** `config.toml` sets `branch_name_template = "{{.Name"` (parse error)
+- **THEN** `swm story create` returns a non-zero exit code with a descriptive error before running any hooks or writing any files
 
 ### Requirement: swm story remove
 `swm story remove <name> [--force]` SHALL remove a story and all its worktrees. Without `--force`, a confirmation prompt MUST be shown listing all attached projects. The removal sequence SHALL be:


### PR DESCRIPTION
The default branch name for new stories was hardcoded to
"feat/<name>" in the CLI, giving users no way to change
the pattern without passing --branch on every invocation.

Add a [story] TOML section to config.toml with a
branch_name_template field that accepts a Go text/template
string evaluated with .Name set to the story name. The
default value "feat/{{.Name}}" preserves existing behaviour.
An empty or absent template also falls back to this default,
keeping backward compatibility for callers that construct
Config{} directly.

Template syntax errors and templates that evaluate to an
empty string are surfaced as errors before any hooks or
store writes occur. The --branch flag continues to override
the template unconditionally.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>