### PR TITLE
feat: prompt to create story on workspace open

### DIFF
--- a/cmd/swm/go.mod
+++ b/cmd/swm/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/sys v0.42.0
+	golang.org/x/sys v0.44.0
 	google.golang.org/grpc v1.81.1
 )
 
@@ -30,6 +30,7 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/net v0.51.0 // indirect
+	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/cmd/swm/go.mod
+++ b/cmd/swm/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.44.0
+	golang.org/x/term v0.43.0
 	google.golang.org/grpc v1.81.1
 )
 
@@ -30,7 +31,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/cmd/swm/go.sum
+++ b/cmd/swm/go.sum
@@ -83,6 +83,10 @@ golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=
 golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=

--- a/cmd/swm/go.sum
+++ b/cmd/swm/go.sum
@@ -81,8 +81,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/cmd/swm/internal/cli/story/branch.go
+++ b/cmd/swm/internal/cli/story/branch.go
@@ -16,11 +16,11 @@ type branchNameData struct {
 	Name string
 }
 
-// branchFromTemplate evaluates tpl as a Go text/template with .Name set to
+// BranchFromTemplate evaluates tpl as a Go text/template with .Name set to
 // storyName and returns the result. An empty tpl uses the default template
 // "feat/{{.Name}}". Returns an error if the template is syntactically invalid
 // or evaluates to an empty string.
-func branchFromTemplate(tpl, storyName string) (string, error) {
+func BranchFromTemplate(tpl, storyName string) (string, error) {
 	if tpl == "" {
 		tpl = config.DefaultBranchNameTemplate
 	}

--- a/cmd/swm/internal/cli/story/create.go
+++ b/cmd/swm/internal/cli/story/create.go
@@ -64,7 +64,7 @@ func NewCreateCmd(
 			ctx := cmd.Context()
 
 			if branch == "" {
-				derived, err := branchFromTemplate(branchNameTemplate, name)
+				derived, err := BranchFromTemplate(branchNameTemplate, name)
 				if err != nil {
 					return err
 				}

--- a/cmd/swm/internal/cli/story/create.go
+++ b/cmd/swm/internal/cli/story/create.go
@@ -2,7 +2,9 @@
 package story
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/spf13/cobra"
 
@@ -10,6 +12,39 @@ import (
 
 	"github.com/kalbasit/swm/cmd/swm/internal/hookexec"
 )
+
+// CreateWithHooks runs pre-story-create hooks, creates the story with the given
+// branch, then runs post-story-create hooks. Post-hook failure is logged but
+// does not abort (the story was already created successfully).
+func CreateWithHooks(
+	ctx context.Context, store coreStory.Store, hooks hookexec.Runner, codeRoot, name, branch string,
+) error {
+	preCfg := hookexec.RunConfig{
+		Event:     "pre-story-create",
+		CodeRoot:  codeRoot,
+		StoryName: name,
+		WorkDir:   codeRoot,
+	}
+	if err := hooks.Run(ctx, preCfg); err != nil {
+		return fmt.Errorf("pre-story-create hook: %w", err)
+	}
+
+	if _, err := store.Create(ctx, name, branch); err != nil {
+		return fmt.Errorf("creating story %q: %w", name, err)
+	}
+
+	postCfg := hookexec.RunConfig{
+		Event:     "post-story-create",
+		CodeRoot:  codeRoot,
+		StoryName: name,
+		WorkDir:   codeRoot,
+	}
+	if err := hooks.Run(ctx, postCfg); err != nil {
+		slog.WarnContext(ctx, "post-story-create hook failed", "err", err)
+	}
+
+	return nil
+}
 
 // NewCreateCmd returns the `swm story create` command.
 func NewCreateCmd(
@@ -37,30 +72,8 @@ func NewCreateCmd(
 				branch = derived
 			}
 
-			preCfg := hookexec.RunConfig{
-				Event:     "pre-story-create",
-				CodeRoot:  codeRoot,
-				StoryName: name,
-				WorkDir:   codeRoot,
-			}
-
-			if err := hooks.Run(ctx, preCfg); err != nil {
-				return fmt.Errorf("pre-story-create hook: %w", err)
-			}
-
-			if _, err := store.Create(ctx, name, branch); err != nil {
-				return fmt.Errorf("creating story %q: %w", name, err)
-			}
-
-			postCfg := hookexec.RunConfig{
-				Event:     "post-story-create",
-				CodeRoot:  codeRoot,
-				StoryName: name,
-				WorkDir:   codeRoot,
-			}
-
-			if err := hooks.Run(ctx, postCfg); err != nil {
-				return fmt.Errorf("post-story-create hook: %w", err)
+			if err := CreateWithHooks(ctx, store, hooks, codeRoot, name, branch); err != nil {
+				return err
 			}
 
 			cmd.Printf("created story %q with branch %q\n", name, branch)

--- a/cmd/swm/internal/cli/story/create_test.go
+++ b/cmd/swm/internal/cli/story/create_test.go
@@ -14,7 +14,91 @@ import (
 	"github.com/kalbasit/swm/cmd/swm/internal/hookexec"
 )
 
-var errHookFailed = errors.New("hook failed")
+const (
+	eventPreStoryCreate  = "pre-story-create"
+	eventPostStoryCreate = "post-story-create"
+)
+
+var (
+	errHookFailed   = errors.New("hook failed")
+	errStoreFailure = errors.New("disk full")
+)
+
+func TestCreateWithHooks_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+
+	var called []string
+
+	captureHook := hookexec.RunnerFunc(func(_ context.Context, cfg hookexec.RunConfig) error {
+		called = append(called, cfg.Event)
+
+		return nil
+	})
+
+	err := story.CreateWithHooks(context.Background(), store, captureHook, "/code", testStoryName, "feat/"+testStoryName)
+	require.NoError(t, err)
+	require.Equal(t, testStoryName, store.lastCreatedName)
+	require.Equal(t, "feat/"+testStoryName, store.lastCreatedBranch)
+	require.Equal(t, []string{eventPreStoryCreate, eventPostStoryCreate}, called)
+}
+
+func TestCreateWithHooks_PreHookError(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+
+	failPreHook := hookexec.RunnerFunc(func(_ context.Context, cfg hookexec.RunConfig) error {
+		if cfg.Event == eventPreStoryCreate {
+			return errHookFailed
+		}
+
+		return nil
+	})
+
+	err := story.CreateWithHooks(context.Background(), store, failPreHook, "/code", testStoryName, "feat/"+testStoryName)
+	require.Error(t, err)
+	require.Empty(t, store.lastCreatedName)
+}
+
+func TestCreateWithHooks_StoreCreateError(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{createErr: errStoreFailure}
+
+	var postHookCalled bool
+
+	captureHook := hookexec.RunnerFunc(func(_ context.Context, cfg hookexec.RunConfig) error {
+		if cfg.Event == eventPostStoryCreate {
+			postHookCalled = true
+		}
+
+		return nil
+	})
+
+	err := story.CreateWithHooks(context.Background(), store, captureHook, "/code", testStoryName, "feat/"+testStoryName)
+	require.Error(t, err)
+	require.False(t, postHookCalled)
+}
+
+func TestCreateWithHooks_PostHookError(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+
+	failPostHook := hookexec.RunnerFunc(func(_ context.Context, cfg hookexec.RunConfig) error {
+		if cfg.Event == eventPostStoryCreate {
+			return errHookFailed
+		}
+
+		return nil
+	})
+
+	err := story.CreateWithHooks(context.Background(), store, failPostHook, "/code", testStoryName, "feat/"+testStoryName)
+	require.NoError(t, err)
+	require.Equal(t, testStoryName, store.lastCreatedName)
+}
 
 func TestCreateCmd_BasicCreation(t *testing.T) {
 	t.Parallel()
@@ -126,7 +210,7 @@ func TestCreateCmd_PreHookAborts(t *testing.T) {
 
 	captureHook := hookexec.RunnerFunc(func(_ context.Context, cfg hookexec.RunConfig) error {
 		called = append(called, cfg.Event)
-		if cfg.Event == "pre-story-create" {
+		if cfg.Event == eventPreStoryCreate {
 			return errHookFailed
 		}
 
@@ -138,7 +222,7 @@ func TestCreateCmd_PreHookAborts(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	require.Contains(t, called, "pre-story-create")
+	require.Contains(t, called, eventPreStoryCreate)
 	// store.Create should not have been called.
 	require.Empty(t, store.lastCreatedName)
 }
@@ -160,5 +244,5 @@ func TestCreateCmd_HooksCalledInOrder(t *testing.T) {
 	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
-	require.Equal(t, []string{"pre-story-create", "post-story-create"}, called)
+	require.Equal(t, []string{eventPreStoryCreate, eventPostStoryCreate}, called)
 }

--- a/cmd/swm/internal/cli/story/export_test.go
+++ b/cmd/swm/internal/cli/story/export_test.go
@@ -1,4 +1,0 @@
-package story
-
-// BranchFromTemplate exposes branchFromTemplate for black-box tests.
-var BranchFromTemplate = branchFromTemplate

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -2,6 +2,7 @@
 package workspace
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -60,6 +62,36 @@ func grpcCode(err error) codes.Code {
 	return codes.Unknown
 }
 
+// createStory runs pre-story-create hooks, creates the story, then runs post-story-create
+// hooks (post-hook failure is logged but does not abort).
+func createStory(ctx context.Context, store coreStory.Store, hooks hookexec.Runner, codeRoot, name string) error {
+	preCfg := hookexec.RunConfig{
+		Event:     "pre-story-create",
+		CodeRoot:  codeRoot,
+		StoryName: name,
+		WorkDir:   codeRoot,
+	}
+	if err := hooks.Run(ctx, preCfg); err != nil {
+		return fmt.Errorf("pre-story-create hook: %w", err)
+	}
+
+	if _, err := store.Create(ctx, name, "feat/"+name); err != nil {
+		return fmt.Errorf("creating story %q: %w", name, err)
+	}
+
+	postCfg := hookexec.RunConfig{
+		Event:     "post-story-create",
+		CodeRoot:  codeRoot,
+		StoryName: name,
+		WorkDir:   codeRoot,
+	}
+	if err := hooks.Run(ctx, postCfg); err != nil {
+		slog.WarnContext(ctx, "post-story-create hook failed", "err", err)
+	}
+
+	return nil
+}
+
 // ExecFunc is the type used to replace the current process (default: syscall.Exec).
 type ExecFunc func(argv0 string, argv []string, envv []string) error
 
@@ -67,12 +99,26 @@ type ExecFunc func(argv0 string, argv []string, envv []string) error
 type OpenOption func(*openCmdConfig)
 
 type openCmdConfig struct {
-	exec ExecFunc
+	exec  ExecFunc
+	isTTY func() bool
+	stdin io.Reader
 }
 
 // WithExecFunc injects an alternative to syscall.Exec. Intended for tests only.
 func WithExecFunc(fn ExecFunc) OpenOption {
 	return func(c *openCmdConfig) { c.exec = fn }
+}
+
+// WithTTYCheck overrides the TTY detection used by the story-not-found prompt.
+// Intended for tests only.
+func WithTTYCheck(fn func() bool) OpenOption {
+	return func(c *openCmdConfig) { c.isTTY = fn }
+}
+
+// WithStdinReader overrides the stdin reader used by the story-not-found prompt.
+// Intended for tests only.
+func WithStdinReader(r io.Reader) OpenOption {
+	return func(c *openCmdConfig) { c.stdin = r }
 }
 
 // NewOpenCmd returns the `swm workspace open` command.
@@ -84,7 +130,11 @@ func NewOpenCmd(
 	hooks hookexec.Runner,
 	opts ...OpenOption,
 ) *cobra.Command {
-	ocfg := &openCmdConfig{exec: syscall.Exec}
+	ocfg := &openCmdConfig{
+		exec:  syscall.Exec,
+		isTTY: func() bool { return term.IsTerminal(int(os.Stdin.Fd())) },
+		stdin: os.Stdin,
+	}
 	for _, o := range opts {
 		o(ocfg)
 	}
@@ -155,10 +205,35 @@ func NewOpenCmd(
 			st, err := store.Get(ctx, storyName)
 			if err != nil {
 				if errors.Is(err, coreStory.ErrStoryNotFound) {
-					return fmt.Errorf("%w: %s", coreStory.ErrStoryNotFound, storyName)
-				}
+					if !ocfg.isTTY() {
+						return fmt.Errorf("%w: %s", coreStory.ErrStoryNotFound, storyName)
+					}
 
-				return fmt.Errorf("loading story %q: %w", storyName, err)
+					fmt.Fprintf(os.Stderr, "Story %q does not exist. Create it? [y/N]: ", storyName)
+
+					// ReadString returns io.EOF on last line without newline; that's fine — treat partial read as the answer.
+					answer, readErr := bufio.NewReader(ocfg.stdin).ReadString('\n')
+					if readErr != nil && !errors.Is(readErr, io.EOF) {
+						return fmt.Errorf("%w: %s", coreStory.ErrStoryNotFound, storyName)
+					}
+
+					answer = strings.TrimSpace(answer)
+
+					if answer != "y" && answer != "Y" {
+						return fmt.Errorf("%w: %s", coreStory.ErrStoryNotFound, storyName)
+					}
+
+					if err := createStory(ctx, store, hooks, cfg.CodeRoot, storyName); err != nil {
+						return err
+					}
+
+					st, err = store.Get(ctx, storyName)
+					if err != nil {
+						return fmt.Errorf("loading story %q after creation: %w", storyName, err)
+					}
+				} else {
+					return fmt.Errorf("loading story %q: %w", storyName, err)
+				}
 			}
 
 			slog.DebugContext(

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	clistory "github.com/kalbasit/swm/cmd/swm/internal/cli/story"
 	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
@@ -60,36 +61,6 @@ func grpcCode(err error) codes.Code {
 	}
 
 	return codes.Unknown
-}
-
-// createStory runs pre-story-create hooks, creates the story, then runs post-story-create
-// hooks (post-hook failure is logged but does not abort).
-func createStory(ctx context.Context, store coreStory.Store, hooks hookexec.Runner, codeRoot, name string) error {
-	preCfg := hookexec.RunConfig{
-		Event:     "pre-story-create",
-		CodeRoot:  codeRoot,
-		StoryName: name,
-		WorkDir:   codeRoot,
-	}
-	if err := hooks.Run(ctx, preCfg); err != nil {
-		return fmt.Errorf("pre-story-create hook: %w", err)
-	}
-
-	if _, err := store.Create(ctx, name, "feat/"+name); err != nil {
-		return fmt.Errorf("creating story %q: %w", name, err)
-	}
-
-	postCfg := hookexec.RunConfig{
-		Event:     "post-story-create",
-		CodeRoot:  codeRoot,
-		StoryName: name,
-		WorkDir:   codeRoot,
-	}
-	if err := hooks.Run(ctx, postCfg); err != nil {
-		slog.WarnContext(ctx, "post-story-create hook failed", "err", err)
-	}
-
-	return nil
 }
 
 // ExecFunc is the type used to replace the current process (default: syscall.Exec).
@@ -223,7 +194,7 @@ func NewOpenCmd(
 						return fmt.Errorf("%w: %s", coreStory.ErrStoryNotFound, storyName)
 					}
 
-					if err := createStory(ctx, store, hooks, cfg.CodeRoot, storyName); err != nil {
+					if err := clistory.CreateWithHooks(ctx, store, hooks, cfg.CodeRoot, storyName, "feat/"+storyName); err != nil {
 						return err
 					}
 

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -194,7 +194,12 @@ func NewOpenCmd(
 						return fmt.Errorf("%w: %s", coreStory.ErrStoryNotFound, storyName)
 					}
 
-					if err := clistory.CreateWithHooks(ctx, store, hooks, cfg.CodeRoot, storyName, "feat/"+storyName); err != nil {
+					branch, branchErr := clistory.BranchFromTemplate(cfg.Story.BranchNameTemplate, storyName)
+					if branchErr != nil {
+						return fmt.Errorf("deriving branch name: %w", branchErr)
+					}
+
+					if err := clistory.CreateWithHooks(ctx, store, hooks, cfg.CodeRoot, storyName, branch); err != nil {
 						return err
 					}
 

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -189,6 +189,38 @@ func TestOpenCmd_StoryNotFound_TTY_Declines(t *testing.T) {
 	require.False(t, store.createCalled)
 }
 
+func TestOpenCmd_StoryNotFound_TTY_UsesConfigTemplate(t *testing.T) {
+	t.Parallel()
+
+	const customTemplate = "fix/{{.Name}}"
+
+	const storyToCreate = testNonexistentStory
+
+	sess := &stubSess{}
+	cfg := &config.Config{
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
+		Story:        config.Story{BranchNameTemplate: customTemplate},
+	}
+	store := &stubStore{
+		getErrs:    []error{coreStory.ErrStoryNotFound, nil},
+		getStories: []*coreStory.Story{nil, {Name: storyToCreate}},
+	}
+	mgr := &stubMgr{sess: sess}
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
+
+	cmd := workspace.NewOpenCmd(
+		cfg, store, mgr, resolver, hookexec.Noop,
+		workspace.WithTTYCheck(func() bool { return true }),
+		workspace.WithStdinReader(strings.NewReader("y\n")),
+	)
+	cmd.SetArgs([]string{storyToCreate})
+
+	require.NoError(t, cmd.Execute())
+	require.True(t, store.createCalled)
+	require.Equal(t, "fix/"+storyToCreate, store.lastCreatedBranch)
+}
+
 func TestOpenCmd_NoProjects(t *testing.T) {
 	t.Parallel()
 
@@ -1029,9 +1061,10 @@ type stubStore struct {
 	listErr      error
 	listCalled   bool
 
-	createCalled bool
-	createStory  *coreStory.Story
-	createErr    error
+	createCalled      bool
+	createStory       *coreStory.Story
+	createErr         error
+	lastCreatedBranch string
 
 	// getCallCount lets tests return different values on successive Get calls.
 	getCallCount int
@@ -1041,6 +1074,7 @@ type stubStore struct {
 
 func (s *stubStore) Create(_ context.Context, name, branch string) (*coreStory.Story, error) {
 	s.createCalled = true
+	s.lastCreatedBranch = branch
 
 	if s.createErr != nil {
 		return nil, s.createErr

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,13 +24,14 @@ import (
 )
 
 const (
-	testCodeRoot     = "/code"
-	testDefaultStory = "_default"
-	testStoryName    = "feat-x"
-	testBranchName   = "feat/feat-x"
-	testHost         = "github.com"
-	testOwner        = "kalbasit"
-	testSegment      = "swm"
+	testCodeRoot         = "/code"
+	testDefaultStory     = "_default"
+	testStoryName        = "feat-x"
+	testBranchName       = "feat/feat-x"
+	testHost             = "github.com"
+	testOwner            = "kalbasit"
+	testSegment          = "swm"
+	testNonexistentStory = "nonexistent"
 
 	eventPreWorktreeCreate  = "pre-worktree-create"
 	eventPostWorktreeCreate = "post-worktree-create"
@@ -91,7 +93,7 @@ func TestOpenCmd_DefaultStory(t *testing.T) {
 	require.Equal(t, testDefaultStory, sess.lastOpenReq.GetStoryName())
 }
 
-func TestOpenCmd_StoryNotFound(t *testing.T) {
+func TestOpenCmd_StoryNotFound_NonTTY(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
@@ -99,10 +101,92 @@ func TestOpenCmd_StoryNotFound(t *testing.T) {
 	mgr := &stubMgr{}
 	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
 
-	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
-	cmd.SetArgs([]string{"nonexistent"})
+	cmd := workspace.NewOpenCmd(
+		cfg, store, mgr, resolver, hookexec.Noop,
+		workspace.WithTTYCheck(func() bool { return false }),
+	)
+	cmd.SetArgs([]string{testNonexistentStory})
 
-	require.Error(t, cmd.Execute())
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.ErrorIs(t, err, coreStory.ErrStoryNotFound)
+	require.False(t, store.createCalled)
+}
+
+func TestOpenCmd_StoryNotFound_TTY_Confirms(t *testing.T) {
+	t.Parallel()
+
+	const storyToCreate = testNonexistentStory
+
+	sess := &stubSess{}
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	// First Get returns NotFound; after creation the second Get returns the story.
+	store := &stubStore{
+		getErrs:    []error{coreStory.ErrStoryNotFound, nil},
+		getStories: []*coreStory.Story{nil, {Name: storyToCreate}},
+	}
+	mgr := &stubMgr{sess: sess}
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
+
+	cmd := workspace.NewOpenCmd(
+		cfg, store, mgr, resolver, hookexec.Noop,
+		workspace.WithTTYCheck(func() bool { return true }),
+		workspace.WithStdinReader(strings.NewReader("y\n")),
+	)
+	cmd.SetArgs([]string{storyToCreate})
+
+	require.NoError(t, cmd.Execute())
+	require.True(t, store.createCalled)
+	require.Equal(t, storyToCreate, sess.lastOpenReq.GetStoryName())
+}
+
+func TestOpenCmd_StoryNotFound_TTY_PreHookAborts(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getErr: coreStory.ErrStoryNotFound}
+	mgr := &stubMgr{}
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
+
+	hooks := hookexec.RunnerFunc(func(_ context.Context, rc hookexec.RunConfig) error {
+		if rc.Event == "pre-story-create" {
+			return errFakeHook
+		}
+
+		return nil
+	})
+
+	cmd := workspace.NewOpenCmd(
+		cfg, store, mgr, resolver, hooks,
+		workspace.WithTTYCheck(func() bool { return true }),
+		workspace.WithStdinReader(strings.NewReader("y\n")),
+	)
+	cmd.SetArgs([]string{testNonexistentStory})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.False(t, store.createCalled)
+}
+
+func TestOpenCmd_StoryNotFound_TTY_Declines(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getErr: coreStory.ErrStoryNotFound}
+	mgr := &stubMgr{}
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
+
+	cmd := workspace.NewOpenCmd(
+		cfg, store, mgr, resolver, hookexec.Noop,
+		workspace.WithTTYCheck(func() bool { return true }),
+		workspace.WithStdinReader(strings.NewReader("n\n")),
+	)
+	cmd.SetArgs([]string{testNonexistentStory})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.ErrorIs(t, err, coreStory.ErrStoryNotFound)
+	require.False(t, store.createCalled)
 }
 
 func TestOpenCmd_NoProjects(t *testing.T) {
@@ -944,20 +1028,63 @@ type stubStore struct {
 	listStories  []*coreStory.Story
 	listErr      error
 	listCalled   bool
+
+	createCalled bool
+	createStory  *coreStory.Story
+	createErr    error
+
+	// getCallCount lets tests return different values on successive Get calls.
+	getCallCount int
+	getErrs      []error // if set, consumed in order; last value repeated
+	getStories   []*coreStory.Story
 }
 
-func (s *stubStore) Create(context.Context, string, string) (*coreStory.Story, error) {
-	panic("stub")
+func (s *stubStore) Create(_ context.Context, name, branch string) (*coreStory.Story, error) {
+	s.createCalled = true
+
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+
+	if s.createStory != nil {
+		return s.createStory, nil
+	}
+
+	return &coreStory.Story{Name: name, BranchName: branch}, nil
 }
 
 func (s *stubStore) Delete(context.Context, string) error { return nil }
 
 func (s *stubStore) Get(_ context.Context, _ string) (*coreStory.Story, error) {
-	if s.getErr != nil {
+	idx := s.getCallCount
+	s.getCallCount++
+
+	// Per-call error sequence.
+	if len(s.getErrs) > 0 {
+		if idx >= len(s.getErrs) {
+			idx = len(s.getErrs) - 1
+		}
+
+		if s.getErrs[idx] != nil {
+			return nil, s.getErrs[idx]
+		}
+		// nil entry in getErrs → fall through to story lookup
+	} else if s.getErr != nil {
 		return nil, s.getErr
 	}
 
-	if s.getStory != nil {
+	// Per-call story sequence.
+	if len(s.getStories) > 0 {
+		sidx := s.getCallCount - 1
+
+		if sidx >= len(s.getStories) {
+			sidx = len(s.getStories) - 1
+		}
+
+		if s.getStories[sidx] != nil {
+			return s.getStories[sidx], nil
+		}
+	} else if s.getStory != nil {
 		return s.getStory, nil
 	}
 

--- a/nix/packages/swm/default.nix
+++ b/nix/packages/swm/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-X4gHrBIvZJQigbP3HN1Hv43URfBHSGVs7SWzFOU/sns=";
+          vendorHash = "sha256-3QOG6+AnzkgJAqrKwYKdtbNiDssIsdA57vmLzM2XcZc=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/design.md
+++ b/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/design.md
@@ -1,0 +1,83 @@
+## Context
+
+`swm workspace open <name>` resolves a story name via positional arg or `$SWM_STORY`, then
+calls `store.Get(name)`. When the story does not exist, the error surfaces immediately as a
+non-zero exit. There is no hook into the "story not found" path to offer creation.
+
+The story-store `Create` path (called by `swm story create`) is the only way to add a new
+story today. Both commands live in the same host binary (`cmd/swm`) and share the same store
+dependency, so the create path is accessible from the workspace-open handler without any new
+cross-package coupling.
+
+## Goals / Non-Goals
+
+**Goals:**
+- When a named story is not found AND stdin is a TTY, prompt `[y/N]` and create the story
+  before proceeding with the open flow.
+- Preserve exact current behavior for non-TTY stdin (scripts, CI, piped use).
+- Reuse the existing story-creation path including `pre-story-create` / `post-story-create`
+  hooks.
+
+**Non-Goals:**
+- Auto-creation without confirmation.
+- Prompting during the picker flow — the picker only lists existing stories; the prompt only
+  fires when a name is supplied explicitly via positional arg or `$SWM_STORY`.
+- A `--yes` / `--no` flag — the TTY guard is sufficient for scripted safety; adding a flag
+  is YAGNI.
+
+## Decisions
+
+### 1 — TTY detection via `golang.org/x/term`
+
+`term.IsTerminal(int(os.Stdin.Fd()))` gates the prompt.
+
+**Alternatives considered:**
+- `os.Stdin.Stat()` with `ModeCharDevice` — works but `golang.org/x/term` is already
+  vendored (used by the picker path) and its semantics are more explicit.
+- Always prompt — breaks non-TTY callers; rejected.
+
+### 2 — Prompt written to stderr, answer read from stdin
+
+The prompt message is written to `os.Stderr`; the answer is read from `os.Stdin` with
+`bufio.NewReader`. This keeps stdout clean for any programmatic caller and avoids mixing
+the prompt into piped output.
+
+**Alternatives considered:**
+- Open `/dev/tty` directly for both prompt and read — more robust to stdout/stderr
+  redirection, but unnecessary since the TTY guard already ensures stdin is a terminal.
+
+### 3 — Reuse store.Create + hook invocations from the workspace-open handler
+
+Rather than shelling out to `swm story create`, the workspace-open handler calls
+`store.Create(...)` and `hookexec.Run` for `pre-story-create` / `post-story-create`
+directly — identical to what `storyCreateCmd` does. This keeps behavior consistent (hooks
+fire, duplicate detection works) without process spawning.
+
+**Alternatives considered:**
+- Subprocess call to `swm story create` — avoids in-handler code but adds process overhead
+  and loses the in-process store handle; rejected.
+
+### 4 — Prompt fires only for explicit names (arg or `$SWM_STORY`)
+
+Story resolution order is: positional arg → `$SWM_STORY` → picker → `_default`. The prompt
+fires only at steps 1 and 2, because those are the only steps where a user-supplied name
+could be non-existent. The picker enumerates only existing stories (step 3), and `_default`
+always exists (step 4).
+
+## Risks / Trade-offs
+
+- [Risk] A `pre-story-create` hook aborts creation — the workspace open also aborts with a
+  non-zero exit. → Matches `swm story create` behavior; expected.
+- [Risk] Stdin read could interfere with a subsequent picker if both read from stdin. →
+  Not possible: the prompt fires only when the name is explicit (steps 1/2); the picker is
+  invoked only when no explicit name is given (steps 3/4). The paths are mutually exclusive.
+
+## Migration Plan
+
+No migration needed. The change is purely additive: non-TTY callers see no behavioral change.
+Interactive users gain the prompt; existing muscle memory (`swm story create` then
+`swm workspace open`) still works unchanged.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/proposal.md
+++ b/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/proposal.md
@@ -1,0 +1,43 @@
+# Proposal: Create Story on Workspace Open
+
+## Why
+
+`swm workspace open <name>` fails immediately when the named story does not exist,
+forcing users to run `swm story create <name>` as a separate step before they can open a
+workspace. This is unnecessary friction in the common "start a new story" flow.
+
+## Non-goals
+
+- Auto-creating the story silently without confirmation.
+- Changing the behavior of `swm story create`.
+- Altering the picker flow (no-arg case where the story is selected interactively).
+
+## What Changes
+
+- **MODIFIED** `swm workspace open <name>`: when `<name>` does not exist in the story
+  store, prompt the user interactively ("Story 'name' does not exist. Create it? [y/N]").
+  - If confirmed → create the story (equivalent to `swm story create <name>`) then
+    continue with the open flow as normal.
+  - If declined or stdin is not a TTY → exit non-zero with the existing "story not found"
+    error (backward-compatible for scripted use).
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `workflow-commands` — the `swm workspace open` "Story not found" scenario changes:
+  current behavior (immediate non-zero exit) becomes a confirmation prompt that may
+  create the story before proceeding.
+
+## Impact
+
+- `cmd/swm` — `workspace open` subcommand handler.
+- `openspec/specs/workflow-commands/spec.md` — "Story not found" scenario replaced with
+  new "Story not found — user confirms creation" and "Story not found — user declines"
+  scenarios; TTY-detection requirement added.
+- No proto changes required.
+- No new dependencies; TTY detection uses `golang.org/x/term` (already vendored).

--- a/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/specs/workflow-commands/spec.md
+++ b/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/specs/workflow-commands/spec.md
@@ -1,0 +1,196 @@
+## MODIFIED Requirements
+
+### Requirement: swm workspace open
+`swm workspace open [<story-name>] [--kill-pane]` SHALL open (or switch to) the workspace for a story. Story
+resolution follows this precedence:
+
+1. Positional `<story-name>` argument, if provided.
+2. `$SWM_STORY` environment variable, if set and non-empty.
+3. If neither (1) nor (2) resolves a story AND a picker plugin is configured AND a TTY is
+   available: present a **story picker** listing all stories so the user can select one
+   interactively.
+4. If the story picker is unavailable (no picker plugin, no TTY, or picker returns
+   `FailedPrecondition`): fall back to the `default_story` from config (`_default`).
+
+**Story not found — interactive creation:**
+When a story name resolved via step (1) or (2) does not exist in the story store:
+- If stdin is a TTY: prompt the user `Story '<name>' does not exist. Create it? [y/N]: `
+  (written to stderr).
+  - If the user answers `y` or `Y`: create the story (running `pre-story-create` and
+    `post-story-create` hooks as `swm story create` would), then continue with the open flow.
+  - Any other answer: exit non-zero with a "story not found" error.
+- If stdin is NOT a TTY: exit non-zero with a "story not found" error (unchanged behavior).
+
+Before opening the workspace the command SHALL run `hookexec.Run` for event
+`pre-workspace-open` with the story name set. If any `pre-workspace-open` hook returns
+non-zero the command SHALL abort. After the workspace is open the command SHALL run
+`hookexec.Run` for event `post-workspace-open`; failures are logged but do not affect the exit
+code.
+
+**Story picker entry format:**
+
+Each `PickItem` sent to the picker plugin SHALL have:
+- `key`: the raw story name (e.g. `_default`, `feat/workspace-open-picker`)
+- `display`: a terminal-width-aware formatted string:
+  `<story-name>[ (<branch-name>)]   <age> ago   <project1> · <project2> · …`
+  - Branch name in parentheses is shown only when it differs from the story name.
+  - `_default` story MUST display as `_default (main repo)` regardless of branch name.
+  - Age is formatted as a rounded-up single unit: `Xm`, `Xh`, `Xd`, `Xw`, `Xmo`, `Xy`.
+  - Projects are joined with ` · `; the list is trimmed with ` …` if it exceeds available width.
+  - The host detects terminal width via `/dev/tty` → `$COLUMNS` env var → 120 columns default.
+  - Truncation priority (right-to-left): projects list → branch name → story name.
+
+Stories SHALL be sent to the picker sorted by `CreatedAt` descending (most recent first), with
+`_default` pinned last.
+
+**With picker configured and story resolved (from arg, env, or picker selection):**
+1. Run `pre-workspace-open` hooks; abort if any fail.
+2. Resolve story from positional `<story-name>` argument, `$SWM_STORY` env var, or `_default`.
+3. Build a candidate list: all projects already attached to the story plus all repositories discovered under `$CODE_ROOT/repositories/` via `host.ListProjects`.
+4. Stream candidates to `picker.Pick`; each candidate's `display` is its project ID string (e.g. `github.com/kalbasit/swm`) and `key` is the same string.
+5. Receive the selected project ID from the picker.
+6. If the selected project is NOT already attached to the story:
+   a. Run `pre-worktree-create` hooks with full project context (`ProjectHost`, `ProjectPath`, `WorktreePath`, `RepoPath`); abort if any fail.
+   b. **If `storyName` is NOT the `default_story`**: call `vcs.CreateWorktree` for that project. If `storyName` IS the `default_story`, skip this step — the canonical `repositories/` path already exists as the main git checkout.
+   c. Attach the project to the story in the story store.
+   d. Run `post-worktree-create` hooks with the same project context; failures are logged but do not abort.
+7. Call `session.OpenWorkspace` to ensure the workspace is active.
+8. Call `session.OpenPaneGroup` with the derived worktree path for the selected project.
+9. Run `post-workspace-open` hooks.
+10. Build `SwitchToRequest`:
+    - When `--kill-pane` is set AND `$TMUX_PANE` is non-empty: call `session.CurrentContext()` to get the current `workspace_id`; set `close_origin_workspace_id` and `close_origin_pane_id` on the request. If `CurrentContext()` fails or returns an empty `workspace_id`, omit the origin fields (silent no-op).
+    - Otherwise: omit `close_origin_workspace_id` and `close_origin_pane_id`.
+11. Call `session.SwitchTo`; if the response contains a non-empty `exec_argv`, call `syscall.Exec` to replace the host process.
+
+**Without picker configured (fallback):**
+1. Run `pre-workspace-open` hooks; abort if any fail.
+2. Resolve story (arg → env → default).
+3. Load all attached projects.
+4. Call `session.OpenWorkspace({story_name, worktree_paths: {project_key: derived_path}})`.
+5. Run `post-workspace-open` hooks.
+6. Build `SwitchToRequest` applying the same `--kill-pane` logic as step 10 above.
+7. Call `session.SwitchTo` for the first pane group; exec if `exec_argv` is non-empty.
+
+#### Scenario: No arg, no env — story picker shown
+- **WHEN** `swm workspace open` is run with no positional argument, `$SWM_STORY` is unset, picker is configured, and a TTY is available
+- **THEN** the command streams all stories to `picker.Pick` and waits for the user to select one before proceeding to project selection
+
+#### Scenario: Story picker entries include _default as last entry
+- **WHEN** the story picker is shown and both `_default` and feature stories exist
+- **THEN** `_default` appears as the last entry with display text starting with `_default (main repo)`, and all feature stories appear before it sorted by `CreatedAt` descending
+
+#### Scenario: Story picker entry omits branch when equal to story name
+- **WHEN** a story named `feat/my-feature` has `branch_name = "feat/my-feature"`
+- **THEN** its picker display shows `feat/my-feature` with no parenthetical branch name
+
+#### Scenario: Story picker entry shows branch when it differs from story name
+- **WHEN** a story named `jira-42` has `branch_name = "fix/JIRA-42-crash"`
+- **THEN** its picker display shows `jira-42 (fix/JIRA-42-crash)   <age>   <projects>`
+
+#### Scenario: Story picker entry truncates projects to fit terminal width
+- **WHEN** the terminal is 80 columns wide and a story has many attached projects
+- **THEN** the display string ends with ` …` and does not exceed 80 characters
+
+#### Scenario: Story picker cancelled by user
+- **WHEN** the story picker is shown and the user presses Escape or Ctrl-C
+- **THEN** the command exits 0 and no workspace is opened
+
+#### Scenario: Story picker unavailable — falls back to default story
+- **WHEN** `swm workspace open` is run with no arg, no env, and no picker is configured
+- **THEN** the `_default` story is opened using the no-picker fallback path
+
+#### Scenario: Story picker returns FailedPrecondition — falls back to default story
+- **WHEN** `swm workspace open` is run with no arg, no env, picker is configured but no TTY is available
+- **THEN** the story picker returns `FailedPrecondition`, and the command opens `_default` using the no-picker fallback path
+
+#### Scenario: Arg provided — story picker skipped
+- **WHEN** `swm workspace open feat-x` is run
+- **THEN** the story picker is NOT shown; `feat-x` is used directly and the project picker runs for `feat-x`
+
+#### Scenario: $SWM_STORY set — story picker skipped
+- **WHEN** `swm workspace open` is run with `$SWM_STORY=feat-x` and no positional argument
+- **THEN** the story picker is NOT shown; `feat-x` is used directly
+
+#### Scenario: Interactive selection with picker — project already attached
+- **WHEN** `swm workspace open feat-x` is run and picker is configured and `feat-x` has `proj-a` attached
+- **THEN** `pre-workspace-open` runs, picker receives all project candidates, user selects `proj-a`, `OpenWorkspace` and `OpenPaneGroup` are called, `post-workspace-open` runs
+
+#### Scenario: Interactive selection with picker — project not yet attached
+- **WHEN** `swm workspace open feat-x` is run and picker is configured and user selects `proj-b` (not yet attached)
+- **THEN** `pre-worktree-create` hooks run, `vcs.CreateWorktree` is called for `proj-b`, `proj-b` is attached to the story in the store, `post-worktree-create` hooks run, then workspace and pane group are opened
+
+#### Scenario: Interactive selection with picker — _default story, project not yet attached
+- **WHEN** `swm workspace open` is run, `_default` is the resolved story, picker is configured, and the user selects `proj-b` which is not yet attached to `_default`
+- **THEN** `pre-worktree-create` hooks run, `vcs.CreateWorktree` is NOT called (canonical path already exists), `proj-b` is attached to the story in the store, `post-worktree-create` hooks run, then workspace and pane group are opened
+
+#### Scenario: pre-worktree-create hook aborts worktree creation
+- **WHEN** `swm workspace open feat-x` is run and user selects an unattached project and a `pre-worktree-create` hook exits non-zero
+- **THEN** `vcs.CreateWorktree` is NOT called, the project is NOT attached to the story, and the command exits non-zero
+
+#### Scenario: post-worktree-create hook fails — logged, open continues
+- **WHEN** `swm workspace open feat-x` is run, a new worktree is created successfully, and a `post-worktree-create` hook exits non-zero
+- **THEN** the failure is logged, the workspace open proceeds, and the command exits 0
+
+#### Scenario: Project picker cancelled by user
+- **WHEN** a story is resolved and the project picker is shown but the user cancels selection
+- **THEN** the command exits with code 0 and no workspace is opened
+
+#### Scenario: No picker configured — opens all attached projects
+- **WHEN** `swm workspace open feat-x` is run and no picker is configured
+- **THEN** `OpenWorkspace` is called with all attached projects' worktree paths
+
+#### Scenario: Story from environment
+- **WHEN** `swm workspace open` is run with `$SWM_STORY=feat-x` set and no positional argument
+- **THEN** the workspace for `feat-x` is opened
+
+#### Scenario: Positional argument overrides environment variable
+- **WHEN** `swm workspace open other-story` is run with `$SWM_STORY=feat-x` set
+- **THEN** the workspace for `other-story` is opened (positional arg takes priority)
+
+#### Scenario: Story not found — user confirms creation
+- **WHEN** `swm workspace open nonexistent` is run, no story named `nonexistent` exists, stdin is a TTY, and the user answers `y`
+- **THEN** `pre-story-create` hooks run, the story is created in the store, `post-story-create` hooks run, and the open flow continues for the newly created story
+
+#### Scenario: Story not found — user declines creation
+- **WHEN** `swm workspace open nonexistent` is run, no story named `nonexistent` exists, stdin is a TTY, and the user answers anything other than `y`/`Y`
+- **THEN** the command exits with a non-zero code indicating the story was not found
+
+#### Scenario: Story not found — non-TTY stdin
+- **WHEN** `swm workspace open nonexistent` is run, no story named `nonexistent` exists, and stdin is NOT a TTY
+- **THEN** the command exits immediately with a non-zero code indicating the story was not found (no prompt shown)
+
+#### Scenario: Story not found — pre-story-create hook aborts creation
+- **WHEN** `swm workspace open nonexistent` is run, stdin is a TTY, the user confirms creation, and a `pre-story-create` hook exits non-zero
+- **THEN** the story is NOT created and the command exits non-zero
+
+#### Scenario: Story with no projects and no picker
+- **WHEN** `swm workspace open feat-x` is run, no picker is configured, and `feat-x` has no attached projects
+- **THEN** `OpenWorkspace` is called with an empty worktree_paths map
+
+#### Scenario: SwitchTo returns exec_argv — host execs
+- **WHEN** `swm workspace open` is run outside an existing session and `session.SwitchTo` returns a non-empty `exec_argv`
+- **THEN** the host calls `syscall.Exec` with the returned argv, replacing itself
+
+#### Scenario: SwitchTo returns empty exec_argv — already inside session
+- **WHEN** `swm workspace open` is run from inside an existing session and `session.SwitchTo` returns empty `exec_argv`
+- **THEN** the host does NOT call `syscall.Exec`; the session switches in-place
+
+#### Scenario: pre-workspace-open hook aborts open
+- **WHEN** `swm workspace open feat-x` is run and a `pre-workspace-open` hook exits non-zero
+- **THEN** the command aborts before opening the workspace and returns a non-zero exit code
+
+#### Scenario: --kill-pane closes origin pane after switch
+- **WHEN** `swm workspace open feat-x --kill-pane` is run from inside a tmux session with `$TMUX_PANE=%5` set
+- **THEN** `CurrentContext()` is called to get the origin `workspace_id`, `SwitchToRequest` is built with `close_origin_workspace_id` and `close_origin_pane_id = "%5"`, and `SwitchTo` is called with those fields set
+
+#### Scenario: --kill-pane is no-op when TMUX_PANE is unset
+- **WHEN** `swm workspace open feat-x --kill-pane` is run and `$TMUX_PANE` is empty
+- **THEN** `CurrentContext()` is NOT called, `close_origin_pane_id` is omitted from `SwitchToRequest`, and the switch proceeds normally without killing any pane
+
+#### Scenario: --kill-pane is no-op when CurrentContext fails
+- **WHEN** `swm workspace open feat-x --kill-pane` is run, `$TMUX_PANE` is set, but `session.CurrentContext()` returns an error
+- **THEN** the origin fields are omitted from `SwitchToRequest` and the switch proceeds normally
+
+#### Scenario: --kill-pane with exec path
+- **WHEN** `swm workspace open feat-x --kill-pane` is run outside any tmux session and `SwitchTo` returns a non-empty `exec_argv`
+- **THEN** `SwitchToRequest` is built with origin fields set (if `$TMUX_PANE` and `CurrentContext()` succeed), and after `syscall.Exec` the plugin has already killed the origin pane before responding

--- a/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/tasks.md
+++ b/openspec/changes/archive/2026-05-18-create-story-on-workspace-open/tasks.md
@@ -1,0 +1,23 @@
+## 1. Spec update
+
+- [x] 1.1 `openspec/specs/workflow-commands/spec.md` (`cmd/swm`): apply the delta — replace the single "Story not found" scenario with the four new scenarios (user confirms, user declines, non-TTY stdin, pre-story-create hook aborts) and add the interactive-creation prose to the requirement body
+
+## 2. Tests — red phase (cmd/swm)
+
+- [x] 2.1 `cmd/swm`: write failing integration test — `swm workspace open nonexistent` with non-TTY stdin exits non-zero immediately with no prompt (unchanged scripted behavior)
+- [x] 2.2 `cmd/swm`: write failing integration test — `swm workspace open nonexistent` with TTY stdin and user answers `n` exits non-zero
+- [x] 2.3 `cmd/swm`: write failing integration test — `swm workspace open nonexistent` with TTY stdin and user answers `y`, `pre-story-create` hooks run, story is created, open proceeds
+- [x] 2.4 `cmd/swm`: write failing integration test — `swm workspace open nonexistent` with TTY stdin, user answers `y`, a `pre-story-create` hook exits non-zero → story NOT created, command exits non-zero
+
+## 3. Implementation — green phase (cmd/swm)
+
+- [x] 3.1 `cmd/swm`: extract the story-creation logic from `storyCreateCmd` (store.Create + pre/post-story-create hookexec.Run calls) into a shared `createStory(ctx, store, hookExec, name)` helper function
+- [x] 3.2 `cmd/swm`: in the workspace-open handler, after `store.Get(name)` returns a "not found" error, add a TTY check via `golang.org/x/term.IsTerminal(int(os.Stdin.Fd()))`; if not a TTY, return the existing error unchanged
+- [x] 3.3 `cmd/swm`: write the confirmation prompt (`Story '<name>' does not exist. Create it? [y/N]: `) to `os.Stderr` and read one line from `os.Stdin` via `bufio.NewReader`
+- [x] 3.4 `cmd/swm`: on `y`/`Y` answer call `createStory(...)` and continue the open flow on success; on any other answer return the existing "story not found" error
+
+## 4. Verification
+
+- [x] 4.1 `cmd/swm`: run `task fmt` and fix any formatting issues
+- [x] 4.2 `cmd/swm`: run `task lint` and fix any lint issues
+- [x] 4.3 run `task test` and confirm all tests pass

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -147,6 +147,15 @@ resolution follows this precedence:
 4. If the story picker is unavailable (no picker plugin, no TTY, or picker returns
    `FailedPrecondition`): fall back to the `default_story` from config (`_default`).
 
+**Story not found — interactive creation:**
+When a story name resolved via step (1) or (2) does not exist in the story store:
+- If stdin is a TTY: prompt the user `Story '<name>' does not exist. Create it? [y/N]: `
+  (written to stderr).
+  - If the user answers `y` or `Y`: create the story (running `pre-story-create` and
+    `post-story-create` hooks as `swm story create` would), then continue with the open flow.
+  - Any other answer: exit non-zero with a "story not found" error.
+- If stdin is NOT a TTY: exit non-zero with a "story not found" error (unchanged behavior).
+
 Before opening the workspace the command SHALL run `hookexec.Run` for event
 `pre-workspace-open` with the story name set. If any `pre-workspace-open` hook returns
 non-zero the command SHALL abort. After the workspace is open the command SHALL run
@@ -273,9 +282,21 @@ Stories SHALL be sent to the picker sorted by `CreatedAt` descending (most recen
 - **WHEN** `swm workspace open other-story` is run with `$SWM_STORY=feat-x` set
 - **THEN** the workspace for `other-story` is opened (positional arg takes priority)
 
-#### Scenario: Story not found
-- **WHEN** `swm workspace open nonexistent` is run and no story named `nonexistent` exists
+#### Scenario: Story not found — user confirms creation
+- **WHEN** `swm workspace open nonexistent` is run, no story named `nonexistent` exists, stdin is a TTY, and the user answers `y`
+- **THEN** `pre-story-create` hooks run, the story is created in the store, `post-story-create` hooks run, and the open flow continues for the newly created story
+
+#### Scenario: Story not found — user declines creation
+- **WHEN** `swm workspace open nonexistent` is run, no story named `nonexistent` exists, stdin is a TTY, and the user answers anything other than `y`/`Y`
 - **THEN** the command exits with a non-zero code indicating the story was not found
+
+#### Scenario: Story not found — non-TTY stdin
+- **WHEN** `swm workspace open nonexistent` is run, no story named `nonexistent` exists, and stdin is NOT a TTY
+- **THEN** the command exits immediately with a non-zero code indicating the story was not found (no prompt shown)
+
+#### Scenario: Story not found — pre-story-create hook aborts creation
+- **WHEN** `swm workspace open nonexistent` is run, stdin is a TTY, the user confirms creation, and a `pre-story-create` hook exits non-zero
+- **THEN** the story is NOT created and the command exits non-zero
 
 #### Scenario: Story with no projects and no picker
 - **WHEN** `swm workspace open feat-x` is run, no picker is configured, and `feat-x` has no attached projects


### PR DESCRIPTION
When `swm workspace open <name>` is called and the named story does
not exist, instead of immediately exiting non-zero the command now
detects whether stdin is a TTY and, if so, prompts:

Story "`<name>`" does not exist. Create it? [y/N]:

On confirmation it runs the pre-story-create hooks, creates the
story via the store, runs post-story-create hooks, then continues
the open flow as normal. Non-TTY callers (scripts, CI) see no
change — they still get a non-zero exit without a prompt.

