### PR TITLE
feat: default story remove to $SWM_STORY

### DIFF
--- a/cmd/swm/README.md
+++ b/cmd/swm/README.md
@@ -30,10 +30,10 @@ swm story list
 Lists all stories and their attached projects.
 
 ```sh
-swm story remove <name> [-f | --force]
+swm story remove [<name>] [-f | --force]
 ```
 
-Removes a story and all its worktrees. Prompts for confirmation unless `--force` is given.
+Removes a story and all its worktrees. Prompts for confirmation unless `--force` is given. When `<name>` is omitted, the story name is taken from `$SWM_STORY` (set automatically inside any story workspace). Exits with an error if neither is provided.
 
 ### `swm workspace`
 

--- a/cmd/swm/internal/cli/story/remove.go
+++ b/cmd/swm/internal/cli/story/remove.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -27,6 +28,9 @@ type pluginManager interface {
 // errRemovalFailed is returned when one or more steps during story removal fail.
 var errRemovalFailed = errors.New("removal failed")
 
+// errNoStoryName is returned when no story name is provided and $SWM_STORY is unset.
+var errNoStoryName = errors.New("story name required: pass <name> or set $SWM_STORY")
+
 // NewRemoveCmd returns the `swm story remove` command.
 func NewRemoveCmd(
 	store coreStory.Store,
@@ -37,11 +41,20 @@ func NewRemoveCmd(
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "remove <name>",
+		Use:   "remove [<name>]",
 		Short: "Remove a story and all its worktrees",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := args[0]
+			var name string
+			if len(args) == 1 {
+				name = args[0]
+			} else {
+				name = os.Getenv("SWM_STORY")
+				if name == "" {
+					return errNoStoryName
+				}
+			}
+
 			ctx := cmd.Context()
 
 			st, err := store.Get(ctx, name)

--- a/cmd/swm/internal/cli/story/remove.go
+++ b/cmd/swm/internal/cli/story/remove.go
@@ -50,9 +50,10 @@ func NewRemoveCmd(
 				name = args[0]
 			} else {
 				name = os.Getenv("SWM_STORY")
-				if name == "" {
-					return errNoStoryName
-				}
+			}
+
+			if name == "" {
+				return errNoStoryName
 			}
 
 			ctx := cmd.Context()

--- a/cmd/swm/internal/cli/story/remove_test.go
+++ b/cmd/swm/internal/cli/story/remove_test.go
@@ -176,3 +176,50 @@ func TestRemoveCmd_HooksCalledInOrder(t *testing.T) {
 	require.Contains(t, called, "post-worktree-remove")
 	require.Contains(t, called, "post-story-remove")
 }
+
+func TestRemoveCmd_NoArg_SWMStorySet_RemovesStory(t *testing.T) {
+	// No t.Parallel(): t.Setenv is not allowed in parallel tests.
+	t.Setenv("SWM_STORY", testStoryName)
+
+	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
+	mgr := &stubManager{}
+	resolver := layout.NewResolver("/code", "_default")
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testForceFlag})
+
+	require.NoError(t, cmd.Execute())
+	require.True(t, store.deleted)
+	require.Equal(t, testStoryName, store.lastGetName)
+}
+
+func TestRemoveCmd_NoArg_SWMStoryUnset_ReturnsError(t *testing.T) {
+	// No t.Parallel(): t.Setenv is not allowed in parallel tests.
+	t.Setenv("SWM_STORY", "")
+
+	store := &stubStore{}
+	mgr := &stubManager{}
+	resolver := layout.NewResolver("/code", "_default")
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testForceFlag})
+
+	require.Error(t, cmd.Execute())
+	require.False(t, store.deleted)
+}
+
+func TestRemoveCmd_ExplicitArg_OverridesSWMStory(t *testing.T) {
+	// No t.Parallel(): t.Setenv is not allowed in parallel tests.
+	t.Setenv("SWM_STORY", "other-story")
+
+	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
+	mgr := &stubManager{}
+	resolver := layout.NewResolver("/code", "_default")
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testStoryName, testForceFlag})
+
+	require.NoError(t, cmd.Execute())
+	require.True(t, store.deleted)
+	require.Equal(t, testStoryName, store.lastGetName)
+}

--- a/cmd/swm/internal/cli/story/testhelpers_test.go
+++ b/cmd/swm/internal/cli/story/testhelpers_test.go
@@ -28,6 +28,7 @@ var errNotFound = errors.New("not found")
 type stubStore struct {
 	lastCreatedName   string
 	lastCreatedBranch string
+	lastGetName       string
 	createErr         error
 	getStory          *coreStory.Story
 	getErr            error
@@ -54,7 +55,9 @@ func (s *stubStore) Delete(_ context.Context, _ string) error {
 	return s.deleteErr
 }
 
-func (s *stubStore) Get(_ context.Context, _ string) (*coreStory.Story, error) {
+func (s *stubStore) Get(_ context.Context, name string) (*coreStory.Story, error) {
+	s.lastGetName = name
+
 	if s.getErr != nil {
 		return nil, s.getErr
 	}

--- a/cmd/swm/tests/integration/integration_test.go
+++ b/cmd/swm/tests/integration/integration_test.go
@@ -32,11 +32,13 @@ const (
 	testStoryName     = "feat-x"
 	testDefaultStory  = "_default"
 	cmdCreate         = "create"
+	cmdRemove         = "remove"
 	cmdGroupStory     = "story"
 	cmdGroupWorkspace = "workspace"
 	cmdOpen           = "open"
 	cmdClone          = "clone"
 	flagStory         = "--story"
+	flagForce         = "--force"
 )
 
 // setupEnv creates an isolated environment for an integration test.
@@ -149,12 +151,63 @@ func TestStoryRemove(t *testing.T) {
 
 	// Remove story (no projects, so no VCS calls needed).
 	root := cli.NewRootCmd(cfg, mgr, store, resolver)
-	root.SetArgs([]string{cmdGroupStory, "remove", "--force", testStoryName})
+	root.SetArgs([]string{cmdGroupStory, cmdRemove, flagForce, testStoryName})
 	require.NoError(t, root.Execute())
 
 	// Story should be gone.
 	_, err = store.Get(t.Context(), testStoryName)
 	require.Error(t, err)
+}
+
+func TestStoryRemove_NoArg_SWMStorySet(t *testing.T) {
+	// No t.Parallel(): t.Setenv is not allowed in parallel tests.
+	t.Setenv("SWM_STORY", testStoryName)
+
+	cfg, resolver, store, mgr := setupEnv(t)
+
+	_, err := store.Create(t.Context(), testStoryName, "feat/"+testStoryName)
+	require.NoError(t, err)
+
+	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root.SetArgs([]string{cmdGroupStory, cmdRemove, flagForce}) // no name arg
+	require.NoError(t, root.Execute())
+
+	_, err = store.Get(t.Context(), testStoryName)
+	require.Error(t, err, "story should be deleted when $SWM_STORY is set and no arg provided")
+}
+
+func TestStoryRemove_NoArg_SWMStoryUnset_ReturnsError(t *testing.T) {
+	// No t.Parallel(): t.Setenv is not allowed in parallel tests.
+	t.Setenv("SWM_STORY", "")
+
+	cfg, resolver, store, mgr := setupEnv(t)
+
+	_, err := store.Create(t.Context(), testStoryName, "feat/"+testStoryName)
+	require.NoError(t, err)
+
+	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root.SetArgs([]string{cmdGroupStory, cmdRemove, flagForce}) // no name, no env
+	require.Error(t, root.Execute(), "should error when neither arg nor $SWM_STORY is set")
+
+	_, err = store.Get(t.Context(), testStoryName)
+	require.NoError(t, err, "story should NOT be deleted when command errors")
+}
+
+func TestStoryRemove_ExplicitArg_OverridesSWMStory(t *testing.T) {
+	// No t.Parallel(): t.Setenv is not allowed in parallel tests.
+	t.Setenv("SWM_STORY", "other-story")
+
+	cfg, resolver, store, mgr := setupEnv(t)
+
+	_, err := store.Create(t.Context(), testStoryName, "feat/"+testStoryName)
+	require.NoError(t, err)
+
+	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root.SetArgs([]string{cmdGroupStory, cmdRemove, flagForce, testStoryName}) // explicit arg
+	require.NoError(t, root.Execute())
+
+	_, err = store.Get(t.Context(), testStoryName)
+	require.Error(t, err, "explicitly named story should be deleted, not the env-var story")
 }
 
 func TestWorkspaceOpenWithPicker(t *testing.T) {

--- a/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/design.md
+++ b/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/design.md
@@ -1,0 +1,47 @@
+## Context
+
+`swm story remove <name>` currently declares `cobra.ExactArgs(1)`, making the story name a mandatory positional argument. Users running the command from within an active story workspace must manually type or expand `$SWM_STORY` — an environment variable the host already injects into every story workspace session.
+
+Other commands in the same CLI (`swm workspace open`, `swm pr list`, `swm pr create`) already read `$SWM_STORY` as a fallback when no explicit story name is given. This change brings `swm story remove` in line with that established pattern.
+
+The change touches a single file (`cmd/swm/internal/cli/story/remove.go`) and a thin layer of tests.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow `swm story remove` to be invoked with zero positional arguments, resolving the story name from `$SWM_STORY`.
+- Produce a clear error when the argument is omitted and `$SWM_STORY` is unset or empty.
+- Keep all existing invocations (explicit `<name>`) working identically.
+
+**Non-Goals:**
+- Adding env-var fallback to `swm story create` or `swm story list`.
+- Changing the confirmation-prompt logic or the `--force` flag.
+- Adding a config-level default for `story remove`.
+
+## Decisions
+
+### D1: `cobra.MaximumNArgs(1)` instead of `cobra.ExactArgs(1)`
+
+Cobra's built-in arg validators are the idiomatic way to control arity. Changing to `MaximumNArgs(1)` lets Cobra still reject 2+ args with a helpful error, while allowing 0. The name resolution block runs inside `RunE`, after Cobra validates arity.
+
+_Alternative considered_: a custom `Args` validator that also checks `$SWM_STORY` — rejected because it conflates arity validation with business logic and produces confusing error messages.
+
+### D2: Resolution precedence matches other commands
+
+```
+1. Positional <name> argument (if provided)
+2. $SWM_STORY environment variable (if set and non-empty)
+3. Error — cannot proceed without a story name
+```
+
+This is the same precedence used by `swm pr list` and `swm pr create` (`--story` flag → `$SWM_STORY` → error). Consistency lowers the cognitive load for users and readers of the code.
+
+### D3: No interactive picker fallback
+
+`swm workspace open` falls back to an interactive story picker when both the arg and `$SWM_STORY` are absent. `story remove` is a destructive operation; silently presenting a picker for a destructive command would be surprising. If neither source provides a name, the command errors out immediately.
+
+## Risks / Trade-offs
+
+[Accidental removal] A user who forgets they are inside a story workspace might run `swm story remove` intending to remove a different story, only to find the current one removed. → Mitigation: the existing confirmation prompt (listing all attached projects) guards against this in non-`--force` invocations. The `--force` path remains as explicit as before.
+
+[No migration needed] All existing call-sites that pass an explicit `<name>` continue to work — `MaximumNArgs(1)` accepts 0 or 1 args, so the change is purely additive for callers.

--- a/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/proposal.md
+++ b/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+`swm story remove` currently requires the story name as a mandatory positional argument, forcing users to type `swm story remove $SWM_STORY` when they want to remove the story they are currently working in. Since `$SWM_STORY` is already set in every story workspace, the name should default to it so users can simply run `swm story remove` from within a story.
+
+## What Changes
+
+- Make the `<name>` argument to `swm story remove` optional (0 or 1 args).
+- When `<name>` is omitted, resolve it from the `$SWM_STORY` environment variable.
+- If `<name>` is omitted and `$SWM_STORY` is unset or empty, the command SHALL exit non-zero with a clear error message.
+- Update `cmd/swm/README.md` to reflect the new optional argument.
+
+## Non-goals
+
+- Changing the confirmation prompt behaviour.
+- Adding env-var fallback to any other story sub-command (`create`, `list`).
+- Changing the resolution order when the positional arg IS provided.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `workflow-commands` — the requirement for `swm story remove` changes: `<name>` becomes optional with `$SWM_STORY` as the fallback. A delta spec is needed to update the existing requirement and add new scenarios.
+
+## Impact
+
+- `cmd/swm/internal/cli/story/remove.go` — change `cobra.ExactArgs(1)` to `cobra.MaximumNArgs(1)`; add env-var resolution when no arg is supplied.
+- `cmd/swm/internal/cli/story/remove_test.go` — new unit-test scenarios.
+- `cmd/swm/tests/integration/integration_test.go` — extend integration tests.
+- `cmd/swm/README.md` — update usage line for `swm story remove`.
+- `openspec/specs/workflow-commands/spec.md` (via delta) — updated requirement + new scenarios.
+- No proto changes. No new plugins. No config changes.

--- a/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/specs/workflow-commands/spec.md
+++ b/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/specs/workflow-commands/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: swm story remove
+`swm story remove [<name>] [--force]` SHALL remove a story and all its worktrees. The `<name>` argument is optional. When omitted, the story name SHALL be resolved from the `$SWM_STORY` environment variable. If `<name>` is omitted and `$SWM_STORY` is unset or empty, the command SHALL exit non-zero with a descriptive error before performing any work. When `<name>` is supplied it always takes precedence over `$SWM_STORY`.
+
+Without `--force`, a confirmation prompt MUST be shown listing all attached projects. The removal sequence SHALL be:
+1. Run `pre-story-remove` hooks; abort if any fail.
+2. For each attached project: run `pre-worktree-remove` hooks, call `vcs.RemoveWorktree`, run `post-worktree-remove` hooks.
+3. Call `session.CloseWorkspace` if a workspace exists.
+4. Delete the story JSON.
+5. Run `post-story-remove` hooks (failures logged, not fatal).
+
+If any step fails the remaining steps SHALL still be attempted (best-effort cleanup) and a summary of failures is printed.
+
+#### Scenario: With --force skips prompt
+- **WHEN** `swm story remove feat-x --force` is run
+- **THEN** the removal proceeds without any confirmation prompt
+
+#### Scenario: Without --force shows prompt
+- **WHEN** `swm story remove feat-x` is run interactively
+- **THEN** a prompt listing the story's projects is shown; entering `y` proceeds, `n` aborts
+
+#### Scenario: Unknown story
+- **WHEN** `swm story remove nonexistent` is run
+- **THEN** the command exits non-zero with an error indicating the story was not found
+
+#### Scenario: Story with no projects
+- **WHEN** `swm story remove feat-x --force` is run and `feat-x` has no attached projects
+- **THEN** no VCS calls are made and the story JSON is deleted
+
+#### Scenario: pre-story-remove hook aborts removal
+- **WHEN** a `pre-story-remove` hook exits non-zero
+- **THEN** the removal is aborted and the story JSON is NOT deleted
+
+#### Scenario: No arg with SWM_STORY set — removes current story
+- **WHEN** `swm story remove` is run with no positional argument and `$SWM_STORY=feat-x` is set in the environment
+- **THEN** the story named `feat-x` is removed (same behaviour as `swm story remove feat-x`)
+
+#### Scenario: No arg with SWM_STORY set and --force — skips prompt
+- **WHEN** `swm story remove --force` is run with `$SWM_STORY=feat-x` set
+- **THEN** the story `feat-x` is removed without a confirmation prompt
+
+#### Scenario: No arg and SWM_STORY unset — exits with error
+- **WHEN** `swm story remove` is run with no positional argument and `$SWM_STORY` is unset or empty
+- **THEN** the command exits non-zero with an error message indicating that a story name is required, and no removal is attempted
+
+#### Scenario: Explicit arg overrides SWM_STORY
+- **WHEN** `swm story remove other-story` is run with `$SWM_STORY=feat-x` set
+- **THEN** the story `other-story` is removed, not `feat-x`

--- a/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/tasks.md
+++ b/openspec/changes/archive/2026-05-18-swm-story-remove-current-story/tasks.md
@@ -1,0 +1,19 @@
+## 1. Spec — Write failing tests first (TDD red phase)
+
+- [x] 1.1 `cmd/swm` — add unit test cases to `remove_test.go`: (a) no arg + `$SWM_STORY` set removes that story, (b) no arg + `$SWM_STORY` unset returns an error, (c) explicit arg overrides `$SWM_STORY`
+- [x] 1.2 `cmd/swm` — add integration test cases to `tests/integration/integration_test.go` covering the same three scenarios end-to-end
+
+## 2. Implementation (green phase)
+
+- [x] 2.1 `cmd/swm` — in `NewRemoveCmd` change `cobra.ExactArgs(1)` to `cobra.MaximumNArgs(1)`
+- [x] 2.2 `cmd/swm` — in `RunE`, when `len(args) == 0` read `os.Getenv("SWM_STORY")`; if empty return a descriptive error; if set assign to `name`
+
+## 3. Documentation
+
+- [x] 3.1 `cmd/swm` — update `README.md`: change usage line for `swm story remove` from `swm story remove <name> [-f | --force]` to `swm story remove [<name>] [-f | --force]`; add a note that when `<name>` is omitted `$SWM_STORY` is used
+
+## 4. Verify
+
+- [x] 4.1 Run `task fmt` and confirm exit 0
+- [x] 4.2 Run `task lint` and confirm exit 0
+- [x] 4.3 Run `task test` and confirm all tests pass

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -61,7 +61,9 @@ The `[story]` TOML section of `$XDG_CONFIG_HOME/swm/config.toml` SHALL support a
 - **THEN** `swm story create` returns a non-zero exit code with a descriptive error before running any hooks or writing any files
 
 ### Requirement: swm story remove
-`swm story remove <name> [--force]` SHALL remove a story and all its worktrees. Without `--force`, a confirmation prompt MUST be shown listing all attached projects. The removal sequence SHALL be:
+`swm story remove [<name>] [--force]` SHALL remove a story and all its worktrees. The `<name>` argument is optional. When omitted, the story name SHALL be resolved from the `$SWM_STORY` environment variable. If `<name>` is omitted and `$SWM_STORY` is unset or empty, the command SHALL exit non-zero with a descriptive error before performing any work. When `<name>` is supplied it always takes precedence over `$SWM_STORY`.
+
+Without `--force`, a confirmation prompt MUST be shown listing all attached projects. The removal sequence SHALL be:
 1. Run `pre-story-remove` hooks; abort if any fail.
 2. For each attached project: run `pre-worktree-remove` hooks, call `vcs.RemoveWorktree`, run `post-worktree-remove` hooks.
 3. Call `session.CloseWorkspace` if a workspace exists.
@@ -89,6 +91,22 @@ If any step fails the remaining steps SHALL still be attempted (best-effort clea
 #### Scenario: pre-story-remove hook aborts removal
 - **WHEN** a `pre-story-remove` hook exits non-zero
 - **THEN** the removal is aborted and the story JSON is NOT deleted
+
+#### Scenario: No arg with SWM_STORY set — removes current story
+- **WHEN** `swm story remove` is run with no positional argument and `$SWM_STORY=feat-x` is set in the environment
+- **THEN** the story named `feat-x` is removed (same behaviour as `swm story remove feat-x`)
+
+#### Scenario: No arg with SWM_STORY set and --force — skips prompt
+- **WHEN** `swm story remove --force` is run with `$SWM_STORY=feat-x` set
+- **THEN** the story `feat-x` is removed without a confirmation prompt
+
+#### Scenario: No arg and SWM_STORY unset — exits with error
+- **WHEN** `swm story remove` is run with no positional argument and `$SWM_STORY` is unset or empty
+- **THEN** the command exits non-zero with an error message indicating that a story name is required, and no removal is attempted
+
+#### Scenario: Explicit arg overrides SWM_STORY
+- **WHEN** `swm story remove other-story` is run with `$SWM_STORY=feat-x` set
+- **THEN** the story `other-story` is removed, not `feat-x`
 
 ### Requirement: swm clone
 `swm clone <url>` SHALL clone a repository to its canonical path. The flow:


### PR DESCRIPTION
Make `swm story remove [<name>]` optional. When the name argument is
omitted, the command resolves the story from the $SWM_STORY environment
variable, which is already set in every story workspace. If both are
absent the command exits with a clear error.

This mirrors the existing fallback pattern used by `swm workspace open`
and `swm pr list`, letting users run `swm story remove` from within a
story to remove it directly — without typing or expanding $SWM_STORY.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>