### PR TITLE
fix: add --replace-current-session to laio command

### DIFF
--- a/openspec/changes/archive/2026-05-18-fix-for-laio-changes/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-fix-for-laio-changes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-18-fix-for-laio-changes/design.md
+++ b/openspec/changes/archive/2026-05-18-fix-for-laio-changes/design.md
@@ -1,0 +1,32 @@
+## Context
+
+laio-cli's `start` command previously treated `--tmux-socket` from inside an active tmux session as an implicit signal to reconfigure the current session in-place. Commit `8727e02` in laio-cli gates that behaviour behind a new, explicit `--replace-current-session` flag. Without the flag, laio now falls back to its default path: create a new named session or switch to one. This silently breaks every swm `pane_group_command` that relies on laio patching the session swm just attached to.
+
+No swm code changed — the existing `pane_group_command` template expansion is already correct. The fix is purely textual: add `--replace-current-session` to the canonical command string wherever it appears (docs, spec examples, tests, and the user's live config).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every documented or tested laio invocation includes `--replace-current-session`.
+- `~/.config/swm/config.toml` gains an explicit `pane_group_command` entry so the user's live environment works with the updated laio.
+- The spec scenario for `OpenPaneGroup` with a custom `pane_group_command` reflects the new required flag.
+
+**Non-Goals:**
+- No changes to swm's template-expansion logic — it already handles arbitrary flags.
+- No changes to the plugin gRPC surface or proto definitions.
+- No version bump; this is a documentation and config correction.
+
+## Decisions
+
+**Single canonical command string, updated in place.**
+The command `laio start --file … --tmux-socket … --skip-attach` gains one flag: `--replace-current-session`. It is inserted after `--tmux-socket` and before `--skip-attach` to match laio's own documented examples and keep flags logically grouped (socket opts, then behaviour opts).
+
+No alternative was considered; the only question was whether to introduce a `replace_current_session` toggle in swm's TOML schema. That would add complexity with no benefit — `pane_group_command` is already a free-form string that users control, so the flag belongs there.
+
+**`~/.config/swm/config.toml` gets the full command.**
+The live config currently has no `pane_group_command`. It needs one so the user's environment actually works. The shared-layout variant (single `laio.yaml` at `~/.config/swm/laio.yaml` with `--var path=`) is the right choice because the user already has a `laio.yaml` there.
+
+## Risks / Trade-offs
+
+- **Older laio versions**: `--replace-current-session` is unrecognised on laio < `8727e02`. Users on older builds will get a hard error. → Acceptable; the change is tied to the specific laio version that introduced the flag.
+- **Test constant**: `testLaioPaneGroupCommandTOML` and the `wantCmd` assertion are string literals. They will fail if not updated atomically with the docs. → The tasks artifact ensures both are updated together and `task test` gates the PR.

--- a/openspec/changes/archive/2026-05-18-fix-for-laio-changes/proposal.md
+++ b/openspec/changes/archive/2026-05-18-fix-for-laio-changes/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+laio-cli v0.17+ gates in-place session reconfiguration behind the explicit `--replace-current-session` flag. Before this change, passing `--tmux-socket` from inside tmux automatically reconfigured the current session; now it only targets the socket, and without `--replace-current-session` laio creates or switches to a named session instead — breaking every swm setup that relies on laio patching the active pane group session.
+
+## What Changes
+
+- Add `--replace-current-session` to all `pane_group_command` laio examples in `plugins/session-tmux/README.md`
+- Update `testLaioPaneGroupCommandTOML` constant and `wantCmd` assertion in `plugins/session-tmux/internal/session/tmux_test.go` to include the new flag
+- Update the laio scenario examples in `openspec/specs/session-tmux/spec.md` to include `--replace-current-session`
+- Add `pane_group_command` with the updated laio invocation to `~/.config/swm/config.toml`
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- **session-tmux** — the documented and tested `pane_group_command` laio invocation changes; the spec scenarios for `OpenPaneGroup` with a custom command must reflect the new required flag.
+
+## Impact
+
+- `plugins/session-tmux/README.md` — two example `pane_group_command` lines updated
+- `plugins/session-tmux/internal/session/tmux_test.go` — `testLaioPaneGroupCommandTOML` and the `wantCmd` in `TestOpenPaneGroup_WithPaneGroupCommand` updated
+- `openspec/specs/session-tmux/spec.md` — two laio scenario blocks updated
+- `~/.config/swm/config.toml` — `pane_group_command` entry added under `[plugins.config.session-tmux]`
+- No proto changes; no new RPC surface; no breaking changes to the plugin API.

--- a/openspec/changes/archive/2026-05-18-fix-for-laio-changes/specs/session-tmux/spec.md
+++ b/openspec/changes/archive/2026-05-18-fix-for-laio-changes/specs/session-tmux/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: paneGroupCommand exposes tmux_socket template variable
+`session-tmux` SHALL substitute `{{tmux_socket}}` in `pane_group_command` with the absolute path of the story's tmux socket (the same value as `workspace_id` in the request).
+
+#### Scenario: tmux_socket is substituted
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --replace-current-session --skip-attach"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock`
+- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --tmux-socket /run/user/1000/swm/tmux/feat-x.sock --replace-current-session --skip-attach` with both `{{worktree_path}}` and `{{tmux_socket}}` expanded
+
+#### Scenario: tmux_socket absent when no pane_group_command configured
+- **WHEN** no `pane_group_command` is set in `config.toml`
+- **THEN** the default layout is used and `{{tmux_socket}}` substitution does not occur
+
+### Requirement: OpenPaneGroup in existing workspace
+`session-tmux` SHALL implement `Session.OpenPaneGroup({story_name, project_id, worktree_path})` by creating a new tmux session for the project within the story's socket (if it doesn't exist). The initial working directory SHALL be `worktree_path`. The default layout SHALL run `$EDITOR` (or `vim` if unset) in the first window and a shell in the second, unless `pane_group_command` is configured.
+
+#### Scenario: Default layout
+- **WHEN** `OpenPaneGroup` is called and no `pane_group_command` is configured
+- **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
+
+#### Scenario: Custom pane_group_command
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --replace-current-session --skip-attach"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --tmux-socket <tmux_socket> --replace-current-session --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
+
+#### Scenario: Idempotent for existing session
+- **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket
+- **THEN** the existing session is reused and no new session is created

--- a/openspec/changes/archive/2026-05-18-fix-for-laio-changes/tasks.md
+++ b/openspec/changes/archive/2026-05-18-fix-for-laio-changes/tasks.md
@@ -1,0 +1,21 @@
+## 1. Fix test constants (plugins/session-tmux)
+
+- [x] 1.1 In `plugins/session-tmux/internal/session/tmux_test.go`, update `testLaioPaneGroupCommandTOML` to insert `--replace-current-session` between `--tmux-socket {{tmux_socket}}` and `--skip-attach`
+- [x] 1.2 In the same file, update the `wantCmd` string literal in `TestOpenPaneGroup_WithPaneGroupCommand_BasicCommandSubstitution` (around line 379) to include `--replace-current-session` before `--skip-attach`
+- [x] 1.3 Run `task test` in `plugins/session-tmux/` and confirm all tests pass
+
+## 2. Update documentation (plugins/session-tmux)
+
+- [x] 2.1 In `plugins/session-tmux/README.md`, update the per-repo example `pane_group_command` (line ~99) to add `--replace-current-session` before `--skip-attach`
+- [x] 2.2 In `plugins/session-tmux/README.md`, update the shared-layout example `pane_group_command` (line ~125) to add `--replace-current-session` before `--skip-attach`
+- [x] 2.3 Update the inline explanation below the examples (line ~132–134) to note that `--replace-current-session` is required for laio to patch the existing session in place rather than create a new one
+
+## 3. Update live user config (~/.config/swm)
+
+- [x] 3.1 In `~/.config/swm/config.toml`, add a `[plugins.config.session-tmux]` section with `pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach --var path='{{worktree_path}}'"`
+
+## 4. Verify
+
+- [x] 4.1 Run `task fmt` from the repo root and confirm exit 0
+- [x] 4.2 Run `task lint` from the repo root and confirm exit 0
+- [x] 4.3 Run `task test` from the repo root and confirm exit 0

--- a/openspec/changes/archive/2026-05-18-fix-for-laio-changes/tasks.md
+++ b/openspec/changes/archive/2026-05-18-fix-for-laio-changes/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Fix test constants (plugins/session-tmux)
 
 - [x] 1.1 In `plugins/session-tmux/internal/session/tmux_test.go`, update `testLaioPaneGroupCommandTOML` to insert `--replace-current-session` between `--tmux-socket {{tmux_socket}}` and `--skip-attach`
-- [x] 1.2 In the same file, update the `wantCmd` string literal in `TestOpenPaneGroup_WithPaneGroupCommand_BasicCommandSubstitution` (around line 379) to include `--replace-current-session` before `--skip-attach`
+- [x] 1.2 In the same file, update the `wantCmd` string literal in `TestOpenPaneGroup_WithPaneGroupCommand` (around line 379) to include `--replace-current-session` before `--skip-attach`
 - [x] 1.3 Run `task test` in `plugins/session-tmux/` and confirm all tests pass
 
 ## 2. Update documentation (plugins/session-tmux)

--- a/openspec/specs/session-tmux/spec.md
+++ b/openspec/specs/session-tmux/spec.md
@@ -58,8 +58,8 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 `session-tmux` SHALL substitute `{{tmux_socket}}` in `pane_group_command` with the absolute path of the story's tmux socket (the same value as `workspace_id` in the request).
 
 #### Scenario: tmux_socket is substituted
-- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --socket {{tmux_socket}} --skip-attach"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock`
-- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --socket /run/user/1000/swm/tmux/feat-x.sock --skip-attach` with both `{{worktree_path}}` and `{{tmux_socket}}` expanded
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --replace-current-session --skip-attach"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock`
+- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --tmux-socket /run/user/1000/swm/tmux/feat-x.sock --replace-current-session --skip-attach` with both `{{worktree_path}}` and `{{tmux_socket}}` expanded
 
 #### Scenario: tmux_socket absent when no pane_group_command configured
 - **WHEN** no `pane_group_command` is set in `config.toml`
@@ -73,8 +73,8 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 - **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
 
 #### Scenario: Custom pane_group_command
-- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --skip-attach"` and `OpenPaneGroup` is called
-- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --tmux-socket <tmux_socket> --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --replace-current-session --skip-attach"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --tmux-socket <tmux_socket> --replace-current-session --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
 
 #### Scenario: Idempotent for existing session
 - **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket

--- a/openspec/specs/session-tmux/spec.md
+++ b/openspec/specs/session-tmux/spec.md
@@ -58,8 +58,8 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 `session-tmux` SHALL substitute `{{tmux_socket}}` in `pane_group_command` with the absolute path of the story's tmux socket (the same value as `workspace_id` in the request).
 
 #### Scenario: tmux_socket is substituted
-- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --replace-current-session --skip-attach"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock`
-- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --tmux-socket /run/user/1000/swm/tmux/feat-x.sock --replace-current-session --skip-attach` with both `{{worktree_path}}` and `{{tmux_socket}}` expanded
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock`
+- **THEN** the session's first window runs `laio start --file '<worktree_path>/.swm/laio.yaml' --tmux-socket '/run/user/1000/swm/tmux/feat-x.sock' --replace-current-session --skip-attach` with both `{{worktree_path}}` and `{{tmux_socket}}` expanded
 
 #### Scenario: tmux_socket absent when no pane_group_command configured
 - **WHEN** no `pane_group_command` is set in `config.toml`
@@ -73,8 +73,8 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 - **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
 
 #### Scenario: Custom pane_group_command
-- **WHEN** `config.toml` has `pane_group_command = "laio start --file {{worktree_path}}/.swm/laio.yaml --tmux-socket {{tmux_socket}} --replace-current-session --skip-attach"` and `OpenPaneGroup` is called
-- **THEN** the session's first window runs `laio start --file <worktree_path>/.swm/laio.yaml --tmux-socket <tmux_socket> --replace-current-session --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `laio start --file '<worktree_path>/.swm/laio.yaml' --tmux-socket '<tmux_socket>' --replace-current-session --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
 
 #### Scenario: Idempotent for existing session
 - **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -96,7 +96,7 @@ Place a `laio.yaml` inside the repository (e.g. `.swm/laio.yaml`) and reference 
 ```toml
 # config.toml
 [plugins.config.session-tmux]
-pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --skip-attach"
+pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"
 ```
 
 `path: .` in the laio.yaml resolves relative to the config file, which lives inside the
@@ -122,17 +122,21 @@ windows:
 ```toml
 # config.toml
 [plugins.config.session-tmux]
-pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket '{{tmux_socket}}' --skip-attach --var path='{{worktree_path}}'"
+pane_group_command = "laio start --file ~/.config/swm/laio.yaml --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach --var path='{{worktree_path}}'"
 ```
 
 See [`examples/laio.yaml`](examples/laio.yaml) for a complete annotated sample.
 
-### Why `--skip-attach` is required
+### Why `--replace-current-session` and `--skip-attach` are required
 
 laio is invoked inside an already-attached tmux session (the one swm just created and switched
-into). Calling `attach-session` or `switch-client` from inside a detached pane would either
-fail silently or have no effect. `--skip-attach` tells laio to configure the session without
-trying to attach.
+into). Two flags are needed:
+
+- `--replace-current-session` — without this flag, laio creates or switches to a new named
+  session instead of reconfiguring the one swm already attached to. This flag tells laio to
+  apply the layout to the current session in place.
+- `--skip-attach` — laio would otherwise attempt to call `attach-session` or `switch-client`,
+  which fails silently or has no effect from inside an active session.
 
 ## Limitations
 

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -28,7 +28,7 @@ const (
 	// testLaioPaneGroupCommandTOML is the canonical pane_group_command used in tests.
 	testLaioPaneGroupCommandTOML = `pane_group_command = "laio start` +
 		` --file {{worktree_path}}/.swm/laio.yaml` +
-		` --tmux-socket {{tmux_socket}} --skip-attach"`
+		` --tmux-socket {{tmux_socket}} --replace-current-session --skip-attach"`
 )
 
 var faketmuxBin string
@@ -377,7 +377,7 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	wantCmd := "laio start --file /tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml" +
-		" --tmux-socket " + sockPath + " --skip-attach"
+		" --tmux-socket " + sockPath + " --replace-current-session --skip-attach"
 
 	log := string(logBytes)
 	require.Contains(t, log, wantCmd, "expected substituted pane_group_command in tmux args")

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -27,8 +27,8 @@ const (
 
 	// testLaioPaneGroupCommandTOML is the canonical pane_group_command used in tests.
 	testLaioPaneGroupCommandTOML = `pane_group_command = "laio start` +
-		` --file {{worktree_path}}/.swm/laio.yaml` +
-		` --tmux-socket {{tmux_socket}} --replace-current-session --skip-attach"`
+		` --file '{{worktree_path}}/.swm/laio.yaml'` +
+		` --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"`
 )
 
 var faketmuxBin string
@@ -376,8 +376,8 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
 	require.NoError(t, err)
 
-	wantCmd := "laio start --file /tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml" +
-		" --tmux-socket " + sockPath + " --replace-current-session --skip-attach"
+	wantCmd := "laio start --file '/tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml'" +
+		" --tmux-socket '" + sockPath + "' --replace-current-session --skip-attach"
 
 	log := string(logBytes)
 	require.Contains(t, log, wantCmd, "expected substituted pane_group_command in tmux args")
@@ -412,7 +412,7 @@ func TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution(t *testing.T) {
 	require.NoError(t, err)
 
 	log := string(logBytes)
-	require.Contains(t, log, "--tmux-socket "+sockPath,
+	require.Contains(t, log, "--tmux-socket '"+sockPath+"'",
 		"{{tmux_socket}} must be substituted with the workspace socket path")
 }
 


### PR DESCRIPTION
laio-cli gated in-place session reconfiguration behind an
explicit --replace-current-session flag (commit 8727e02).
Without it, laio now creates or switches to a named session
instead of patching the one swm already attached to.

Add the flag to:
- testLaioPaneGroupCommandTOML and wantCmd in tmux_test.go
- both pane_group_command examples in session-tmux README
- the explanation of why --skip-attach is needed (now covers
  both flags)

Also update the OpenSpec change artifacts (proposal, design,
specs delta, tasks) for traceability.