### PR TITLE
feat: add shell completion for bash, zsh, and fish

### DIFF
--- a/cmd/swm/internal/cli/completion_test.go
+++ b/cmd/swm/internal/cli/completion_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/kalbasit/swm/cmd/swm/internal/core/layout"
 )
 
+func TestCompletionCmd_HiddenFromHelp(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	root := cli.NewRootCmd(config.Defaults(), &stubMgr{}, nil, layout.NewResolver("", ""))
+	root.SetOut(&buf)
+	root.SetArgs([]string{"--help"})
+
+	require.NoError(t, root.Execute())
+	require.NotContains(t, buf.String(), "completion")
+}
+
 func TestCompletionCmd(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/cli/completion_test.go
+++ b/cmd/swm/internal/cli/completion_test.go
@@ -1,0 +1,31 @@
+package cli_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/cli"
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
+	"github.com/kalbasit/swm/cmd/swm/internal/core/layout"
+)
+
+func TestCompletionCmd(t *testing.T) {
+	t.Parallel()
+
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			root := cli.NewRootCmd(config.Defaults(), &stubMgr{}, nil, layout.NewResolver("", ""))
+			root.SetOut(&buf)
+			root.SetArgs([]string{"completion", shell})
+
+			require.NoError(t, root.Execute())
+			require.NotEmpty(t, buf.String())
+		})
+	}
+}

--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -36,9 +36,10 @@ func NewRootCmd(
 	var logLevel string
 
 	root := &cobra.Command{
-		Use:          "swm",
-		Short:        "Story-based Workflow Manager",
-		SilenceUsage: true,
+		Use:               "swm",
+		Short:             "Story-based Workflow Manager",
+		SilenceUsage:      true,
+		CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 			var level slog.Level
 			if err := level.UnmarshalText([]byte(logLevel)); err != nil {

--- a/nix/packages/swm/default.nix
+++ b/nix/packages/swm/default.nix
@@ -42,7 +42,7 @@
             export HOME=$(mktemp -d)
           '';
 
-          postInstall = ''
+          postInstall = lib.optionalString (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) ''
             installShellCompletion --cmd swm \
               --bash <($out/bin/swm completion bash) \
               --zsh  <($out/bin/swm completion zsh)  \

--- a/nix/packages/swm/default.nix
+++ b/nix/packages/swm/default.nix
@@ -32,11 +32,21 @@
           };
 
           doCheck = true;
-          nativeBuildInputs = [ pkgs.git ];
+          nativeBuildInputs = [
+            pkgs.git
+            pkgs.installShellFiles
+          ];
 
           preCheck = ''
             export XDG_RUNTIME_DIR=$(mktemp -d)
             export HOME=$(mktemp -d)
+          '';
+
+          postInstall = ''
+            installShellCompletion --cmd swm \
+              --bash <($out/bin/swm completion bash) \
+              --zsh  <($out/bin/swm completion zsh)  \
+              --fish <($out/bin/swm completion fish)
           '';
 
           meta = {

--- a/openspec/changes/archive/2026-05-18-shell-completion/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-shell-completion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/archive/2026-05-18-shell-completion/design.md
+++ b/openspec/changes/archive/2026-05-18-shell-completion/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`swm` is a Cobra-based CLI. Cobra ships with a built-in `completion` subcommand
+(and `GenBashCompletionV2`, `GenZshCompletion`, `GenFishCompletion`, etc.) that
+is registered on the root command by default in Cobra v1.8+. Currently the root
+command does not opt out, so the subcommand should already be present — but no
+completions are installed into the Nix package.
+
+The Nix package (`nix/packages/swm/default.nix`) uses `buildGoModule`. It does
+not currently use `installShellFiles` and has no `postInstall` hook.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose `swm completion bash|zsh|fish|powershell` as a working subcommand.
+- Install completion scripts for bash, zsh, and fish into the Nix profile via
+  `installShellFiles`.
+
+**Non-Goals:**
+- Dynamic argument completion (story names, workspace names, repo slugs) — that
+  requires `ValidArgsFunction` on individual subcommands and is a follow-on.
+- PowerShell installation via Nix (no `installShellCompletion` support for it).
+- Completion for plugin subcommands beyond what Cobra generates statically.
+
+## Decisions
+
+### 1. Use Cobra's built-in completion — no custom completion logic
+
+**Decision:** rely entirely on Cobra's auto-generated `completion` subcommand.
+
+Cobra v1.8 auto-registers `completion` unless `root.CompletionOptions.DisableDefaultCmd = true`.
+The current root command does not set this option, so the subcommand is already
+present. No Go code changes are needed for basic completion.
+
+If `swm completion bash` is tested and found absent, the fix is a single line:
+`root.InitDefaultCompletionCmd()` (or removing any `DisableDefaultCmd` setting).
+
+**Alternative considered:** write a custom `completion` subcommand that calls
+the individual `Gen*` methods. Rejected — Cobra's built-in is functionally
+identical and eliminates maintenance burden.
+
+### 2. Generate and install completions in Nix `postInstall`
+
+**Decision:** add `installShellFiles` to `nativeBuildInputs` and a `postInstall`
+hook that runs the built binary to generate scripts, then installs them.
+
+```nix
+nativeBuildInputs = [ pkgs.git pkgs.installShellFiles ];
+
+postInstall = ''
+  installShellCompletion --cmd swm \
+    --bash <($out/bin/swm completion bash) \
+    --zsh  <($out/bin/swm completion zsh)  \
+    --fish <($out/bin/swm completion fish)
+'';
+```
+
+`installShellCompletion` from `installShellFiles` places scripts at the
+conventional paths (`share/bash-completion/completions/`, `share/zsh/site-functions/`,
+`share/fish/vendor_completions.d/`) so that Nix profiles wire them up
+automatically.
+
+**Alternative considered:** commit static completion scripts to the repo and
+copy them at build time. Rejected — scripts would diverge from the command tree
+as `swm` evolves; generating at build time is always in sync.
+
+## Risks / Trade-offs
+
+- [Risk] `postInstall` runs the binary on the build host — fails if binary is
+  not host-executable (e.g. cross-compilation). → Mitigation: `swm` is only
+  packaged for native targets today; if cross-compilation is added later, guard
+  `postInstall` with `stdenv.hostPlatform == stdenv.buildPlatform`.
+
+- [Trade-off] Static completion (no dynamic arg completion). Users get
+  subcommand and flag completion but not story/workspace name completion until a
+  follow-on change adds `ValidArgsFunction` to the relevant subcommands.

--- a/openspec/changes/archive/2026-05-18-shell-completion/proposal.md
+++ b/openspec/changes/archive/2026-05-18-shell-completion/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`swm` has no shell completion, making subcommands, flags, and arguments
+undiscoverable via tab-completion in bash, zsh, or fish. Cobra provides this
+for free once wired up; it only needs to be activated and installed.
+
+## What Changes
+
+- Add Cobra's built-in `completion` subcommand to the `swm` root command so
+  users can run `swm completion bash|zsh|fish|powershell`.
+- Add `installShellFiles` to the `nix/packages/swm/default.nix` package and
+  generate completion scripts at build time so they are installed into the
+  Nix profile alongside the binary.
+
+## Capabilities
+
+### New Capabilities
+
+- `shell-completion` — the `swm completion` subcommand and Nix-side
+  installation of generated completion scripts for bash, zsh, and fish.
+
+### Modified Capabilities
+
+<!-- none -->
+
+## Impact
+
+- `cmd/swm/internal/cli/root.go` — enable Cobra completion; no proto changes.
+- `nix/packages/swm/default.nix` — add `installShellFiles` native build input
+  and a `postInstall` hook that generates and installs the completion scripts.

--- a/openspec/changes/archive/2026-05-18-shell-completion/specs/shell-completion/spec.md
+++ b/openspec/changes/archive/2026-05-18-shell-completion/specs/shell-completion/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Completion subcommand
+
+`swm` MUST expose a `completion` subcommand that accepts a shell name
+(`bash`, `zsh`, `fish`, `powershell`) and writes a valid completion script
+for that shell to stdout.
+
+#### Scenario: Bash completion script
+
+- **WHEN** the user runs `swm completion bash`
+- **THEN** a valid bash completion script is printed to stdout and exits 0
+
+#### Scenario: Zsh completion script
+
+- **WHEN** the user runs `swm completion zsh`
+- **THEN** a valid zsh completion script is printed to stdout and exits 0
+
+#### Scenario: Fish completion script
+
+- **WHEN** the user runs `swm completion fish`
+- **THEN** a valid fish completion script is printed to stdout and exits 0
+
+#### Scenario: PowerShell completion script
+
+- **WHEN** the user runs `swm completion powershell`
+- **THEN** a valid PowerShell completion script is printed to stdout and exits 0
+
+#### Scenario: Completion covers all top-level subcommands
+
+- **WHEN** the bash completion script is sourced and the user types `swm <TAB>`
+- **THEN** all registered top-level subcommands appear as candidates
+  (`story`, `workspace`, `pr`, `clone`, `completion`)
+
+### Requirement: Nix shell completion installation
+
+The `swm` Nix package MUST install shell completion scripts for bash, zsh,
+and fish into the conventional locations so that Nix profiles wire them up
+automatically.
+
+#### Scenario: Bash completion installed
+
+- **WHEN** the `swm` Nix package is built
+- **THEN** a bash completion file for `swm` is present under
+  `$out/share/bash-completion/completions/`
+
+#### Scenario: Zsh completion installed
+
+- **WHEN** the `swm` Nix package is built
+- **THEN** a zsh completion file (`_swm`) is present under
+  `$out/share/zsh/site-functions/`
+
+#### Scenario: Fish completion installed
+
+- **WHEN** the `swm` Nix package is built
+- **THEN** a fish completion file for `swm` is present under
+  `$out/share/fish/vendor_completions.d/`

--- a/openspec/changes/archive/2026-05-18-shell-completion/tasks.md
+++ b/openspec/changes/archive/2026-05-18-shell-completion/tasks.md
@@ -1,0 +1,29 @@
+## 1. Verify Cobra completion subcommand (cmd/swm)
+
+- [x] 1.1 Run `swm completion bash` against a locally built binary and confirm it exits 0 with non-empty output
+- [x] 1.2 If the subcommand is absent (e.g. `DisableDefaultCmd` is set in `root.go`), call `root.InitDefaultCompletionCmd()` or remove the option to re-enable it
+
+## 2. Tests (cmd/swm)
+
+- [x] 2.1 Write a table-driven unit test in `cmd/swm/internal/cli/` (e.g. `completion_test.go`) that invokes the root command with `completion <shell>` for each of `bash`, `zsh`, `fish`, `powershell` and asserts exit code 0 and non-empty stdout
+- [x] 2.2 Run `task test` in `cmd/swm` and confirm the new tests pass
+
+## 3. Nix packaging (nix/packages/swm)
+
+- [x] 3.1 Add `pkgs.installShellFiles` to `nativeBuildInputs` in `nix/packages/swm/default.nix` (alongside `pkgs.git`)
+- [x] 3.2 Add a `postInstall` hook that generates and installs completions:
+  ```nix
+  postInstall = ''
+    installShellCompletion --cmd swm \
+      --bash <($out/bin/swm completion bash) \
+      --zsh  <($out/bin/swm completion zsh)  \
+      --fish <($out/bin/swm completion fish)
+  '';
+  ```
+- [x] 3.3 Build the package with `nix build .#swm` and verify completion files exist under `result/share/bash-completion/`, `result/share/zsh/site-functions/`, and `result/share/fish/vendor_completions.d/`
+
+## 4. Final verification
+
+- [x] 4.1 Run `task fmt` — confirm exit 0 with no diff
+- [x] 4.2 Run `task lint` — confirm exit 0
+- [x] 4.3 Run `task test` — confirm all tests pass

--- a/openspec/specs/shell-completion/spec.md
+++ b/openspec/specs/shell-completion/spec.md
@@ -1,0 +1,63 @@
+## Purpose
+
+Shell completion support for the `swm` CLI, covering both the runtime
+`completion` subcommand and Nix-level installation of completion scripts into
+conventional share directories.
+
+## Requirements
+
+### Requirement: Completion subcommand
+
+`swm` MUST expose a `completion` subcommand that accepts a shell name
+(`bash`, `zsh`, `fish`, `powershell`) and writes a valid completion script
+for that shell to stdout.
+
+#### Scenario: Bash completion script
+
+- **WHEN** the user runs `swm completion bash`
+- **THEN** a valid bash completion script is printed to stdout and exits 0
+
+#### Scenario: Zsh completion script
+
+- **WHEN** the user runs `swm completion zsh`
+- **THEN** a valid zsh completion script is printed to stdout and exits 0
+
+#### Scenario: Fish completion script
+
+- **WHEN** the user runs `swm completion fish`
+- **THEN** a valid fish completion script is printed to stdout and exits 0
+
+#### Scenario: PowerShell completion script
+
+- **WHEN** the user runs `swm completion powershell`
+- **THEN** a valid PowerShell completion script is printed to stdout and exits 0
+
+#### Scenario: Completion covers all top-level subcommands
+
+- **WHEN** the bash completion script is sourced and the user types `swm <TAB>`
+- **THEN** all registered top-level subcommands appear as candidates
+  (`story`, `workspace`, `pr`, `clone`, `completion`)
+
+### Requirement: Nix shell completion installation
+
+The `swm` Nix package MUST install shell completion scripts for bash, zsh,
+and fish into the conventional locations so that Nix profiles wire them up
+automatically.
+
+#### Scenario: Bash completion installed
+
+- **WHEN** the `swm` Nix package is built
+- **THEN** a bash completion file for `swm` is present under
+  `$out/share/bash-completion/completions/`
+
+#### Scenario: Zsh completion installed
+
+- **WHEN** the `swm` Nix package is built
+- **THEN** a zsh completion file (`_swm`) is present under
+  `$out/share/zsh/site-functions/`
+
+#### Scenario: Fish completion installed
+
+- **WHEN** the `swm` Nix package is built
+- **THEN** a fish completion file for `swm` is present under
+  `$out/share/fish/vendor_completions.d/`


### PR DESCRIPTION
Cobra v1.9.1 auto-registers a `completion` subcommand on the root
command. This change wires it up end-to-end by installing the
generated scripts into the Nix package.

- Add installShellFiles nativeBuildInput and a postInstall hook to
  nix/packages/swm/default.nix so that `nix build .#swm` installs
  completion scripts at the conventional share/ paths; symlinkJoin
  in swm-full propagates them automatically.
- Add completion_test.go verifying all four shells exit 0 with
  non-empty output through the public NewRootCmd interface.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>