### PR TITLE
test: run hookexec tests sequentially

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,6 +119,14 @@ linters:
         linters:
           - forbidigo
           - gochecknoglobals
+      # hookexec tests must run sequentially to prevent an inherent Linux ETXTBSY race:
+      # when parallel tests run concurrently, a forked child from one test can inherit
+      # an open write fd to a temp inode that another test later renames to its hook
+      # path; execve on that inode then fails because the child's inherited fd is still
+      # open. Sequential execution eliminates all concurrent fork+write windows.
+      - path: cmd/swm/internal/hookexec/hookexec_test\.go$
+        linters:
+          - paralleltest
     paths:
       # Generated proto Go code: skip linting entirely.
       # Match by suffix so patterns work both from the workspace root and from

--- a/cmd/swm/internal/hookexec/hookexec_test.go
+++ b/cmd/swm/internal/hookexec/hookexec_test.go
@@ -106,8 +106,6 @@ func installFakehook(t *testing.T, tierDir, event, name string) {
 }
 
 func TestRun_NoHooksExist(t *testing.T) {
-	t.Parallel()
-
 	// No hooks exist — should succeed silently.
 	cfg := hookexec.RunConfig{
 		Event:      "pre-story-create",
@@ -120,8 +118,6 @@ func TestRun_NoHooksExist(t *testing.T) {
 }
 
 func TestRun_LexicalOrder(t *testing.T) {
-	t.Parallel()
-
 	configHome := t.TempDir()
 
 	sentinelDir := t.TempDir()
@@ -175,8 +171,6 @@ func TestRun_PreHookAborts(t *testing.T) {
 }
 
 func TestRun_PostHookFailsButContinues(t *testing.T) {
-	t.Parallel()
-
 	configHome := t.TempDir()
 
 	sentinelDir := t.TempDir()
@@ -200,8 +194,6 @@ func TestRun_PostHookFailsButContinues(t *testing.T) {
 }
 
 func TestRun_EnvVarsSet(t *testing.T) {
-	t.Parallel()
-
 	configHome := t.TempDir()
 
 	logFile := filepath.Join(t.TempDir(), "env.log")
@@ -236,8 +228,6 @@ func TestRun_EnvVarsSet(t *testing.T) {
 }
 
 func TestRun_StdinJSON(t *testing.T) {
-	t.Parallel()
-
 	configHome := t.TempDir()
 
 	logFile := filepath.Join(t.TempDir(), "stdin.log")
@@ -268,8 +258,6 @@ func TestRun_StdinJSON(t *testing.T) {
 }
 
 func TestRun_WorkDirIsSet(t *testing.T) {
-	t.Parallel()
-
 	configHome := t.TempDir()
 	workDir := t.TempDir()
 	logFile := filepath.Join(t.TempDir(), "pwd.log")
@@ -293,8 +281,6 @@ func TestRun_WorkDirIsSet(t *testing.T) {
 }
 
 func TestRun_WorkDirEmpty_InheritsCwd(t *testing.T) {
-	t.Parallel()
-
 	configHome := t.TempDir()
 	logFile := filepath.Join(t.TempDir(), "pwd.log")
 


### PR DESCRIPTION
The atomicInstallExec fix (write-temp-rename) was correct but
incomplete. It closes the write fd in the parent before rename, but
any concurrent fork() inherits the fd before it is closed. After the
parent closes and renames, the forked child still holds that inode
open for writing. When the test then execs the renamed path the kernel
sees the child's inherited fd and returns ETXTBSY.

The only portable fix without coordination in production code is
sequential execution: when no two tests run concurrently, no fork can
happen while another test has a write fd open, making the race
impossible.

Remove t.Parallel() from all seven hookexec tests and add a scoped
paralleltest linter exclusion in .golangci.yml with an explanation.