### PR TITLE
feat: add SWM_PLUGIN_PATH for dev plugin override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 cmd/swm/swm
 plugins/*/swm-plugin-*
+/.dev-bin/
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/adrg/xdg"
@@ -285,12 +284,9 @@ func (m *Manager) capabilityName(capability string) (string, error) {
 func (m *Manager) discover(capability, name string) (string, error) {
 	binary := "swm-plugin-" + capability + "-" + name
 
-	// 0. SWM_PLUGIN_PATH: colon-separated list, searched left-to-right.
+	// 0. SWM_PLUGIN_PATH: platform-specific path list, searched left-to-right.
 	// Non-existent or non-directory entries are silently skipped.
-	for _, dir := range strings.Split(os.Getenv("SWM_PLUGIN_PATH"), ":") {
-		if dir == "" {
-			continue
-		}
+	for _, dir := range filepath.SplitList(os.Getenv("SWM_PLUGIN_PATH")) {
 
 		candidate := filepath.Join(dir, binary)
 		if _, err := os.Stat(candidate); err == nil {

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/adrg/xdg"
@@ -280,9 +281,22 @@ func (m *Manager) capabilityName(capability string) (string, error) {
 }
 
 // discover finds the binary for the plugin providing the given capability with the given name.
-// Search order: (1) explicit config path, (2) XDG plugins dir, (3) PATH.
+// Search order: (0) SWM_PLUGIN_PATH dirs, (1) explicit config path, (2) XDG plugins dir, (3) PATH.
 func (m *Manager) discover(capability, name string) (string, error) {
 	binary := "swm-plugin-" + capability + "-" + name
+
+	// 0. SWM_PLUGIN_PATH: colon-separated list, searched left-to-right.
+	// Non-existent or non-directory entries are silently skipped.
+	for _, dir := range strings.Split(os.Getenv("SWM_PLUGIN_PATH"), ":") {
+		if dir == "" {
+			continue
+		}
+
+		candidate := filepath.Join(dir, binary)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
 
 	// 1. Explicit config path.
 	if explicit, ok := m.cfg.Plugins.Paths[name]; ok {

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -271,6 +271,121 @@ func TestGet_NoDebugLogs_AtWarnLevel(t *testing.T) { //nolint:paralleltest // mu
 	require.NotContains(t, sink.String(), `"@level":"trace"`)
 }
 
+// copyBinary copies src to dst with executable permissions.
+func copyBinary(t *testing.T, src, dst string) {
+	t.Helper()
+
+	data, err := os.ReadFile(src) //nolint:gosec // reading trusted test binary
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst, data, 0o755)) //nolint:gosec // binary must be executable
+}
+
+func TestDiscover_SWMPluginPath(t *testing.T) {
+	// Cannot use t.Parallel with t.Setenv.
+
+	t.Run("finds binary in SWM_PLUGIN_PATH", func(t *testing.T) {
+		dir := t.TempDir()
+		copyBinary(t, fakeVCSBin, filepath.Join(dir, "swm-plugin-vcs-fake"))
+		t.Setenv("SWM_PLUGIN_PATH", dir)
+
+		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+		raw, err := mgr.Get(context.Background(), "vcs")
+		require.NoError(t, err)
+		require.NotNil(t, raw)
+	})
+
+	t.Run("takes precedence over PATH", func(t *testing.T) {
+		devDir := t.TempDir()
+		sysDir := t.TempDir()
+
+		copyBinary(t, fakeVCSBin, filepath.Join(devDir, "swm-plugin-vcs-fake"))
+		// dummy file on PATH — valid executable size but not a go-plugin binary
+		require.NoError(t, os.WriteFile(filepath.Join(sysDir, "swm-plugin-vcs-fake"), []byte("#!/bin/sh\nexit 1"), 0o755)) //nolint:gosec // test dummy
+
+		t.Setenv("SWM_PLUGIN_PATH", devDir)
+		t.Setenv("PATH", sysDir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+
+		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+		raw, err := mgr.Get(context.Background(), "vcs")
+		require.NoError(t, err)
+		require.NotNil(t, raw)
+	})
+
+	t.Run("takes precedence over explicit config path", func(t *testing.T) {
+		devDir := t.TempDir()
+
+		copyBinary(t, fakeVCSBin, filepath.Join(devDir, "swm-plugin-vcs-fake"))
+
+		// dummy file at explicit config path — exists but not a real plugin
+		dummyPath := filepath.Join(t.TempDir(), "swm-plugin-vcs-fake")
+		require.NoError(t, os.WriteFile(dummyPath, []byte("#!/bin/sh\nexit 1"), 0o755)) //nolint:gosec // test dummy
+
+		t.Setenv("SWM_PLUGIN_PATH", devDir)
+
+		cfg := &config.Config{
+			Plugins: config.Plugins{
+				VCS:   fakePluginName,
+				Paths: map[string]string{fakePluginName: dummyPath},
+			},
+		}
+
+		mgr := pluginmgr.New(cfg, "")
+		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+		raw, err := mgr.Get(context.Background(), "vcs")
+		require.NoError(t, err)
+		require.NotNil(t, raw)
+	})
+
+	t.Run("colon-separated list searched left-to-right", func(t *testing.T) {
+		dir1 := t.TempDir()
+		dir2 := t.TempDir()
+
+		// Binary only in dir2.
+		copyBinary(t, fakeVCSBin, filepath.Join(dir2, "swm-plugin-vcs-fake"))
+		t.Setenv("SWM_PLUGIN_PATH", dir1+":"+dir2)
+
+		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+		raw, err := mgr.Get(context.Background(), "vcs")
+		require.NoError(t, err)
+		require.NotNil(t, raw)
+	})
+
+	t.Run("non-existent entries silently skipped", func(t *testing.T) {
+		realDir := t.TempDir()
+		copyBinary(t, fakeVCSBin, filepath.Join(realDir, "swm-plugin-vcs-fake"))
+		t.Setenv("SWM_PLUGIN_PATH", "/nonexistent-pluginmgr-test:"+realDir)
+
+		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+		raw, err := mgr.Get(context.Background(), "vcs")
+		require.NoError(t, err)
+		require.NotNil(t, raw)
+	})
+
+	t.Run("unset leaves existing discovery unchanged", func(t *testing.T) {
+		t.Setenv("SWM_PLUGIN_PATH", "")
+
+		dir := t.TempDir()
+		copyBinary(t, fakeVCSBin, filepath.Join(dir, "swm-plugin-vcs-fake"))
+		t.Setenv("PATH", dir+string(filepath.ListSeparator)+os.Getenv("PATH"))
+
+		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+		raw, err := mgr.Get(context.Background(), "vcs")
+		require.NoError(t, err)
+		require.NotNil(t, raw)
+	})
+}
+
 func TestGet_DebugLogs_AtDebugLevel(t *testing.T) { //nolint:paralleltest // mutates slog.Default global state
 	original := slog.Default()
 

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -347,7 +347,7 @@ func TestDiscover_SWMPluginPath(t *testing.T) {
 
 		// Binary only in dir2.
 		copyBinary(t, fakeVCSBin, filepath.Join(dir2, "swm-plugin-vcs-fake"))
-		t.Setenv("SWM_PLUGIN_PATH", dir1+":"+dir2)
+		t.Setenv("SWM_PLUGIN_PATH", dir1+string(filepath.ListSeparator)+dir2)
 
 		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
 		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
@@ -360,7 +360,7 @@ func TestDiscover_SWMPluginPath(t *testing.T) {
 	t.Run("non-existent entries silently skipped", func(t *testing.T) {
 		realDir := t.TempDir()
 		copyBinary(t, fakeVCSBin, filepath.Join(realDir, "swm-plugin-vcs-fake"))
-		t.Setenv("SWM_PLUGIN_PATH", "/nonexistent-pluginmgr-test:"+realDir)
+		t.Setenv("SWM_PLUGIN_PATH", "/nonexistent-pluginmgr-test"+string(filepath.ListSeparator)+realDir)
 
 		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
 		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown

--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -29,6 +29,8 @@
             goVersion = pkgs.go.version;
           in
           ''
+            export PATH="$PWD/scripts:$PATH"
+
             ${config.pre-commit.installationScript}
 
             if [[ ! -f go.work ]]; then

--- a/openspec/changes/archive/2026-05-18-swm-with-plugins-development/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-swm-with-plugins-development/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/archive/2026-05-18-swm-with-plugins-development/design.md
+++ b/openspec/changes/archive/2026-05-18-swm-with-plugins-development/design.md
@@ -1,0 +1,87 @@
+# Design: swm-with-plugins-development
+
+## Context
+
+Plugin discovery today follows a fixed three-tier order: explicit `config.toml`
+paths → XDG data dir → PATH.  There is no way to inject dev-built binaries ahead
+of system-installed ones without either modifying config or manipulating PATH.
+
+The current dev workflow requires `nix profile remove swm-full && nix profile
+install .#swm-full` on every change — several minutes per iteration.  Development
+happens inside per-story git worktrees whose absolute paths are not stable, so
+any solution relying on a fixed installed path is ruled out.
+
+## Goals / Non-Goals
+
+**Goals**
+- Let dev-built plugin binaries win over system-installed ones without config changes.
+- Provide a single script (`scripts/swm-dev`) that builds and runs swm from source
+  in one command, usable both inside and outside direnv.
+- Keep the mechanism general enough to be useful in CI or integration tests.
+
+**Non-Goals**
+- Plugin sandboxing or version pinning.
+- Any changes to proto, SDK, or plugin RPC protocol.
+- A `swm dev` subcommand inside the swm binary.
+
+## Decisions
+
+### 1. Env var (`SWM_PLUGIN_PATH`) over flag or config key
+
+A flag would require the caller to pass it on every invocation; the `swm-dev`
+script would need to forward it through `exec`, and any tool that shells out to
+`swm` would break.  An env var propagates automatically across `exec` chains.  A
+config key would persist on disk and risk leaking into non-dev sessions.
+
+### 2. `SWM_PLUGIN_PATH` is tier 0 — before explicit config paths
+
+The purpose is to guarantee dev binaries win unconditionally.  Placing the env
+var after explicit config paths would mean a stale config entry could silently
+shadow the dev binary, creating hard-to-debug situations.
+
+### 3. Colon-separated list, left-to-right, non-existent entries silently skipped
+
+Consistent with `PATH` convention.  Skipping missing dirs allows partial
+`SWM_PLUGIN_PATH` entries without erroring (e.g. when only some plugins are
+built locally).
+
+### 4. `scripts/swm-dev` always rebuilds — no freshness check
+
+A `make`-style mtime comparison adds code complexity for modest gain.  Go's
+incremental builds already skip unchanged packages; a clean rebuild of an
+unchanged tree completes in ~100 ms.  Always-rebuild eliminates stale-binary
+bugs and keeps the script trivially auditable.
+
+### 5. Script discovers repo root via `git rev-parse --show-toplevel`
+
+Works correctly from any directory inside any worktree regardless of the
+absolute path.  No hardcoded paths, no environment variables required.
+
+### 6. Devshell adds `$PWD/scripts` to PATH via `shellHook`
+
+`$PWD` in a Nix `mkShell` `shellHook` is the project root at the moment direnv
+activates.  This makes `swm-dev` available without a path prefix inside the
+devshell while keeping the approach simple (no derivation, no wrapper package).
+Outside direnv, `./scripts/swm-dev` is used directly.
+
+## Risks / Trade-offs
+
+- **`SWM_PLUGIN_PATH` set accidentally** → silently no-ops on non-existent dirs;
+  worst case is a missing plugin error, same as today.  Mitigation: document
+  clearly that this var is for development only.
+- **Build failure blocks invocation** → `set -euo pipefail` in the script means a
+  compile error surfaces immediately with a clear Go error message.  This is
+  desirable, not a risk.
+- **`go work` not initialised** → `go build` may fail if `go.work` is absent.
+  The devshell `shellHook` already ensures `go work init` and `go work use` run,
+  so this is only a concern when outside direnv.  The script should check for
+  `go.work` and call `go work use` if needed, or document the prerequisite.
+
+## Migration Plan
+
+Fully additive — no existing behaviour changes.  `SWM_PLUGIN_PATH` unset (the
+common case) leaves discovery identical to today.  No rollback needed.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-18-swm-with-plugins-development/proposal.md
+++ b/openspec/changes/archive/2026-05-18-swm-with-plugins-development/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: swm-with-plugins-development
+
+## Why
+
+During development of swm or any of its plugins, there is no way to direct swm
+to load locally-built plugin binaries — the host always discovers plugins from
+PATH and XDG dirs, so a system-installed swm wins over a dev build and vice
+versa.  This blocks iterative plugin development without hacking PATH or
+installing binaries system-wide.
+
+## What Changes
+
+- Introduce a `SWM_PLUGIN_PATH` environment variable: a colon-separated list of
+  directories that is **prepended** to the normal plugin search order (XDG dirs,
+  then PATH).  Plugins found in `SWM_PLUGIN_PATH` take precedence over all
+  system-level discoveries.
+- Document `SWM_PLUGIN_PATH` in shell-completion help text and the existing
+  plugin-lifecycle spec.
+- Add a `scripts/swm-dev` script committed to the repository.  On each invocation
+  it:
+  1. Builds `cmd/swm` and all plugins under `plugins/` with `go build` into
+     `$REPO_ROOT/.dev-bin/`.
+  2. Sets `SWM_PLUGIN_PATH` to that directory.
+  3. `exec`s the freshly built `swm` binary with all original arguments.
+  This replaces the current workflow of `nix profile remove swm-full; nix profile
+  install .#swm-full` (several minutes) with a single `swm-dev` invocation backed
+  by Go's incremental builds (~100 ms when nothing changed).
+- The Nix devshell adds `$REPO_ROOT/scripts` to `PATH` so `swm-dev` is available
+  without a path prefix when inside direnv.  Outside direnv (e.g. running tests
+  in a separate shell while still inside the worktree), invoke it directly as
+  `./scripts/swm-dev`.  Because development happens inside git worktrees whose
+  paths change per story, no stable installed path is assumed.
+- No new flags, no new config keys, no new subcommands in the swm binary itself.
+
+## Non-goals
+
+- Plugin sandboxing or version pinning.
+- A `swm dev` subcommand baked into the swm binary.
+- Changing how plugins are discovered outside of `SWM_PLUGIN_PATH`.
+
+## Capabilities
+
+**New Capabilities**: none
+
+**Modified Capabilities**:
+- `plugin-lifecycle` — the plugin discovery algorithm gains a new first-priority
+  search tier driven by `SWM_PLUGIN_PATH`.  Requirements change: the host MUST
+  iterate each directory in `SWM_PLUGIN_PATH` before consulting XDG dirs or
+  PATH.  A delta spec is needed.
+
+## Impact
+
+- `cmd/swm`: plugin loader / discovery code reads `SWM_PLUGIN_PATH` at startup.
+- `openspec/specs/plugin-lifecycle/spec.md`: discovery algorithm section updated
+  via delta spec in this change.
+- `scripts/swm-dev`: new committed script, works from any shell inside the worktree.
+- Nix devshell configuration: adds `$REPO_ROOT/scripts` to `PATH`.
+- No proto changes; no new capabilities; no SDK changes.
+
+Capability surface affected: **none** (internal host behavior only).

--- a/openspec/changes/archive/2026-05-18-swm-with-plugins-development/specs/plugin-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-05-18-swm-with-plugins-development/specs/plugin-lifecycle/spec.md
@@ -1,0 +1,45 @@
+# Delta Spec: plugin-lifecycle
+
+## MODIFIED Requirements
+
+### Requirement: Plugin discovery
+The plugin manager SHALL discover plugin binaries in the following priority order,
+stopping at the first match per capability:
+(0) each directory listed in `$SWM_PLUGIN_PATH` (colon-separated, evaluated
+left-to-right) — non-existent or non-directory entries MUST be silently skipped,
+(1) explicit paths from `config.toml [plugins.paths]`,
+(2) `$XDG_DATA_HOME/swm/plugins/<name>/swm-plugin-<capability>-<name>`,
+(3) `$PATH` lookup for `swm-plugin-<capability>-<name>`.
+The binary naming convention MUST be `swm-plugin-<capability>-<name>`.
+
+#### Scenario: PATH discovery
+- **WHEN** no explicit path or XDG path is configured for capability `vcs` and `swm-plugin-vcs-git` is in `$PATH`
+- **THEN** the manager discovers `swm-plugin-vcs-git` as the vcs plugin
+
+#### Scenario: Explicit config overrides PATH
+- **WHEN** `config.toml` sets an explicit path for `vcs` and `swm-plugin-vcs-git` is also in `$PATH`
+- **THEN** the manager uses the explicitly configured binary, not the PATH one
+
+#### Scenario: Missing required plugin
+- **WHEN** `config.toml` specifies `vcs = "git"` and no `swm-plugin-vcs-git` is found in any search location
+- **THEN** `Manager.Get("vcs")` returns an error describing which capability binary was not found
+
+#### Scenario: SWM_PLUGIN_PATH takes precedence over all other search locations
+- **WHEN** `SWM_PLUGIN_PATH=/dev/bin`, `swm-plugin-vcs-git` exists in `/dev/bin`, and `swm-plugin-vcs-git` is also discoverable via `$PATH`
+- **THEN** the manager uses `/dev/bin/swm-plugin-vcs-git`
+
+#### Scenario: SWM_PLUGIN_PATH takes precedence over explicit config paths
+- **WHEN** `SWM_PLUGIN_PATH=/dev/bin`, `swm-plugin-vcs-git` exists in `/dev/bin`, and `config.toml` sets an explicit path for `vcs` pointing elsewhere
+- **THEN** the manager uses `/dev/bin/swm-plugin-vcs-git`
+
+#### Scenario: SWM_PLUGIN_PATH colon-separated list searched left-to-right
+- **WHEN** `SWM_PLUGIN_PATH=/dir1:/dir2` and `swm-plugin-vcs-git` exists only in `/dir2`
+- **THEN** the manager discovers `/dir2/swm-plugin-vcs-git`
+
+#### Scenario: Non-existent SWM_PLUGIN_PATH entries are silently skipped
+- **WHEN** `SWM_PLUGIN_PATH=/nonexistent:/dir2` and `swm-plugin-vcs-git` exists in `/dir2`
+- **THEN** `/nonexistent` is silently skipped and the manager discovers `/dir2/swm-plugin-vcs-git`
+
+#### Scenario: Unset SWM_PLUGIN_PATH leaves discovery unchanged
+- **WHEN** `SWM_PLUGIN_PATH` is not set and `swm-plugin-vcs-git` is in `$PATH`
+- **THEN** the manager discovers `swm-plugin-vcs-git` via PATH as before

--- a/openspec/changes/archive/2026-05-18-swm-with-plugins-development/tasks.md
+++ b/openspec/changes/archive/2026-05-18-swm-with-plugins-development/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: swm-with-plugins-development
+
+## 1. SWM_PLUGIN_PATH support in cmd/swm
+
+- [x] 1.1 (`cmd/swm`) Write failing table-driven tests in `pluginmgr/manager_test.go` covering: SWM_PLUGIN_PATH wins over PATH, SWM_PLUGIN_PATH wins over explicit config, colon-separated list searched left-to-right, non-existent entries silently skipped, unset SWM_PLUGIN_PATH leaves existing discovery unchanged
+- [x] 1.2 (`cmd/swm`) In `pluginmgr/manager.go`, read `SWM_PLUGIN_PATH` at discovery time, split on `:`, skip non-existent/non-directory entries, and prepend matching dirs to the search list ahead of all existing tiers
+- [x] 1.3 (`cmd/swm`) Run `task test` scoped to `cmd/swm` and confirm all new tests pass
+
+## 2. scripts/swm-dev wrapper
+
+- [x] 2.1 Create `scripts/swm-dev`: bash script that resolves `REPO_ROOT` via `git rev-parse --show-toplevel`, builds `cmd/swm` and all four plugins (`forge-github`, `picker-fzf`, `session-tmux`, `vcs-git`) into `$REPO_ROOT/.dev-bin/` using `go build`, sets `SWM_PLUGIN_PATH=$REPO_ROOT/.dev-bin`, then `exec`s `$REPO_ROOT/.dev-bin/swm "$@"`
+- [x] 2.2 Make `scripts/swm-dev` executable (`chmod +x`) and add `.dev-bin/` to `.gitignore`
+- [x] 2.3 Manually verify `./scripts/swm-dev --help` succeeds from the repo root and from a subdirectory
+
+## 3. Nix devshell PATH update
+
+- [x] 3.1 In `nix/devshells/flake-module.nix`, add `export PATH="$PWD/scripts:$PATH"` to the `shellHook` so `swm-dev` is on PATH inside direnv without a path prefix
+
+## 4. Verification
+
+- [x] 4.1 Run `task fmt` and apply any formatting changes
+- [x] 4.2 Run `task lint` and fix any issues
+- [x] 4.3 Run `task test` and confirm all tests pass

--- a/openspec/specs/plugin-lifecycle/spec.md
+++ b/openspec/specs/plugin-lifecycle/spec.md
@@ -1,5 +1,12 @@
 ### Requirement: Plugin discovery
-The plugin manager SHALL discover plugin binaries in the following priority order, stopping at the first match per capability: (1) explicit paths from `config.toml [plugins.paths]`, (2) `$XDG_DATA_HOME/swm/plugins/<name>/swm-plugin-<capability>-<name>`, (3) `$PATH` lookup for `swm-plugin-<capability>-<name>`. The binary naming convention MUST be `swm-plugin-<capability>-<name>`.
+The plugin manager SHALL discover plugin binaries in the following priority order,
+stopping at the first match per capability:
+(0) each directory listed in `$SWM_PLUGIN_PATH` (colon-separated, evaluated
+left-to-right) — non-existent or non-directory entries MUST be silently skipped,
+(1) explicit paths from `config.toml [plugins.paths]`,
+(2) `$XDG_DATA_HOME/swm/plugins/<name>/swm-plugin-<capability>-<name>`,
+(3) `$PATH` lookup for `swm-plugin-<capability>-<name>`.
+The binary naming convention MUST be `swm-plugin-<capability>-<name>`.
 
 #### Scenario: PATH discovery
 - **WHEN** no explicit path or XDG path is configured for capability `vcs` and `swm-plugin-vcs-git` is in `$PATH`
@@ -12,6 +19,26 @@ The plugin manager SHALL discover plugin binaries in the following priority orde
 #### Scenario: Missing required plugin
 - **WHEN** `config.toml` specifies `vcs = "git"` and no `swm-plugin-vcs-git` is found in any search location
 - **THEN** `Manager.Get("vcs")` returns an error describing which capability binary was not found
+
+#### Scenario: SWM_PLUGIN_PATH takes precedence over all other search locations
+- **WHEN** `SWM_PLUGIN_PATH=/dev/bin`, `swm-plugin-vcs-git` exists in `/dev/bin`, and `swm-plugin-vcs-git` is also discoverable via `$PATH`
+- **THEN** the manager uses `/dev/bin/swm-plugin-vcs-git`
+
+#### Scenario: SWM_PLUGIN_PATH takes precedence over explicit config paths
+- **WHEN** `SWM_PLUGIN_PATH=/dev/bin`, `swm-plugin-vcs-git` exists in `/dev/bin`, and `config.toml` sets an explicit path for `vcs` pointing elsewhere
+- **THEN** the manager uses `/dev/bin/swm-plugin-vcs-git`
+
+#### Scenario: SWM_PLUGIN_PATH colon-separated list searched left-to-right
+- **WHEN** `SWM_PLUGIN_PATH=/dir1:/dir2` and `swm-plugin-vcs-git` exists only in `/dir2`
+- **THEN** the manager discovers `/dir2/swm-plugin-vcs-git`
+
+#### Scenario: Non-existent SWM_PLUGIN_PATH entries are silently skipped
+- **WHEN** `SWM_PLUGIN_PATH=/nonexistent:/dir2` and `swm-plugin-vcs-git` exists in `/dir2`
+- **THEN** `/nonexistent` is silently skipped and the manager discovers `/dir2/swm-plugin-vcs-git`
+
+#### Scenario: Unset SWM_PLUGIN_PATH leaves discovery unchanged
+- **WHEN** `SWM_PLUGIN_PATH` is not set and `swm-plugin-vcs-git` is in `$PATH`
+- **THEN** the manager discovers `swm-plugin-vcs-git` via PATH as before
 
 ### Requirement: Plugin launch via go-plugin
 The plugin manager SHALL launch plugins using go-plugin's gRPC client. The magic cookie key MUST be `SWM_PLUGIN_MAGIC_COOKIE` and the value MUST be `swm-plugin-v1` (from `sdk/go/handshake`). Launched plugin processes MUST be terminated when `Manager.Close()` is called.

--- a/scripts/swm-dev
+++ b/scripts/swm-dev
@@ -5,6 +5,7 @@
 # Usage (inside devshell):  swm-dev <swm-args>
 # Usage (outside direnv):   ./scripts/swm-dev <swm-args>
 set -euo pipefail
+shopt -s globstar nullglob
 
 REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 DEV_BIN="$REPO_ROOT/.dev-bin"

--- a/scripts/swm-dev
+++ b/scripts/swm-dev
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Development wrapper: builds swm and all plugins from source, then execs swm
+# with SWM_PLUGIN_PATH set so the freshly built binaries take priority.
+#
+# Usage (inside devshell):  swm-dev <swm-args>
+# Usage (outside direnv):   ./scripts/swm-dev <swm-args>
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+DEV_BIN="$REPO_ROOT/.dev-bin"
+
+mkdir -p "$DEV_BIN"
+
+# Ensure go.work exists so go build resolves the local modules correctly.
+if [[ ! -f "$REPO_ROOT/go.work" ]]; then
+  (cd "$REPO_ROOT" && go work init)
+  for mod in cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod proto/go.mod; do
+    (cd "$REPO_ROOT" && go work use "$(dirname "$mod")")
+  done
+fi
+
+echo "swm-dev: building swm..." >&2
+go build -o "$DEV_BIN/swm" "$REPO_ROOT/cmd/swm"
+
+for plugin_dir in "$REPO_ROOT"/plugins/*/; do
+  plugin_name="$(basename "$plugin_dir")"
+  binary_name="swm-plugin-$plugin_name"
+  echo "swm-dev: building $binary_name..." >&2
+  go build -o "$DEV_BIN/$binary_name" "$plugin_dir"
+done
+
+export SWM_PLUGIN_PATH="$DEV_BIN"
+exec "$DEV_BIN/swm" "$@"


### PR DESCRIPTION
Iterating on swm or its plugins previously required
`nix profile remove swm-full && nix profile install .#swm-full`
on every change — several minutes per cycle with no way to point
a running swm at locally-built binaries.

Two complementary pieces:

1. SWM_PLUGIN_PATH env var (colon-separated directory list) is
   now checked as tier 0 in pluginmgr.discover(), before explicit
   config paths, XDG dirs, and PATH. Non-existent entries are
   silently skipped. Unset leaves existing discovery unchanged.

2. scripts/swm-dev wrapper builds cmd/swm and all four plugins
   via `go build` into .dev-bin/, sets SWM_PLUGIN_PATH, and execs
   the freshly built binary. Works from any directory inside the
   worktree (repo root resolved via git rev-parse). The devshell
   shellHook prepends scripts/ to PATH so `swm-dev` is available
   without a prefix inside direnv; use ./scripts/swm-dev outside.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>