### PR TITLE
feat: add swm config command

### DIFF
--- a/cmd/swm/internal/cli/completion_test.go
+++ b/cmd/swm/internal/cli/completion_test.go
@@ -16,7 +16,7 @@ func TestCompletionCmd_HiddenFromHelp(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	root := cli.NewRootCmd(config.Defaults(), &stubMgr{}, nil, layout.NewResolver("", ""))
+	root := cli.NewRootCmd("", config.Defaults(), &stubMgr{}, nil, layout.NewResolver("", ""))
 	root.SetOut(&buf)
 	root.SetArgs([]string{"--help"})
 
@@ -33,7 +33,7 @@ func TestCompletionCmd(t *testing.T) {
 
 			var buf bytes.Buffer
 
-			root := cli.NewRootCmd(config.Defaults(), &stubMgr{}, nil, layout.NewResolver("", ""))
+			root := cli.NewRootCmd("", config.Defaults(), &stubMgr{}, nil, layout.NewResolver("", ""))
 			root.SetOut(&buf)
 			root.SetArgs([]string{"completion", shell})
 

--- a/cmd/swm/internal/cli/config/cmd.go
+++ b/cmd/swm/internal/cli/config/cmd.go
@@ -1,0 +1,22 @@
+// Package config implements the `swm config` CLI subcommands.
+package config
+
+import (
+	"github.com/spf13/cobra"
+
+	appconfig "github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+// NewConfigCmd builds the `swm config` command group.
+func NewConfigCmd(cfgPath string, cfg *appconfig.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Read and write swm configuration",
+	}
+
+	cmd.AddCommand(NewGetCmd(cfg))
+	cmd.AddCommand(NewSetCmd(cfgPath))
+	cmd.AddCommand(NewListCmd(cfgPath, cfg))
+
+	return cmd
+}

--- a/cmd/swm/internal/cli/config/get.go
+++ b/cmd/swm/internal/cli/config/get.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	appconfig "github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+// NewGetCmd builds the `swm config get <key>` command.
+func NewGetCmd(cfg *appconfig.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:          "get <key>",
+		Short:        "Print the effective value of a config key",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k, ok := appconfig.LookupKey(args[0])
+			if !ok {
+				return fmt.Errorf("%q: %w", args[0], appconfig.ErrUnknownKey)
+			}
+
+			cmd.Println(k.Get(cfg))
+
+			return nil
+		},
+	}
+}

--- a/cmd/swm/internal/cli/config/get_test.go
+++ b/cmd/swm/internal/cli/config/get_test.go
@@ -1,0 +1,78 @@
+package config_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cliconfig "github.com/kalbasit/swm/cmd/swm/internal/cli/config"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+func TestGetCmd_KnownKeyWithDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cmd := cliconfig.NewGetCmd(cfg)
+
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"default_story"})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, "_default\n", out.String())
+}
+
+func TestGetCmd_KnownKeyConfigured(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Plugins.Session = testValTmux
+
+	cmd := cliconfig.NewGetCmd(cfg)
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{testKeyPluginsSession})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, testValTmux+"\n", out.String())
+}
+
+func TestGetCmd_NestedMapKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Plugins.Paths = map[string]string{
+		"vcs-git": testPluginBinPath,
+	}
+
+	cmd := cliconfig.NewGetCmd(cfg)
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{testKeyPluginPaths})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, testPluginBinPath+"\n", out.String())
+}
+
+func TestGetCmd_UnknownKeyExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cmd := cliconfig.NewGetCmd(cfg)
+	cmd.SetArgs([]string{"does.not.exist"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestGetCmd_MissingArgExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cmd := cliconfig.NewGetCmd(cfg)
+	cmd.SetArgs([]string{})
+
+	require.Error(t, cmd.Execute())
+}

--- a/cmd/swm/internal/cli/config/list.go
+++ b/cmd/swm/internal/cli/config/list.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	appconfig "github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+// NewListCmd builds the `swm config list` command.
+// Without --all, only keys explicitly present in the config file are shown.
+// With --all, all registered keys with their effective values are shown.
+func NewListCmd(cfgPath string, cfg *appconfig.Config) *cobra.Command {
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "List config key-value pairs",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if all {
+				return printAll(cmd, cfg)
+			}
+
+			return printConfigured(cmd, cfgPath, cfg)
+		},
+	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "show all registered keys with their effective values")
+
+	return cmd
+}
+
+func printAll(cmd *cobra.Command, cfg *appconfig.Config) error {
+	for _, k := range appconfig.AllKeys(cfg) {
+		cmd.Printf("%s = %s\n", k.Path, k.Get(cfg))
+	}
+
+	return nil
+}
+
+func printConfigured(cmd *cobra.Command, cfgPath string, cfg *appconfig.Config) error {
+	keys, err := appconfig.ConfiguredKeys(cfgPath, cfg)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	for _, k := range keys {
+		cmd.Printf("%s = %s\n", k.Path, k.Get(cfg))
+	}
+
+	return nil
+}

--- a/cmd/swm/internal/cli/config/list_test.go
+++ b/cmd/swm/internal/cli/config/list_test.go
@@ -1,0 +1,138 @@
+package config_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cliconfig "github.com/kalbasit/swm/cmd/swm/internal/cli/config"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+func TestListCmd_NoFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cmd := cliconfig.NewListCmd("/nonexistent/path/config.toml", cfg)
+
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+	require.Empty(t, out.String())
+}
+
+func TestListCmd_ConfiguredKeysOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := "code_root = \"/workspace\"\n\n[plugins]\nsession = \"tmux\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg := config.Defaults()
+	cfg.CodeRoot = "/workspace"
+	cfg.Plugins.Session = "tmux"
+
+	cmd := cliconfig.NewListCmd(path, cfg)
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Contains(t, lines, "code_root = /workspace")
+	require.Contains(t, lines, "plugins.session = tmux")
+
+	// Keys not in the file must not appear
+	for _, line := range lines {
+		require.NotContains(t, line, "default_story")
+		require.NotContains(t, line, "plugins.vcs")
+	}
+}
+
+func TestListCmd_ArrayKeyInline(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := "[plugins]\nforges = [\"github\"]\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg := config.Defaults()
+	cfg.Plugins.Forges = []string{"github"}
+
+	cmd := cliconfig.NewListCmd(path, cfg)
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+
+	require.Contains(t, out.String(), `plugins.forges = ["github"]`)
+}
+
+func TestListCmd_AllFlag_NoFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cmd := cliconfig.NewListCmd("/nonexistent/path/config.toml", cfg)
+
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{testFlagAll})
+	require.NoError(t, cmd.Execute())
+
+	output := out.String()
+	require.Contains(t, output, "code_root")
+	require.Contains(t, output, "default_story")
+	require.Contains(t, output, "plugins.session")
+	require.Contains(t, output, "plugins.forges")
+	require.Contains(t, output, "story.branch_name_template")
+}
+
+func TestListCmd_AllFlag_StableOrder(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cmd1 := cliconfig.NewListCmd("/nonexistent/path/config.toml", cfg)
+	cmd2 := cliconfig.NewListCmd("/nonexistent/path/config.toml", cfg)
+
+	out1 := new(bytes.Buffer)
+	cmd1.SetOut(out1)
+	cmd1.SetArgs([]string{"--all"})
+	require.NoError(t, cmd1.Execute())
+
+	out2 := new(bytes.Buffer)
+	cmd2.SetOut(out2)
+	cmd2.SetArgs([]string{"--all"})
+	require.NoError(t, cmd2.Execute())
+
+	require.Equal(t, out1.String(), out2.String())
+}
+
+func TestListCmd_AllFlag_ShowsConfiguredAndDefault(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("code_root = \"/workspace\"\n"), 0o600))
+
+	cfg := config.Defaults()
+	cfg.CodeRoot = "/workspace"
+
+	cmd := cliconfig.NewListCmd(path, cfg)
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{testFlagAll})
+	require.NoError(t, cmd.Execute())
+
+	output := out.String()
+	require.Contains(t, output, "code_root = /workspace")
+	// default_story still shows (from defaults)
+	require.Contains(t, output, "default_story = _default")
+}

--- a/cmd/swm/internal/cli/config/set.go
+++ b/cmd/swm/internal/cli/config/set.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	appconfig "github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+// NewSetCmd builds the `swm config set <key> <value>` command.
+func NewSetCmd(cfgPath string) *cobra.Command {
+	return &cobra.Command{
+		Use:          "set <key> <value>",
+		Short:        "Write a config value to the config file",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			key, value := args[0], args[1]
+
+			k, ok := appconfig.LookupKey(key)
+			if !ok {
+				return fmt.Errorf("%q: %w", key, appconfig.ErrUnknownKey)
+			}
+
+			cfg, err := appconfig.LoadForWrite(cfgPath)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			if err := k.Set(cfg, value); err != nil {
+				return err
+			}
+
+			if err := appconfig.Save(cfgPath, cfg); err != nil {
+				return fmt.Errorf("saving config: %w", err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/swm/internal/cli/config/set_test.go
+++ b/cmd/swm/internal/cli/config/set_test.go
@@ -1,0 +1,105 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cliconfig "github.com/kalbasit/swm/cmd/swm/internal/cli/config"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+func TestSetCmd_CreatesNewFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cmd := cliconfig.NewSetCmd(path)
+	cmd.SetArgs([]string{testKeyPluginsSession, testValTmux})
+	require.NoError(t, cmd.Execute())
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, testValTmux, loaded.Plugins.Session)
+}
+
+func TestSetCmd_UpdatesExistingFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte("code_root = \"/workspace\"\n"), 0o600))
+
+	cmd := cliconfig.NewSetCmd(path)
+	cmd.SetArgs([]string{testKeyPluginsSession, testValTmux})
+	require.NoError(t, cmd.Execute())
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "/workspace", loaded.CodeRoot)
+	require.Equal(t, testValTmux, loaded.Plugins.Session)
+}
+
+func TestSetCmd_MapSubkey(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cmd := cliconfig.NewSetCmd(path)
+	cmd.SetArgs([]string{testKeyPluginPaths, testPluginBinPath})
+	require.NoError(t, cmd.Execute())
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, testPluginBinPath, loaded.Plugins.Paths["vcs-git"])
+}
+
+func TestSetCmd_NonWritableKeyExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cmd := cliconfig.NewSetCmd(path)
+	cmd.SetArgs([]string{"plugins.forges", "github"})
+	require.Error(t, cmd.Execute())
+}
+
+func TestSetCmd_UnknownKeyExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cmd := cliconfig.NewSetCmd(path)
+	cmd.SetArgs([]string{"does.not.exist", "value"})
+	require.Error(t, cmd.Execute())
+}
+
+func TestSetCmd_MissingValueArgExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cmd := cliconfig.NewSetCmd(path)
+	cmd.SetArgs([]string{"plugins.session"})
+	require.Error(t, cmd.Execute())
+}
+
+func TestSetCmd_CreatesParentDirs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "config.toml")
+
+	cmd := cliconfig.NewSetCmd(path)
+	cmd.SetArgs([]string{"default_story", "main"})
+	require.NoError(t, cmd.Execute())
+	require.FileExists(t, path)
+}

--- a/cmd/swm/internal/cli/config/testhelpers_test.go
+++ b/cmd/swm/internal/cli/config/testhelpers_test.go
@@ -1,0 +1,10 @@
+package config_test
+
+const (
+	testKeyCodeRoot       = "code_root"
+	testKeyPluginsSession = "plugins.session"
+	testKeyPluginPaths    = "plugins.paths.vcs-git"
+	testValTmux           = "tmux"
+	testPluginBinPath     = "/usr/local/bin/swm-plugin-vcs-git"
+	testFlagAll           = "--all"
+)

--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cliconfig "github.com/kalbasit/swm/cmd/swm/internal/cli/config"
 	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
@@ -28,6 +29,7 @@ type PluginManager interface {
 
 // NewRootCmd builds the top-level swm cobra.Command.
 func NewRootCmd(
+	cfgPath string,
 	cfg *config.Config,
 	mgr PluginManager,
 	store coreStory.Store,
@@ -79,6 +81,8 @@ func NewRootCmd(
 	prGroup.AddCommand(pr.NewListCmd(store, mgr, cfg))
 	prGroup.AddCommand(pr.NewCreateCmd(mgr, resolver, store, cfg))
 	root.AddCommand(prGroup)
+
+	root.AddCommand(cliconfig.NewConfigCmd(cfgPath, cfg))
 
 	return root
 }

--- a/cmd/swm/internal/config/config.go
+++ b/cmd/swm/internal/config/config.go
@@ -4,17 +4,17 @@ package config
 // Plugins contains names and per-plugin config for all capabilities.
 // This maps directly to the [plugins] TOML table.
 type Plugins struct {
-	Session string   `toml:"session"`
-	VCS     string   `toml:"vcs"`
-	Picker  string   `toml:"picker"`
-	Forges  []string `toml:"forges"`
+	Session string   `toml:"session,omitempty"`
+	VCS     string   `toml:"vcs,omitempty"`
+	Picker  string   `toml:"picker,omitempty"`
+	Forges  []string `toml:"forges,omitempty"`
 
 	// Paths contains explicit binary paths keyed by plugin name, e.g. "vcs-git" -> "/usr/bin/swm-plugin-vcs-git".
-	Paths map[string]string `toml:"paths"`
+	Paths map[string]string `toml:"paths,omitempty"`
 
 	// Config holds per-plugin raw config sections, keyed by plugin name.
 	// Each value is the raw key/value map from [plugins.config.<name>].
-	Config map[string]map[string]any `toml:"config"`
+	Config map[string]map[string]any `toml:"config,omitempty"`
 }
 
 // DefaultBranchNameTemplate is the branch_name_template used when no value is
@@ -26,15 +26,15 @@ type Story struct {
 	// BranchNameTemplate is a Go text/template string evaluated with .Name set
 	// to the story name. It controls the default branch name produced by
 	// "swm story create". When empty, "feat/{{.Name}}" is used.
-	BranchNameTemplate string `toml:"branch_name_template"`
+	BranchNameTemplate string `toml:"branch_name_template,omitempty"`
 }
 
 // Config is the parsed representation of $XDG_CONFIG_HOME/swm/config.toml.
 type Config struct {
-	CodeRoot     string  `toml:"code_root"`
-	DefaultStory string  `toml:"default_story"`
-	Plugins      Plugins `toml:"plugins"`
-	Story        Story   `toml:"story"`
+	CodeRoot     string  `toml:"code_root,omitempty"`
+	DefaultStory string  `toml:"default_story,omitempty"`
+	Plugins      Plugins `toml:"plugins,omitempty"`
+	Story        Story   `toml:"story,omitempty"`
 
 	// HooksConfigHome overrides the XDG config home used for hook discovery.
 	// When empty, the system XDG config home is used. Set in tests to avoid

--- a/cmd/swm/internal/config/keys.go
+++ b/cmd/swm/internal/config/keys.go
@@ -130,6 +130,10 @@ func LookupKey(path string) (KeyDef, bool) {
 
 // isKeyPresent reports whether a dot-separated path exists in a nested map.
 func isKeyPresent(m map[string]any, dotPath string) bool {
+	if m == nil {
+		return false
+	}
+
 	top, rest, found := strings.Cut(dotPath, ".")
 	if !found {
 		_, ok := m[dotPath]

--- a/cmd/swm/internal/config/keys.go
+++ b/cmd/swm/internal/config/keys.go
@@ -1,0 +1,241 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// ErrNotWritable is returned by KeyDef.Set when the key cannot be set via swm config set.
+var ErrNotWritable = errors.New("not writable in this version; edit config.toml directly to change it")
+
+// ErrUnknownKey is returned when a key path is not found in the registry.
+var ErrUnknownKey = errors.New("unknown config key; run 'swm config list --all' to see valid keys")
+
+// KeyDef describes one configurable key accessible via swm config.
+type KeyDef struct {
+	Path        string
+	Description string
+	Writable    bool
+	get         func(cfg *Config) string
+	set         func(cfg *Config, value string) error
+}
+
+// Get returns the string representation of this key's effective value.
+func (k KeyDef) Get(cfg *Config) string { return k.get(cfg) }
+
+// Set writes value into cfg. Returns ErrNotWritable if the key is not writable.
+func (k KeyDef) Set(cfg *Config, value string) error {
+	if !k.Writable {
+		return fmt.Errorf("%q: %w", k.Path, ErrNotWritable)
+	}
+
+	return k.set(cfg, value)
+}
+
+// wildcardPathPrefix is the dot-path prefix for dynamic plugins.paths.* keys.
+const wildcardPathPrefix = "plugins.paths."
+
+// AllKeys returns all statically registered keys followed by any currently-configured
+// plugins.paths.* entries (sorted for stable output).
+func AllKeys(cfg *Config) []KeyDef {
+	reg := keyRegistry()
+	out := append([]KeyDef{}, reg...)
+
+	if len(cfg.Plugins.Paths) > 0 {
+		names := make([]string, 0, len(cfg.Plugins.Paths))
+		for name := range cfg.Plugins.Paths {
+			names = append(names, name)
+		}
+
+		sort.Strings(names)
+
+		for _, name := range names {
+			k, _ := LookupKey(wildcardPathPrefix + name)
+			out = append(out, k)
+		}
+	}
+
+	return out
+}
+
+// ConfiguredKeys returns KeyDef entries for all keys explicitly present in the
+// config file at path. Returns nil, nil if the file does not exist.
+func ConfiguredKeys(path string, cfg *Config) ([]KeyDef, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-specified config file path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	var raw map[string]any
+
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing config file: %w", err)
+	}
+
+	var result []KeyDef
+
+	for _, k := range AllKeys(cfg) {
+		if isKeyPresent(raw, k.Path) {
+			result = append(result, k)
+		}
+	}
+
+	return result, nil
+}
+
+// LookupKey finds a KeyDef by exact dot-path or by plugins.paths.<name> wildcard match.
+func LookupKey(path string) (KeyDef, bool) {
+	for _, k := range keyRegistry() {
+		if k.Path == path {
+			return k, true
+		}
+	}
+
+	if strings.HasPrefix(path, wildcardPathPrefix) {
+		name := path[len(wildcardPathPrefix):]
+		if name == "" {
+			return KeyDef{}, false
+		}
+
+		return KeyDef{
+			Path:        path,
+			Description: fmt.Sprintf("Explicit binary path for plugin %q", name),
+			Writable:    true,
+			get: func(cfg *Config) string {
+				return cfg.Plugins.Paths[name]
+			},
+			set: func(cfg *Config, v string) error {
+				if cfg.Plugins.Paths == nil {
+					cfg.Plugins.Paths = make(map[string]string)
+				}
+
+				cfg.Plugins.Paths[name] = v
+
+				return nil
+			},
+		}, true
+	}
+
+	return KeyDef{}, false
+}
+
+// isKeyPresent reports whether a dot-separated path exists in a nested map.
+func isKeyPresent(m map[string]any, dotPath string) bool {
+	top, rest, found := strings.Cut(dotPath, ".")
+	if !found {
+		_, ok := m[dotPath]
+
+		return ok
+	}
+
+	sub, ok := m[top]
+	if !ok {
+		return false
+	}
+
+	subMap, ok := sub.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	return isKeyPresent(subMap, rest)
+}
+
+// keyRegistry returns the ordered list of all statically known config keys.
+func keyRegistry() []KeyDef {
+	return []KeyDef{
+		{
+			Path:        "code_root",
+			Description: "Root directory for all code repositories (default: ~/code)",
+			Writable:    true,
+			get:         func(cfg *Config) string { return cfg.CodeRoot },
+			set: func(cfg *Config, v string) error {
+				cfg.CodeRoot = v
+
+				return nil
+			},
+		},
+		{
+			Path:        "default_story",
+			Description: "Name of the default story (default: _default)",
+			Writable:    true,
+			get:         func(cfg *Config) string { return cfg.DefaultStory },
+			set: func(cfg *Config, v string) error {
+				cfg.DefaultStory = v
+
+				return nil
+			},
+		},
+		{
+			Path:        "plugins.session",
+			Description: "Session plugin name (e.g. tmux)",
+			Writable:    true,
+			get:         func(cfg *Config) string { return cfg.Plugins.Session },
+			set: func(cfg *Config, v string) error {
+				cfg.Plugins.Session = v
+
+				return nil
+			},
+		},
+		{
+			Path:        "plugins.vcs",
+			Description: "VCS plugin name (e.g. git)",
+			Writable:    true,
+			get:         func(cfg *Config) string { return cfg.Plugins.VCS },
+			set: func(cfg *Config, v string) error {
+				cfg.Plugins.VCS = v
+
+				return nil
+			},
+		},
+		{
+			Path:        "plugins.picker",
+			Description: "Picker plugin name (e.g. fzf)",
+			Writable:    true,
+			get:         func(cfg *Config) string { return cfg.Plugins.Picker },
+			set: func(cfg *Config, v string) error {
+				cfg.Plugins.Picker = v
+
+				return nil
+			},
+		},
+		{
+			Path:        "plugins.forges",
+			Description: "Forge plugin names (read-only via set; edit config.toml to change)",
+			Writable:    false,
+			get: func(cfg *Config) string {
+				if len(cfg.Plugins.Forges) == 0 {
+					return "[]"
+				}
+
+				parts := make([]string, len(cfg.Plugins.Forges))
+				for i, f := range cfg.Plugins.Forges {
+					parts[i] = `"` + f + `"`
+				}
+
+				return "[" + strings.Join(parts, ", ") + "]"
+			},
+			set: nil,
+		},
+		{
+			Path:        "story.branch_name_template",
+			Description: `Go template for branch names on story create (default: feat/{{.Name}})`,
+			Writable:    true,
+			get:         func(cfg *Config) string { return cfg.Story.BranchNameTemplate },
+			set: func(cfg *Config, v string) error {
+				cfg.Story.BranchNameTemplate = v
+
+				return nil
+			},
+		},
+	}
+}

--- a/cmd/swm/internal/config/keys_test.go
+++ b/cmd/swm/internal/config/keys_test.go
@@ -1,0 +1,171 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+const (
+	testKeyPluginPaths = "plugins.paths.vcs-git"
+	testPluginBinPath  = "/usr/bin/swm-plugin-vcs-git"
+)
+
+func TestLookupKey_StaticKeys(t *testing.T) {
+	t.Parallel()
+
+	paths := []string{
+		"code_root",
+		"default_story",
+		"plugins.session",
+		"plugins.vcs",
+		"plugins.picker",
+		"plugins.forges",
+		"story.branch_name_template",
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			k, ok := config.LookupKey(path)
+			require.True(t, ok)
+			require.Equal(t, path, k.Path)
+		})
+	}
+}
+
+func TestLookupKey_UnknownKey(t *testing.T) {
+	t.Parallel()
+
+	_, ok := config.LookupKey("does.not.exist")
+	require.False(t, ok)
+}
+
+func TestLookupKey_DynamicPathKey(t *testing.T) {
+	t.Parallel()
+
+	k, ok := config.LookupKey(testKeyPluginPaths)
+	require.True(t, ok)
+	require.Equal(t, testKeyPluginPaths, k.Path)
+	require.True(t, k.Writable)
+
+	cfg := config.Defaults()
+	require.NoError(t, k.Set(cfg, testPluginBinPath))
+	require.Equal(t, testPluginBinPath, k.Get(cfg))
+}
+
+func TestLookupKey_DynamicPathKey_EmptySubkey(t *testing.T) {
+	t.Parallel()
+
+	_, ok := config.LookupKey("plugins.paths.")
+	require.False(t, ok)
+}
+
+func TestKeyDef_ForgesIsNotWritable(t *testing.T) {
+	t.Parallel()
+
+	k, ok := config.LookupKey("plugins.forges")
+	require.True(t, ok)
+	require.False(t, k.Writable)
+
+	err := k.Set(config.Defaults(), "foo")
+	require.Error(t, err)
+}
+
+func TestKeyDef_ScalarRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path  string
+		value string
+	}{
+		{"code_root", testCodeRoot},
+		{"default_story", "main"},
+		{"plugins.session", testValTmux},
+		{"plugins.vcs", testValGit},
+		{"plugins.picker", testValFzf},
+		{"story.branch_name_template", "fix/{{.Name}}"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+
+			k, ok := config.LookupKey(tc.path)
+			require.True(t, ok)
+
+			cfg := config.Defaults()
+			require.NoError(t, k.Set(cfg, tc.value))
+			require.Equal(t, tc.value, k.Get(cfg))
+		})
+	}
+}
+
+func TestAllKeys_StableOrder(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	first := config.AllKeys(cfg)
+	second := config.AllKeys(cfg)
+	require.Len(t, second, len(first))
+
+	for i := range first {
+		require.Equal(t, first[i].Path, second[i].Path)
+	}
+}
+
+func TestAllKeys_IncludesDynamicPaths(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	cfg.Plugins.Paths = map[string]string{
+		"vcs-git": testPluginBinPath,
+	}
+
+	keys := config.AllKeys(cfg)
+
+	paths := make([]string, len(keys))
+	for i, k := range keys {
+		paths[i] = k.Path
+	}
+
+	require.Contains(t, paths, testKeyPluginPaths)
+}
+
+func TestConfiguredKeys_NoFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Defaults()
+	keys, err := config.ConfiguredKeys("/nonexistent/path/config.toml", cfg)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestConfiguredKeys_WithFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := dir + "/config.toml"
+	content := "code_root = \"/workspace\"\n\n[plugins]\nsession = \"tmux\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg := config.Defaults()
+	cfg.CodeRoot = "/workspace"
+	cfg.Plugins.Session = "tmux"
+
+	keys, err := config.ConfiguredKeys(path, cfg)
+	require.NoError(t, err)
+
+	paths := make([]string, len(keys))
+	for i, k := range keys {
+		paths[i] = k.Path
+	}
+
+	require.Contains(t, paths, "code_root")
+	require.Contains(t, paths, "plugins.session")
+	require.NotContains(t, paths, "default_story")
+}

--- a/cmd/swm/internal/config/keys_test.go
+++ b/cmd/swm/internal/config/keys_test.go
@@ -2,16 +2,12 @@ package config_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/kalbasit/swm/cmd/swm/internal/config"
-)
-
-const (
-	testKeyPluginPaths = "plugins.paths.vcs-git"
-	testPluginBinPath  = "/usr/bin/swm-plugin-vcs-git"
 )
 
 func TestLookupKey_StaticKeys(t *testing.T) {
@@ -134,6 +130,19 @@ func TestAllKeys_IncludesDynamicPaths(t *testing.T) {
 	}
 
 	require.Contains(t, paths, testKeyPluginPaths)
+}
+
+func TestConfiguredKeys_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o600))
+
+	cfg := config.Defaults()
+	keys, err := config.ConfiguredKeys(path, cfg)
+	require.NoError(t, err)
+	require.Empty(t, keys)
 }
 
 func TestConfiguredKeys_NoFile(t *testing.T) {

--- a/cmd/swm/internal/config/testhelpers_test.go
+++ b/cmd/swm/internal/config/testhelpers_test.go
@@ -1,9 +1,11 @@
 package config_test
 
 const (
-	testCodeRoot   = "/workspace"
-	testValTmux    = "tmux"
-	testValGit     = "git"
-	testValFzf     = "fzf"
-	testValSession = "tmux"
+	testCodeRoot       = "/workspace"
+	testKeyPluginPaths = "plugins.paths.vcs-git"
+	testKeySession     = "plugins.session"
+	testPluginBinPath  = "/usr/bin/swm-plugin-vcs-git"
+	testValFzf         = "fzf"
+	testValGit         = "git"
+	testValTmux        = "tmux"
 )

--- a/cmd/swm/internal/config/testhelpers_test.go
+++ b/cmd/swm/internal/config/testhelpers_test.go
@@ -1,0 +1,9 @@
+package config_test
+
+const (
+	testCodeRoot   = "/workspace"
+	testValTmux    = "tmux"
+	testValGit     = "git"
+	testValFzf     = "fzf"
+	testValSession = "tmux"
+)

--- a/cmd/swm/internal/config/write.go
+++ b/cmd/swm/internal/config/write.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// LoadForWrite reads the config file at path for the purpose of mutation.
+// Unlike Load, it does not apply defaults or expand tildes — it returns only
+// what is explicitly present in the file. Returns an empty *Config if the file
+// does not exist, so callers can create a new config via Save.
+func LoadForWrite(path string) (*Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // user-specified config file path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{}, nil
+		}
+
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	var cfg Config
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// Save writes cfg to path atomically, creating parent directories if absent.
+// Only non-zero fields are written (via omitempty struct tags on Config).
+// Any comments in the original file are not preserved.
+func Save(path string, cfg *Config) error {
+	data, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("writing temp config file: %w", err)
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("renaming config file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/swm/internal/config/write.go
+++ b/cmd/swm/internal/config/write.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -31,12 +32,33 @@ func LoadForWrite(path string) (*Config, error) {
 }
 
 // Save writes cfg to path atomically, creating parent directories if absent.
-// Only non-zero fields are written (via omitempty struct tags on Config).
-// Any comments in the original file are not preserved.
+// Unknown fields already present in the file are preserved via deep merge so
+// that future versions of swm (or manual additions) are not silently dropped.
+// Comments in the original file are not preserved.
 func Save(path string, cfg *Config) error {
-	data, err := toml.Marshal(cfg)
+	// Load existing raw TOML to preserve fields not known to this Config struct.
+	rawData := make(map[string]any)
+
+	if existing, err := os.ReadFile(path); err == nil { //nolint:gosec // user-specified config file path
+		if err := toml.Unmarshal(existing, &rawData); err != nil {
+			rawData = make(map[string]any) // reset in case of partial parse
+		}
+	}
+
+	cfgBytes, err := toml.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	var cfgMap map[string]any
+
+	if err := toml.Unmarshal(cfgBytes, &cfgMap); err != nil {
+		return fmt.Errorf("parsing config map: %w", err)
+	}
+
+	data, err := toml.Marshal(deepMerge(rawData, cfgMap))
+	if err != nil {
+		return fmt.Errorf("marshaling merged config: %w", err)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -53,4 +75,29 @@ func Save(path string, cfg *Config) error {
 	}
 
 	return nil
+}
+
+// deepMerge returns a new map containing all entries from base with entries
+// from override applied on top. Nested maps are merged recursively; all other
+// value types are replaced by the override value.
+func deepMerge(base, override map[string]any) map[string]any {
+	result := make(map[string]any, len(base))
+	maps.Copy(result, base)
+
+	for k, v := range override {
+		if baseVal, ok := result[k]; ok {
+			baseMap, baseIsMap := baseVal.(map[string]any)
+			overrideMap, overrideIsMap := v.(map[string]any)
+
+			if baseIsMap && overrideIsMap {
+				result[k] = deepMerge(baseMap, overrideMap)
+
+				continue
+			}
+		}
+
+		result[k] = v
+	}
+
+	return result
 }

--- a/cmd/swm/internal/config/write_test.go
+++ b/cmd/swm/internal/config/write_test.go
@@ -63,6 +63,34 @@ func TestSave_OmitsZeroValueFields(t *testing.T) {
 	require.NotContains(t, string(data), "vcs")
 }
 
+func TestSave_PreservesUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// Seed file with a known field and a field unknown to the current Config struct.
+	content := "code_root = \"/workspace\"\nunknown_future_key = \"preserved\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := config.LoadForWrite(path)
+	require.NoError(t, err)
+
+	k, ok := config.LookupKey(testKeySession)
+	require.True(t, ok)
+	require.NoError(t, k.Set(cfg, testValTmux))
+	require.NoError(t, config.Save(path, cfg))
+
+	data, err := os.ReadFile(path) //nolint:gosec // test temp path
+	require.NoError(t, err)
+
+	output := string(data)
+	require.Contains(t, output, "unknown_future_key")
+	require.Contains(t, output, "preserved")
+	require.Contains(t, output, "session")
+	require.Contains(t, output, testValTmux)
+}
+
 func TestLoadForWrite_ReturnsEmptyForMissingFile(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/config/write_test.go
+++ b/cmd/swm/internal/config/write_test.go
@@ -1,0 +1,108 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/config"
+)
+
+func TestSave_CreatesParentDirs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "config.toml")
+
+	cfg := &config.Config{}
+	cfg.CodeRoot = testCodeRoot
+
+	require.NoError(t, config.Save(path, cfg))
+	require.FileExists(t, path)
+}
+
+func TestSave_WritesExpectedContent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := &config.Config{}
+	cfg.CodeRoot = testCodeRoot
+	cfg.Plugins.Session = testValTmux
+
+	require.NoError(t, config.Save(path, cfg))
+
+	data, err := os.ReadFile(path) //nolint:gosec // user-controlled test temp path, safe in tests
+	require.NoError(t, err)
+	require.Contains(t, string(data), "code_root")
+	require.Contains(t, string(data), testCodeRoot)
+	require.Contains(t, string(data), "session")
+	require.Contains(t, string(data), testValTmux)
+}
+
+func TestSave_OmitsZeroValueFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := &config.Config{}
+	cfg.CodeRoot = testCodeRoot
+
+	require.NoError(t, config.Save(path, cfg))
+
+	data, err := os.ReadFile(path) //nolint:gosec // user-controlled test temp path, safe in tests
+	require.NoError(t, err)
+
+	// Fields not set must not appear in the output
+	require.NotContains(t, string(data), "default_story")
+	require.NotContains(t, string(data), "session")
+	require.NotContains(t, string(data), "vcs")
+}
+
+func TestLoadForWrite_ReturnsEmptyForMissingFile(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.LoadForWrite("/nonexistent/path/config.toml")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Empty(t, cfg.CodeRoot)
+}
+
+func TestLoadForWrite_ReadsExistingFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`code_root = "/workspace"`+"\n"), 0o600))
+
+	cfg, err := config.LoadForWrite(path)
+	require.NoError(t, err)
+	require.Equal(t, testCodeRoot, cfg.CodeRoot)
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// Write via LoadForWrite + Save
+	cfg, err := config.LoadForWrite(path)
+	require.NoError(t, err)
+
+	cfg.Plugins.Session = testValTmux
+	cfg.DefaultStory = "main"
+	require.NoError(t, config.Save(path, cfg))
+
+	// Read back via Load (which applies defaults and expands tildes)
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, testValTmux, loaded.Plugins.Session)
+	require.Equal(t, "main", loaded.DefaultStory)
+	// code_root was not set, so Load's default applies (expanded to absolute path)
+	require.NotEmpty(t, loaded.CodeRoot)
+}

--- a/cmd/swm/main.go
+++ b/cmd/swm/main.go
@@ -20,7 +20,9 @@ import (
 var version = "v2.0.0-dev"
 
 func main() {
-	cfg, err := config.Load(config.ResolveConfigPath(os.Getenv("SWM_CONFIG"), xdg.ConfigHome))
+	cfgPath := config.ResolveConfigPath(os.Getenv("SWM_CONFIG"), xdg.ConfigHome)
+
+	cfg, err := config.Load(cfgPath)
 	if err != nil && !errors.Is(err, config.ErrConfigNotFound) {
 		fmt.Fprintf(os.Stderr, "swm: loading config: %v\n", err)
 		os.Exit(1)
@@ -44,7 +46,7 @@ func main() {
 	mgr := pluginmgr.New(cfg, hostSrv.SocketPath())
 	defer mgr.Close() //nolint:errcheck // best-effort close on exit
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd(cfgPath, cfg, mgr, store, resolver)
 	root.Version = version
 
 	if err := root.Execute(); err != nil {

--- a/cmd/swm/tests/integration/integration_test.go
+++ b/cmd/swm/tests/integration/integration_test.go
@@ -115,7 +115,7 @@ func TestCloneAndStoryCreate(t *testing.T) {
 	srcRepo := initLocalRepo(t)
 	fileURL := "file://" + srcRepo
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdClone, fileURL})
 	require.NoError(t, root.Execute())
 
@@ -126,7 +126,7 @@ func TestCloneAndStoryCreate(t *testing.T) {
 		"expected .git at canonical path %s", canonical)
 
 	// Create a story.
-	root2 := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root2 := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root2.SetArgs([]string{cmdGroupStory, cmdCreate, testStoryName})
 	require.NoError(t, root2.Execute())
 
@@ -150,7 +150,7 @@ func TestStoryRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove story (no projects, so no VCS calls needed).
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdGroupStory, cmdRemove, flagForce, testStoryName})
 	require.NoError(t, root.Execute())
 
@@ -168,7 +168,7 @@ func TestStoryRemove_NoArg_SWMStorySet(t *testing.T) {
 	_, err := store.Create(t.Context(), testStoryName, "feat/"+testStoryName)
 	require.NoError(t, err)
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdGroupStory, cmdRemove, flagForce}) // no name arg
 	require.NoError(t, root.Execute())
 
@@ -185,7 +185,7 @@ func TestStoryRemove_NoArg_SWMStoryUnset_ReturnsError(t *testing.T) {
 	_, err := store.Create(t.Context(), testStoryName, "feat/"+testStoryName)
 	require.NoError(t, err)
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdGroupStory, cmdRemove, flagForce}) // no name, no env
 	require.Error(t, root.Execute(), "should error when neither arg nor $SWM_STORY is set")
 
@@ -202,7 +202,7 @@ func TestStoryRemove_ExplicitArg_OverridesSWMStory(t *testing.T) {
 	_, err := store.Create(t.Context(), testStoryName, "feat/"+testStoryName)
 	require.NoError(t, err)
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdGroupStory, cmdRemove, flagForce, testStoryName}) // explicit arg
 	require.NoError(t, root.Execute())
 
@@ -260,7 +260,7 @@ func TestWorkspaceOpenWithPicker(t *testing.T) {
 	srcRepo := initLocalRepo(t)
 	fileURL := "file://" + srcRepo
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdClone, fileURL})
 	require.NoError(t, root.Execute())
 
@@ -270,7 +270,7 @@ func TestWorkspaceOpenWithPicker(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	root2 := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root2 := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root2.SetArgs([]string{cmdGroupWorkspace, cmdOpen, testStoryName})
 	root2.SetOut(&buf)
 	require.NoError(t, root2.Execute())
@@ -346,14 +346,14 @@ func TestWorkspaceOpenWithStoryPicker(t *testing.T) { //nolint:paralleltest // u
 	srcRepo := initLocalRepo(t)
 	fileURL := "file://" + srcRepo
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdClone, fileURL})
 	require.NoError(t, root.Execute())
 
 	// Run workspace open with NO story argument — story picker must be shown.
 	var buf bytes.Buffer
 
-	root2 := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root2 := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root2.SetArgs([]string{cmdGroupWorkspace, cmdOpen}) // no story name
 	root2.SetOut(&buf)
 	require.NoError(t, root2.Execute())
@@ -388,7 +388,7 @@ func TestWorkspaceOpenWithSWMStorySkipsStoryPicker(t *testing.T) {
 	srcRepo := initLocalRepo(t)
 	fileURL := "file://" + srcRepo
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdClone, fileURL})
 	require.NoError(t, root.Execute())
 
@@ -397,7 +397,7 @@ func TestWorkspaceOpenWithSWMStorySkipsStoryPicker(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	root2 := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root2 := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root2.SetArgs([]string{cmdGroupWorkspace, cmdOpen}) // no positional arg
 	root2.SetOut(&buf)
 	require.NoError(t, root2.Execute())
@@ -432,13 +432,13 @@ func TestWorkspaceOpenWithPositionalArgSkipsStoryPicker(t *testing.T) { //nolint
 	srcRepo := initLocalRepo(t)
 	fileURL := "file://" + srcRepo
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdClone, fileURL})
 	require.NoError(t, root.Execute())
 
 	var buf bytes.Buffer
 
-	root2 := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root2 := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root2.SetArgs([]string{cmdGroupWorkspace, cmdOpen, testStoryName}) // positional arg provided
 	root2.SetOut(&buf)
 	require.NoError(t, root2.Execute())
@@ -470,13 +470,13 @@ func TestWorkspaceOpenStoryPickerRespectsTerminalWidth(t *testing.T) {
 	srcRepo := initLocalRepo(t)
 	fileURL := "file://" + srcRepo
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdClone, fileURL})
 	require.NoError(t, root.Execute())
 
 	var buf bytes.Buffer
 
-	root2 := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root2 := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root2.SetArgs([]string{cmdGroupWorkspace, cmdOpen}) // no story name — triggers story picker
 	root2.SetOut(&buf)
 	require.NoError(t, root2.Execute())
@@ -499,7 +499,7 @@ func TestWorkspaceOpen(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	root := cli.NewRootCmd(cfg, mgr, store, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, store, resolver)
 	root.SetArgs([]string{cmdGroupWorkspace, cmdOpen, testStoryName})
 	root.SetOut(&buf)
 	require.NoError(t, root.Execute())
@@ -598,7 +598,7 @@ func TestPRListAndCreate(t *testing.T) {
 	// --- pr list ---
 	var listBuf bytes.Buffer
 
-	root := cli.NewRootCmd(cfg, mgr, st, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, st, resolver)
 	root.SetArgs([]string{"pr", "list", flagStory, "feat-pr"})
 	root.SetOut(&listBuf)
 	require.NoError(t, root.Execute())
@@ -615,7 +615,7 @@ func TestPRListAndCreate(t *testing.T) {
 
 	var createBuf bytes.Buffer
 
-	root2 := cli.NewRootCmd(cfg, mgr, st, resolver)
+	root2 := cli.NewRootCmd("", cfg, mgr, st, resolver)
 	root2.SetArgs([]string{"pr", "create", "--title", "New PR", "--head", "feat/new"})
 	root2.SetOut(&createBuf)
 	require.NoError(t, root2.Execute())
@@ -642,7 +642,7 @@ func TestHooksRunOnStoryCreate(t *testing.T) {
 	cfg, resolver, st, mgr := setupEnv(t)
 	cfg.HooksConfigHome = hooksConfigHome
 
-	root := cli.NewRootCmd(cfg, mgr, st, resolver)
+	root := cli.NewRootCmd("", cfg, mgr, st, resolver)
 	root.SetArgs([]string{cmdGroupStory, cmdCreate, testStoryName})
 	require.NoError(t, root.Execute())
 

--- a/openspec/changes/archive/2026-05-18-config-command/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-18-config-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/archive/2026-05-18-config-command/design.md
+++ b/openspec/changes/archive/2026-05-18-config-command/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`cmd/swm/internal/config` currently provides read-only access: `Load` reads and unmarshals `config.toml`; `Defaults` returns zero-file defaults. There is no write path and no key registry. Users must hand-edit the TOML file to change any setting.
+
+The `swm config` command adds `get`, `set`, and `list` subcommands to `cmd/swm`. It is host-only: no plugin protocol changes, no proto bump.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `swm config get <key>` — print the effective value of any registered scalar key (configured or default).
+- `swm config set <key> <value>` — write a new scalar value to the config file, creating it if absent.
+- `swm config list` — print only file-configured key/value pairs.
+- `swm config list --all` — print all registered keys with their effective values.
+- A static key registry that is the single source of truth for key names, types, defaults, and descriptions.
+
+**Non-Goals:**
+- Setting array fields (`plugins.forges`) or nested plugin config (`plugins.config.*`) — get/list display them, set is scalar-only in v1.
+- Preserving TOML comments on write — acceptable loss.
+- Interactive TUI editor or `swm config edit`.
+- Per-plugin config namespacing under `plugins.config.*` as settable keys.
+
+## Decisions
+
+### 1. Key notation: dot-separated TOML path
+
+Keys use dot-separated segments mirroring the TOML hierarchy:
+
+| Key | TOML field |
+|---|---|
+| `code_root` | `code_root` |
+| `default_story` | `default_story` |
+| `plugins.session` | `[plugins] session` |
+| `plugins.vcs` | `[plugins] vcs` |
+| `plugins.picker` | `[plugins] picker` |
+| `plugins.forges` | `[plugins] forges` (read-only in v1) |
+| `plugins.paths.<name>` | `[plugins.paths] <name>` |
+| `story.branch_name_template` | `[story] branch_name_template` |
+
+**Alternatives considered:** `swm config set plugins session tmux` (positional segments) — rejected because it makes scripting harder and doesn't compose with shell quoting conventions.
+
+### 2. Key registry in `config/keys.go`
+
+A static `[]KeyDef` slice lives in `cmd/swm/internal/config/keys.go`. Each entry carries: dot-path, human description, whether it is writable via `set`, and a getter/setter func pair that operates on `*Config`. This is the single source of truth for `list --all` ordering, `get` validation, and `set` routing.
+
+**Alternatives considered:** Reflection over struct tags — rejected because it cannot express write-only vs read-only, cannot handle map sub-keys (`plugins.paths.<name>`), and produces unpredictable key ordering.
+
+### 3. Write strategy: unmarshal → mutate → marshal → write
+
+`set` flow:
+1. If config file does not exist, create parent dirs and write an empty file first.
+2. Read raw bytes.
+3. Unmarshal into `Config` via `toml.Unmarshal`.
+4. Apply the mutation through the key's setter.
+5. Marshal with `toml.Marshal`.
+6. Write back atomically (write to `<path>.tmp`, then `os.Rename`).
+
+TOML comments are lost on round-trip — this is documented and accepted. `go-toml/v2` has no comment-preserving round-trip API.
+
+**Alternatives considered:** Regex/sed-style in-place line replacement — rejected because it is fragile against multi-line values, array syntax, and inline tables.
+
+### 4. `get` returns effective value (default or configured)
+
+`get <key>` always returns a value (never empty) because it reads the effective config (defaults merged with file). This is consistent with how every other `swm` command uses config.
+
+### 5. `list` vs `list --all`
+
+`list` (no flag): reads raw TOML file, emits only keys present in the file. If no file exists, prints nothing and exits 0.
+`list --all`: iterates the key registry in definition order, emitting effective values for all registered keys.
+
+Both output `key = value` lines (TOML scalar syntax), one per line.
+
+## Risks / Trade-offs
+
+- **Comment loss on write** → Documented in command help text. Users who care about comments should use `$EDITOR`.
+- **Partial key coverage** — `plugins.forges` and `plugins.config.*` are display-only in v1 → Mitigation: `set` returns a clear error "key is not writable in this version" rather than silently doing nothing.
+- **Concurrent writes** — no file locking on config writes → Mitigation: atomic rename reduces the window; config writes are rare interactive actions, not high-frequency operations. File locking can be added later if needed.
+- **`plugins.paths.<name>` dynamic keys** — the key registry must handle open-ended map sub-keys → Mitigation: registry uses a wildcard entry `plugins.paths.*` with a dynamic getter/setter.
+
+## Open Questions
+
+- Should `swm config set` create the config file if it does not exist, or require the user to create it first? **Decision: create it** (mkdir -p + empty file, then write).
+- Output format for `list --all` on array values (`plugins.forges`): TOML inline array (`["tmux"]`) or one-per-line? **Decision: TOML inline array** for consistency with the file format.

--- a/openspec/changes/archive/2026-05-18-config-command/proposal.md
+++ b/openspec/changes/archive/2026-05-18-config-command/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Users must manually edit `~/.config/swm/config.toml` to change any swm setting, with no way to read or write values from the command line. A `swm config` command makes configuration scriptable and removes the need to know the TOML file path or format.
+
+## What Changes
+
+- Add `swm config get <key>` — print the current value of a single config key to stdout.
+- Add `swm config set <key> <value>` — write a new value for a config key to the config file.
+- Add `swm config list` — print only explicitly configured key-value pairs in dot-notation (e.g. `plugins.session = tmux`).
+- Add `swm config list --all` — print all available keys with their effective values (configured or default).
+- Add config write support to `cmd/swm/internal/config` (currently read-only).
+
+## Capabilities
+
+### New Capabilities
+
+- `config-command` — CLI subcommands for reading and writing swm configuration without touching the TOML file directly.
+
+### Modified Capabilities
+
+<!-- No existing spec-level requirements change. -->
+
+## Non-goals
+
+- No interactive TUI editor.
+- No validation of plugin-specific config values under `plugins.config.*` — those are opaque to the host.
+- No merging or diffing of config files.
+- No `swm config edit` (opening `$EDITOR`) — out of scope for now.
+- No support for writing array fields (e.g. `plugins.forges`) in v1 of this command; get and list will display them, set will be limited to scalar and map-string values.
+
+## Impact
+
+- `cmd/swm` — new `config` cobra command with `get`, `set`, and `list` subcommands.
+- `cmd/swm/internal/config` — new write path: load → mutate → marshal TOML → write back to the resolved config file path.
+- Capability surfaces affected: **none** (host-only CLI feature, no plugin protocol changes).
+- No proto changes required.

--- a/openspec/changes/archive/2026-05-18-config-command/specs/config-command/spec.md
+++ b/openspec/changes/archive/2026-05-18-config-command/specs/config-command/spec.md
@@ -1,0 +1,118 @@
+# Spec: config-command
+
+CLI subcommands for reading and writing swm configuration without manually editing the TOML file.
+
+---
+
+## Requirement: swm config get
+
+`swm config get <key>` prints the effective value of a registered config key to stdout, followed by a newline. The effective value is the file-configured value if present, otherwise the compiled-in default.
+
+### Scenario: Get a key that has a default and is not in the config file
+- **GIVEN** no config file exists (or the key is absent from the file)
+- **WHEN** `swm config get code_root` is run
+- **THEN** the command exits zero and prints the default value (`~/code`)
+
+### Scenario: Get a key that is set in the config file
+- **GIVEN** `config.toml` contains `code_root = "/workspace/code"`
+- **WHEN** `swm config get code_root` is run
+- **THEN** the command exits zero and prints `/workspace/code`
+
+### Scenario: Get a nested key
+- **GIVEN** `config.toml` contains `[plugins]\nsession = "tmux"`
+- **WHEN** `swm config get plugins.session` is run
+- **THEN** the command exits zero and prints `tmux`
+
+### Scenario: Get a map sub-key
+- **GIVEN** `config.toml` contains `[plugins.paths]\nvcs-git = "/usr/local/bin/swm-plugin-vcs-git"`
+- **WHEN** `swm config get plugins.paths.vcs-git` is run
+- **THEN** the command exits zero and prints `/usr/local/bin/swm-plugin-vcs-git`
+
+### Scenario: Get an unknown key
+- **WHEN** `swm config get does.not.exist` is run
+- **THEN** the command exits non-zero and prints an error message listing valid keys to stderr
+
+### Scenario: Get with missing argument
+- **WHEN** `swm config get` is run with no arguments
+- **THEN** the command exits non-zero and prints usage to stderr
+
+---
+
+## Requirement: swm config set
+
+`swm config set <key> <value>` writes a new scalar value for a registered writable key to the config file. If the config file does not exist, it is created (including parent directories). Comments in an existing file are not preserved after a write.
+
+### Scenario: Set a top-level key in an existing config file
+- **GIVEN** `config.toml` exists with `code_root = "~/code"`
+- **WHEN** `swm config set code_root /workspace` is run
+- **THEN** the command exits zero, and `config.toml` contains `code_root = "/workspace"`
+
+### Scenario: Set creates the config file when it does not exist
+- **GIVEN** no config file exists
+- **WHEN** `swm config set default_story main` is run
+- **THEN** the command exits zero, the config file is created, and it contains `default_story = "main"`
+
+### Scenario: Set a nested key
+- **WHEN** `swm config set plugins.session tmux` is run
+- **THEN** the command exits zero and `config.toml` contains `session = "tmux"` under `[plugins]`
+
+### Scenario: Set a map sub-key
+- **WHEN** `swm config set plugins.paths.vcs-git /usr/local/bin/swm-plugin-vcs-git` is run
+- **THEN** the command exits zero and `config.toml` contains the path under `[plugins.paths]`
+
+### Scenario: Set a non-writable key
+- **WHEN** `swm config set plugins.forges "github"` is run
+- **THEN** the command exits non-zero and prints an error message indicating the key is not writable via `set` in this version
+
+### Scenario: Set an unknown key
+- **WHEN** `swm config set does.not.exist value` is run
+- **THEN** the command exits non-zero and prints an error message listing valid keys to stderr
+
+### Scenario: Set with wrong argument count
+- **WHEN** `swm config set plugins.session` is run with only one argument
+- **THEN** the command exits non-zero and prints usage to stderr
+
+---
+
+## Requirement: swm config list
+
+`swm config list` prints only the keys that are explicitly present in the config file, in `key = value` format (one per line). If no config file exists, it prints nothing and exits zero.
+
+### Scenario: No config file
+- **GIVEN** no config file exists
+- **WHEN** `swm config list` is run
+- **THEN** the command exits zero and prints nothing to stdout
+
+### Scenario: Config file with some keys set
+- **GIVEN** `config.toml` contains `code_root = "/workspace"` and `[plugins]\nsession = "tmux"`
+- **WHEN** `swm config list` is run
+- **THEN** the command exits zero and prints exactly:
+  ```
+  code_root = /workspace
+  plugins.session = tmux
+  ```
+
+### Scenario: Array key displayed inline
+- **GIVEN** `config.toml` contains `[plugins]\nforges = ["github"]`
+- **WHEN** `swm config list` is run
+- **THEN** the command exits zero and the output includes `plugins.forges = ["github"]`
+
+---
+
+## Requirement: swm config list --all
+
+`swm config list --all` prints every registered key with its effective value (configured or default), in key registry definition order.
+
+### Scenario: Fresh install with no config file
+- **GIVEN** no config file exists
+- **WHEN** `swm config list --all` is run
+- **THEN** the command exits zero and all registered keys are printed with their default values
+
+### Scenario: Some keys configured
+- **GIVEN** `config.toml` contains `code_root = "/workspace"`
+- **WHEN** `swm config list --all` is run
+- **THEN** the command exits zero, `code_root` shows `/workspace`, and all other keys show their defaults
+
+### Scenario: Output order is stable
+- **WHEN** `swm config list --all` is run twice
+- **THEN** both outputs are identical (keys appear in registry definition order, not map iteration order)

--- a/openspec/changes/archive/2026-05-18-config-command/tasks.md
+++ b/openspec/changes/archive/2026-05-18-config-command/tasks.md
@@ -1,0 +1,34 @@
+## 1. Key Registry (cmd/swm)
+
+- [x] 1.1 Create `cmd/swm/internal/config/keys.go` — define `KeyDef` struct (dot-path, description, writable bool, getter/setter funcs on `*Config`) and the static registry covering all scalar keys: `code_root`, `default_story`, `plugins.session`, `plugins.vcs`, `plugins.picker`, `plugins.forges` (read-only), `plugins.paths.*` (wildcard), `story.branch_name_template`
+- [x] 1.2 Write table-driven unit tests in `cmd/swm/internal/config/keys_test.go` — verify each registered key round-trips through its getter/setter, and that unknown keys return an error from the lookup function
+
+## 2. Config Write Path (cmd/swm)
+
+- [x] 2.1 Create `cmd/swm/internal/config/write.go` — implement `Save(path string, cfg *Config) error`: marshal `cfg` with `toml.Marshal`, write to `<path>.tmp`, then `os.Rename` to `path`; create parent directories if absent
+- [x] 2.2 Write unit tests in `cmd/swm/internal/config/write_test.go` — cover: save to new path (creates dirs + file), save over existing file, marshal+reload round-trip preserves values
+
+## 3. `swm config get` (cmd/swm)
+
+- [x] 3.1 Create `cmd/swm/internal/cli/config/get.go` — implement `NewGetCmd(cfg *config.Config)` cobra command: look up key in registry, print effective value to stdout; exit non-zero with error listing valid keys for unknown key; require exactly one argument
+- [x] 3.2 Write unit tests in `cmd/swm/internal/cli/config/get_test.go` — cover: known key with default (no file), known key configured in file, map sub-key, unknown key exits non-zero, missing argument exits non-zero
+
+## 4. `swm config set` (cmd/swm)
+
+- [x] 4.1 Create `cmd/swm/internal/cli/config/set.go` — implement `NewSetCmd(cfgPath string)` cobra command: reject non-writable and unknown keys with non-zero exit; load config (or start from `Defaults()` if file absent); apply setter; call `Save`; require exactly two arguments
+- [x] 4.2 Write unit tests in `cmd/swm/internal/cli/config/set_test.go` — cover: set creates new file, set updates existing file, set persists value readable by `Load`, non-writable key exits non-zero, unknown key exits non-zero, wrong argument count exits non-zero
+
+## 5. `swm config list` (cmd/swm)
+
+- [x] 5.1 Create `cmd/swm/internal/cli/config/list.go` — implement `NewListCmd(cfgPath string, cfg *config.Config)` cobra command with `--all` bool flag; without `--all`: read raw file and emit only present keys in `key = value` format; with `--all`: iterate registry in definition order, emit effective values for every key; array values use TOML inline array format
+- [x] 5.2 Write unit tests in `cmd/swm/internal/cli/config/list_test.go` — cover: no file → empty output, some configured keys → only those shown, `--all` with no file → all defaults shown, `--all` with partial file → mix of configured and default values, output order is stable
+
+## 6. Wire config command into root (cmd/swm)
+
+- [x] 6.1 Create `cmd/swm/internal/cli/config/cmd.go` — implement `NewConfigCmd(cfgPath string, cfg *config.Config)` that builds the `config` cobra command and adds `get`, `set`, and `list` as subcommands
+- [x] 6.2 Update `cmd/swm/internal/cli/root.go` — add `cfgPath string` parameter to `NewRootCmd` and register `NewConfigCmd` as a subcommand of root
+- [x] 6.3 Update `cmd/swm/main.go` — compute `cfgPath := config.ResolveConfigPath(...)` before calling `config.Load`, and pass it to `cli.NewRootCmd`
+
+## 7. Verification
+
+- [x] 7.1 Run `task fmt && task lint && task test` in `cmd/swm` — confirm zero exit status and all tests green

--- a/openspec/specs/config-command/spec.md
+++ b/openspec/specs/config-command/spec.md
@@ -1,0 +1,118 @@
+# Spec: config-command
+
+CLI subcommands for reading and writing swm configuration without manually editing the TOML file.
+
+---
+
+## Requirement: swm config get
+
+`swm config get <key>` prints the effective value of a registered config key to stdout, followed by a newline. The effective value is the file-configured value if present, otherwise the compiled-in default.
+
+### Scenario: Get a key that has a default and is not in the config file
+- **GIVEN** no config file exists (or the key is absent from the file)
+- **WHEN** `swm config get code_root` is run
+- **THEN** the command exits zero and prints the default value (`~/code`)
+
+### Scenario: Get a key that is set in the config file
+- **GIVEN** `config.toml` contains `code_root = "/workspace/code"`
+- **WHEN** `swm config get code_root` is run
+- **THEN** the command exits zero and prints `/workspace/code`
+
+### Scenario: Get a nested key
+- **GIVEN** `config.toml` contains `[plugins]\nsession = "tmux"`
+- **WHEN** `swm config get plugins.session` is run
+- **THEN** the command exits zero and prints `tmux`
+
+### Scenario: Get a map sub-key
+- **GIVEN** `config.toml` contains `[plugins.paths]\nvcs-git = "/usr/local/bin/swm-plugin-vcs-git"`
+- **WHEN** `swm config get plugins.paths.vcs-git` is run
+- **THEN** the command exits zero and prints `/usr/local/bin/swm-plugin-vcs-git`
+
+### Scenario: Get an unknown key
+- **WHEN** `swm config get does.not.exist` is run
+- **THEN** the command exits non-zero and prints an error message listing valid keys to stderr
+
+### Scenario: Get with missing argument
+- **WHEN** `swm config get` is run with no arguments
+- **THEN** the command exits non-zero and prints usage to stderr
+
+---
+
+## Requirement: swm config set
+
+`swm config set <key> <value>` writes a new scalar value for a registered writable key to the config file. If the config file does not exist, it is created (including parent directories). Comments in an existing file are not preserved after a write.
+
+### Scenario: Set a top-level key in an existing config file
+- **GIVEN** `config.toml` exists with `code_root = "~/code"`
+- **WHEN** `swm config set code_root /workspace` is run
+- **THEN** the command exits zero, and `config.toml` contains `code_root = "/workspace"`
+
+### Scenario: Set creates the config file when it does not exist
+- **GIVEN** no config file exists
+- **WHEN** `swm config set default_story main` is run
+- **THEN** the command exits zero, the config file is created, and it contains `default_story = "main"`
+
+### Scenario: Set a nested key
+- **WHEN** `swm config set plugins.session tmux` is run
+- **THEN** the command exits zero and `config.toml` contains `session = "tmux"` under `[plugins]`
+
+### Scenario: Set a map sub-key
+- **WHEN** `swm config set plugins.paths.vcs-git /usr/local/bin/swm-plugin-vcs-git` is run
+- **THEN** the command exits zero and `config.toml` contains the path under `[plugins.paths]`
+
+### Scenario: Set a non-writable key
+- **WHEN** `swm config set plugins.forges "github"` is run
+- **THEN** the command exits non-zero and prints an error message indicating the key is not writable via `set` in this version
+
+### Scenario: Set an unknown key
+- **WHEN** `swm config set does.not.exist value` is run
+- **THEN** the command exits non-zero and prints an error message listing valid keys to stderr
+
+### Scenario: Set with wrong argument count
+- **WHEN** `swm config set plugins.session` is run with only one argument
+- **THEN** the command exits non-zero and prints usage to stderr
+
+---
+
+## Requirement: swm config list
+
+`swm config list` prints only the keys that are explicitly present in the config file, in `key = value` format (one per line). If no config file exists, it prints nothing and exits zero.
+
+### Scenario: No config file
+- **GIVEN** no config file exists
+- **WHEN** `swm config list` is run
+- **THEN** the command exits zero and prints nothing to stdout
+
+### Scenario: Config file with some keys set
+- **GIVEN** `config.toml` contains `code_root = "/workspace"` and `[plugins]\nsession = "tmux"`
+- **WHEN** `swm config list` is run
+- **THEN** the command exits zero and prints exactly:
+  ```
+  code_root = /workspace
+  plugins.session = tmux
+  ```
+
+### Scenario: Array key displayed inline
+- **GIVEN** `config.toml` contains `[plugins]\nforges = ["github"]`
+- **WHEN** `swm config list` is run
+- **THEN** the command exits zero and the output includes `plugins.forges = ["github"]`
+
+---
+
+## Requirement: swm config list --all
+
+`swm config list --all` prints every registered key with its effective value (configured or default), in key registry definition order.
+
+### Scenario: Fresh install with no config file
+- **GIVEN** no config file exists
+- **WHEN** `swm config list --all` is run
+- **THEN** the command exits zero and all registered keys are printed with their default values
+
+### Scenario: Some keys configured
+- **GIVEN** `config.toml` contains `code_root = "/workspace"`
+- **WHEN** `swm config list --all` is run
+- **THEN** the command exits zero, `code_root` shows `/workspace`, and all other keys show their defaults
+
+### Scenario: Output order is stable
+- **WHEN** `swm config list --all` is run twice
+- **THEN** both outputs are identical (keys appear in registry definition order, not map iteration order)


### PR DESCRIPTION
Users previously had to open config.toml manually to change any
setting. This adds a `swm config` subcommand so settings can be
read and written directly from the CLI.

Three subcommands are provided:
- `swm config get <key>` — prints the effective value of a key
- `swm config set <key> <value>` — writes a value to config.toml
- `swm config list` — shows only keys present in the config file
- `swm config list --all` — shows all keys with their effective
  values (including defaults)

Keys use dot notation (e.g. `plugins.session`, `plugins.paths.*`).
A static KeyDef registry maps each key to typed getter/setter funcs
on *Config. Wildcard matching handles the `plugins.paths.<name>`
namespace.

Writes are atomic: config is marshalled, written to a `.tmp` file,
then renamed over the destination. `omitempty` TOML tags ensure
only explicitly set fields appear in the saved file.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>