### PR TITLE
feat: add story name completion to workspace open/story remove

### DIFF
--- a/cmd/swm/internal/cli/story/remove.go
+++ b/cmd/swm/internal/cli/story/remove.go
@@ -98,7 +98,11 @@ func NewRemoveCmd(
 
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "skip confirmation prompt")
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
 		stories, err := store.List(cmd.Context())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError

--- a/cmd/swm/internal/cli/story/remove.go
+++ b/cmd/swm/internal/cli/story/remove.go
@@ -98,6 +98,20 @@ func NewRemoveCmd(
 
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "skip confirmation prompt")
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		stories, err := store.List(cmd.Context())
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		names := make([]string, len(stories))
+		for i, s := range stories {
+			names[i] = s.Name
+		}
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 

--- a/cmd/swm/internal/cli/story/remove_test.go
+++ b/cmd/swm/internal/cli/story/remove_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
@@ -222,4 +223,47 @@ func TestRemoveCmd_ExplicitArg_OverridesSWMStory(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	require.True(t, store.deleted)
 	require.Equal(t, testStoryName, store.lastGetName)
+}
+
+func TestRemoveCmd_Completion_ReturnsStoryNames(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{
+		listStories: []*coreStory.Story{{Name: testStoryName}, {Name: testBugName}},
+	}
+	mgr := &stubManager{}
+	resolver := layout.NewResolver("/code", "_default")
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, nil, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	require.ElementsMatch(t, []string{testStoryName, testBugName}, completions)
+}
+
+func TestRemoveCmd_Completion_NoFileComp(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{listStories: []*coreStory.Story{{Name: testStoryName}}}
+	mgr := &stubManager{}
+	resolver := layout.NewResolver("/code", "_default")
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
+
+	_, directive := cmd.ValidArgsFunction(cmd, nil, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestRemoveCmd_Completion_StoreError_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{listErr: errFakeStore}
+	mgr := &stubManager{}
+	resolver := layout.NewResolver("/code", "_default")
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, nil, "")
+	require.Equal(t, cobra.ShellCompDirectiveError, directive)
+	require.Empty(t, completions)
 }

--- a/cmd/swm/internal/cli/story/remove_test.go
+++ b/cmd/swm/internal/cli/story/remove_test.go
@@ -267,3 +267,19 @@ func TestRemoveCmd_Completion_StoreError_ReturnsError(t *testing.T) {
 	require.Equal(t, cobra.ShellCompDirectiveError, directive)
 	require.Empty(t, completions)
 }
+
+func TestRemoveCmd_Completion_ArgAlreadyProvided_NoMoreCompletions(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{
+		listStories: []*coreStory.Story{{Name: testStoryName}, {Name: testBugName}},
+	}
+	mgr := &stubManager{}
+	resolver := layout.NewResolver("/code", "_default")
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{testStoryName}, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	require.Empty(t, completions)
+}

--- a/cmd/swm/internal/cli/story/testhelpers_test.go
+++ b/cmd/swm/internal/cli/story/testhelpers_test.go
@@ -24,6 +24,9 @@ const (
 // errNotFound is a sentinel used in tests.
 var errNotFound = errors.New("not found")
 
+// errFakeStore is a sentinel used by completion tests.
+var errFakeStore = errors.New("store unavailable")
+
 // stubStore is a minimal story.Store implementation for CLI tests.
 type stubStore struct {
 	lastCreatedName   string

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -271,7 +271,11 @@ func NewOpenCmd(
 	cmd.Flags().BoolVar(&killPane, "kill-pane", false,
 		"close the originating multiplexer pane after switching to the new workspace")
 
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
 		stories, err := store.List(cmd.Context())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -271,6 +271,20 @@ func NewOpenCmd(
 	cmd.Flags().BoolVar(&killPane, "kill-pane", false,
 		"close the originating multiplexer pane after switching to the new workspace")
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		stories, err := store.List(cmd.Context())
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		names := make([]string, len(stories))
+		for i, s := range stories {
+			names[i] = s.Name
+		}
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -1100,6 +1100,23 @@ func TestOpenCmd_Completion_StoreError_ReturnsError(t *testing.T) {
 	require.Empty(t, completions)
 }
 
+func TestOpenCmd_Completion_ArgAlreadyProvided_NoMoreCompletions(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{
+		listStories: []*coreStory.Story{{Name: testStoryName}, {Name: testDefaultStory}},
+	}
+	mgr := &stubMgr{}
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{testStoryName}, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	require.Empty(t, completions)
+}
+
 // stubStore is a minimal story.Store.
 type stubStore struct {
 	getStory     *coreStory.Story

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -40,8 +41,9 @@ const (
 )
 
 var (
-	errNoPlugin = errors.New("no plugin")
-	errFakeHook = errors.New("hook error")
+	errNoPlugin  = errors.New("no plugin")
+	errFakeHook  = errors.New("hook error")
+	errFakeStore = errors.New("store unavailable")
 )
 
 func TestOpenCmd_WithPositionalArg(t *testing.T) {
@@ -1051,6 +1053,52 @@ func TestOpenCmd_NoKillPane_OmitsOriginFields(t *testing.T) {
 }
 
 // ─── stubs ───────────────────────────────────────────────────────────────────
+
+func TestOpenCmd_Completion_ReturnsStoryNames(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{
+		listStories: []*coreStory.Story{{Name: testStoryName}, {Name: testDefaultStory}},
+	}
+	mgr := &stubMgr{}
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, nil, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	require.ElementsMatch(t, []string{testStoryName, testDefaultStory}, completions)
+}
+
+func TestOpenCmd_Completion_NoFileComp(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{listStories: []*coreStory.Story{{Name: testStoryName}}}
+	mgr := &stubMgr{}
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
+
+	_, directive := cmd.ValidArgsFunction(cmd, nil, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestOpenCmd_Completion_StoreError_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{listErr: errFakeStore}
+	mgr := &stubMgr{}
+	resolver := layout.NewResolver(testCodeRoot, testDefaultStory)
+
+	cmd := workspace.NewOpenCmd(cfg, store, mgr, resolver, hookexec.Noop)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, nil, "")
+	require.Equal(t, cobra.ShellCompDirectiveError, directive)
+	require.Empty(t, completions)
+}
 
 // stubStore is a minimal story.Store.
 type stubStore struct {

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -287,9 +287,8 @@ func (m *Manager) discover(capability, name string) (string, error) {
 	// 0. SWM_PLUGIN_PATH: platform-specific path list, searched left-to-right.
 	// Non-existent or non-directory entries are silently skipped.
 	for _, dir := range filepath.SplitList(os.Getenv("SWM_PLUGIN_PATH")) {
-
 		candidate := filepath.Join(dir, binary)
-		if _, err := os.Stat(candidate); err == nil {
+		if _, err := os.Stat(candidate); err == nil { //nolint:gosec // SWM_PLUGIN_PATH is user-owned
 			return candidate, nil
 		}
 	}

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -81,13 +81,12 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func newCfg(session, vcs string) *config.Config {
+func newCfg(vcs string) *config.Config {
 	return &config.Config{
 		CodeRoot:     "/tmp/code",
 		DefaultStory: "_default",
 		Plugins: config.Plugins{
-			Session: session,
-			VCS:     vcs,
+			VCS: vcs,
 		},
 	}
 }
@@ -104,7 +103,7 @@ func TestDiscover_Path(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(dst, data, 0o755)) //nolint:gosec // binary must be executable
 
-	mgr := pluginmgr.New(newCfg("", "git"), "")
+	mgr := pluginmgr.New(newCfg("git"), "")
 	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
 	raw, err := mgr.Get(context.Background(), "vcs")
@@ -169,7 +168,7 @@ func TestGet_ClientIsVCSClient(t *testing.T) {
 func TestGet_MissingPlugin(t *testing.T) {
 	t.Parallel()
 
-	mgr := pluginmgr.New(newCfg("", "nonexistent"), "")
+	mgr := pluginmgr.New(newCfg("nonexistent"), "")
 	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
 	_, err := mgr.Get(context.Background(), "vcs")
@@ -179,7 +178,7 @@ func TestGet_MissingPlugin(t *testing.T) {
 func TestGet_UnconfiguredCapability(t *testing.T) {
 	t.Parallel()
 
-	mgr := pluginmgr.New(newCfg("", ""), "")
+	mgr := pluginmgr.New(newCfg(""), "")
 	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
 	_, err := mgr.Get(context.Background(), "vcs")
@@ -282,13 +281,12 @@ func copyBinary(t *testing.T, src, dst string) {
 
 func TestDiscover_SWMPluginPath(t *testing.T) {
 	// Cannot use t.Parallel with t.Setenv.
-
 	t.Run("finds binary in SWM_PLUGIN_PATH", func(t *testing.T) {
 		dir := t.TempDir()
 		copyBinary(t, fakeVCSBin, filepath.Join(dir, "swm-plugin-vcs-fake"))
 		t.Setenv("SWM_PLUGIN_PATH", dir)
 
-		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		mgr := pluginmgr.New(newCfg(fakePluginName), "")
 		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
 		raw, err := mgr.Get(context.Background(), "vcs")
@@ -302,12 +300,13 @@ func TestDiscover_SWMPluginPath(t *testing.T) {
 
 		copyBinary(t, fakeVCSBin, filepath.Join(devDir, "swm-plugin-vcs-fake"))
 		// dummy file on PATH — valid executable size but not a go-plugin binary
-		require.NoError(t, os.WriteFile(filepath.Join(sysDir, "swm-plugin-vcs-fake"), []byte("#!/bin/sh\nexit 1"), 0o755)) //nolint:gosec // test dummy
+		dummyPath := filepath.Join(sysDir, "swm-plugin-vcs-fake")
+		require.NoError(t, os.WriteFile(dummyPath, []byte("#!/bin/sh\nexit 1"), 0o755)) //nolint:gosec // test dummy
 
 		t.Setenv("SWM_PLUGIN_PATH", devDir)
 		t.Setenv("PATH", sysDir+string(filepath.ListSeparator)+os.Getenv("PATH"))
 
-		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		mgr := pluginmgr.New(newCfg(fakePluginName), "")
 		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
 		raw, err := mgr.Get(context.Background(), "vcs")
@@ -349,7 +348,7 @@ func TestDiscover_SWMPluginPath(t *testing.T) {
 		copyBinary(t, fakeVCSBin, filepath.Join(dir2, "swm-plugin-vcs-fake"))
 		t.Setenv("SWM_PLUGIN_PATH", dir1+string(filepath.ListSeparator)+dir2)
 
-		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		mgr := pluginmgr.New(newCfg(fakePluginName), "")
 		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
 		raw, err := mgr.Get(context.Background(), "vcs")
@@ -362,7 +361,7 @@ func TestDiscover_SWMPluginPath(t *testing.T) {
 		copyBinary(t, fakeVCSBin, filepath.Join(realDir, "swm-plugin-vcs-fake"))
 		t.Setenv("SWM_PLUGIN_PATH", "/nonexistent-pluginmgr-test"+string(filepath.ListSeparator)+realDir)
 
-		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		mgr := pluginmgr.New(newCfg(fakePluginName), "")
 		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
 		raw, err := mgr.Get(context.Background(), "vcs")
@@ -377,7 +376,7 @@ func TestDiscover_SWMPluginPath(t *testing.T) {
 		copyBinary(t, fakeVCSBin, filepath.Join(dir, "swm-plugin-vcs-fake"))
 		t.Setenv("PATH", dir+string(filepath.ListSeparator)+os.Getenv("PATH"))
 
-		mgr := pluginmgr.New(newCfg("", fakePluginName), "")
+		mgr := pluginmgr.New(newCfg(fakePluginName), "")
 		defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
 		raw, err := mgr.Get(context.Background(), "vcs")

--- a/openspec/changes/archive/2026-05-19-autocomplete-story-name/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-autocomplete-story-name/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/archive/2026-05-19-autocomplete-story-name/design.md
+++ b/openspec/changes/archive/2026-05-19-autocomplete-story-name/design.md
@@ -1,0 +1,46 @@
+## Context
+
+`swm workspace open [story]` and `swm story remove [story]` each accept an optional story name positional argument. Currently no `ValidArgsFunction` is registered on either command, so shells offer no dynamic completions for that argument. Both commands already receive a `coreStory.Store` parameter, so the story list is available without any new wiring.
+
+The existing `shell-completion` spec covers static script generation (bash/zsh/fish) and Nix installation. It does not address dynamic argument completions. Cobra's shell completion infrastructure supports dynamic completions via `ValidArgsFunction` on a `*cobra.Command`; the generated scripts already call back to `swm __complete` at tab time, so no changes to the generated scripts or Nix installation are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Register a `ValidArgsFunction` on `workspace open` that returns all story names from the store.
+- Register a `ValidArgsFunction` on `story remove` that returns all story names from the store.
+- Completions return `cobra.ShellCompDirectiveNoFileComp` so the shell does not fall back to filename completion.
+
+**Non-Goals:**
+- Adding completion to `story create` (new name, not an existing one).
+- Changing the static completion scripts or Nix installation.
+- Filtering out `_default` from completion results (user may want to open it explicitly).
+
+## Decisions
+
+### Use `ValidArgsFunction` on each command directly
+
+Each command constructor (`NewOpenCmd`, `NewRemoveCmd`) already takes `store coreStory.Store`. Setting `cmd.ValidArgsFunction` inline in the constructor keeps the completion logic co-located with the command, requires no new types or packages, and is the idiomatic cobra pattern.
+
+Alternative considered: a shared helper `StoryNameCompletionFunc(store)` extracted to a shared package. Rejected — two call sites don't justify an abstraction, and the helper would need to import `coreStory` anyway, creating no real decoupling.
+
+### Return all stories; let the shell filter by prefix
+
+`ValidArgsFunction` returns the full list; the shell handles prefix filtering. This is the standard cobra approach and avoids re-implementing prefix matching.
+
+### Errors in `ValidArgsFunction` are silent
+
+If `store.List` fails, return an empty slice with `cobra.ShellCompDirectiveError`. This degrades gracefully (no completion, no crash) and matches cobra convention. No logging — completion runs in a short-lived subprocess where log output would corrupt completion output.
+
+## Risks / Trade-offs
+
+- **Store I/O on every tab press**: `store.List` reads the story JSON store from disk. For typical story counts (< 100) this is negligible. No caching needed.
+- **Completion subprocess context**: cobra spawns a child process for `__complete`. The store path comes from the same config resolution as the main command, so it is correct.
+
+## Migration Plan
+
+No migration needed. Additive change; existing scripts continue to work unchanged.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-19-autocomplete-story-name/proposal.md
+++ b/openspec/changes/archive/2026-05-19-autocomplete-story-name/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Commands that accept a story name positional argument (`workspace open`, `story remove`) require users to type the name verbatim with no shell completion support. This forces users to remember exact story names or run `swm story list` first, breaking the fast-switching workflow swm is designed for.
+
+## What Changes
+
+- Extend shell completion for `swm workspace open [story]` to complete available story names from the story store.
+- Extend shell completion for `swm story remove [story]` to complete available story names from the story store.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None -->
+
+### Modified Capabilities
+
+- `shell-completion` — add requirements for dynamic story-name completions on commands that accept a story name argument.
+
+## Non-goals
+
+- Completing story names for `swm story create` (creation implies a new, previously unknown name).
+- Adding story-name completion to plugin-facing or internal APIs.
+- Changing how the interactive story picker behaves when no argument is provided to `workspace open`.
+
+## Impact
+
+- Capability surface: none (shell completion is a CLI surface, not session/vcs/forge/picker/hook).
+- No proto changes required.
+- Affected code: command definitions for `workspace open` and `story remove` — each needs a `ValidArgsFunction` (cobra) that queries the story store and returns story names as completion candidates.
+- No new dependencies.

--- a/openspec/changes/archive/2026-05-19-autocomplete-story-name/specs/shell-completion/spec.md
+++ b/openspec/changes/archive/2026-05-19-autocomplete-story-name/specs/shell-completion/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Story name completion for workspace open
+The `swm workspace open` command SHALL provide dynamic shell completion for its optional `[story-name]` positional argument by returning all known story names from the story store.
+
+#### Scenario: Story names are offered as completions
+- **WHEN** the user presses Tab after `swm workspace open `
+- **THEN** the shell displays all story names from the store as completion candidates
+
+#### Scenario: Story name prefix is filtered by shell
+- **WHEN** the user types `swm workspace open feat` and presses Tab
+- **THEN** the shell displays only story names that begin with `feat`
+
+#### Scenario: No fallback to filename completion
+- **WHEN** the user presses Tab after `swm workspace open `
+- **THEN** the shell does NOT offer filenames as completion candidates
+
+#### Scenario: Store error degrades gracefully
+- **WHEN** the user presses Tab after `swm workspace open ` and the story store returns an error
+- **THEN** no completion candidates are offered and the shell exits without error output
+
+### Requirement: Story name completion for story remove
+The `swm story remove` command SHALL provide dynamic shell completion for its optional `[name]` positional argument by returning all known story names from the story store.
+
+#### Scenario: Story names are offered as completions
+- **WHEN** the user presses Tab after `swm story remove `
+- **THEN** the shell displays all story names from the store as completion candidates
+
+#### Scenario: Story name prefix is filtered by shell
+- **WHEN** the user types `swm story remove feat` and presses Tab
+- **THEN** the shell displays only story names that begin with `feat`
+
+#### Scenario: No fallback to filename completion
+- **WHEN** the user presses Tab after `swm story remove `
+- **THEN** the shell does NOT offer filenames as completion candidates
+
+#### Scenario: Store error degrades gracefully
+- **WHEN** the user presses Tab after `swm story remove ` and the story store returns an error
+- **THEN** no completion candidates are offered and the shell exits without error output

--- a/openspec/changes/archive/2026-05-19-autocomplete-story-name/tasks.md
+++ b/openspec/changes/archive/2026-05-19-autocomplete-story-name/tasks.md
@@ -1,0 +1,15 @@
+## 1. Story name completion for `workspace open` (cmd/swm)
+
+- [x] 1.1 Write failing unit tests in `cmd/swm/internal/cli/workspace/open_test.go` covering: story names returned on Tab, no-file-comp directive, and graceful store error
+- [x] 1.2 Add `ValidArgsFunction` to `NewOpenCmd` in `cmd/swm/internal/cli/workspace/open.go` that calls `store.List` and returns story names with `cobra.ShellCompDirectiveNoFileComp`
+- [x] 1.3 Confirm all `workspace open` completion unit tests pass
+
+## 2. Story name completion for `story remove` (cmd/swm)
+
+- [x] 2.1 Write failing unit tests in `cmd/swm/internal/cli/story/remove_test.go` covering: story names returned on Tab, no-file-comp directive, and graceful store error
+- [x] 2.2 Add `ValidArgsFunction` to `NewRemoveCmd` in `cmd/swm/internal/cli/story/remove.go` that calls `store.List` and returns story names with `cobra.ShellCompDirectiveNoFileComp`
+- [x] 2.3 Confirm all `story remove` completion unit tests pass
+
+## 3. Verification
+
+- [x] 3.1 Run `task fmt && task lint && task test` in `cmd/swm` — confirm all pass with zero errors

--- a/openspec/specs/shell-completion/spec.md
+++ b/openspec/specs/shell-completion/spec.md
@@ -61,3 +61,51 @@ automatically.
 - **WHEN** the `swm` Nix package is built
 - **THEN** a fish completion file for `swm` is present under
   `$out/share/fish/vendor_completions.d/`
+
+### Requirement: Story name completion for workspace open
+
+The `swm workspace open` command SHALL provide dynamic shell completion for its optional `[story-name]` positional argument by returning all known story names from the story store.
+
+#### Scenario: Story names are offered as completions
+
+- **WHEN** the user presses Tab after `swm workspace open `
+- **THEN** the shell displays all story names from the store as completion candidates
+
+#### Scenario: Story name prefix is filtered by shell
+
+- **WHEN** the user types `swm workspace open feat` and presses Tab
+- **THEN** the shell displays only story names that begin with `feat`
+
+#### Scenario: No fallback to filename completion
+
+- **WHEN** the user presses Tab after `swm workspace open `
+- **THEN** the shell does NOT offer filenames as completion candidates
+
+#### Scenario: Store error degrades gracefully
+
+- **WHEN** the user presses Tab after `swm workspace open ` and the story store returns an error
+- **THEN** no completion candidates are offered and the shell exits without error output
+
+### Requirement: Story name completion for story remove
+
+The `swm story remove` command SHALL provide dynamic shell completion for its optional `[name]` positional argument by returning all known story names from the story store.
+
+#### Scenario: Story names are offered as completions
+
+- **WHEN** the user presses Tab after `swm story remove `
+- **THEN** the shell displays all story names from the store as completion candidates
+
+#### Scenario: Story name prefix is filtered by shell
+
+- **WHEN** the user types `swm story remove feat` and presses Tab
+- **THEN** the shell displays only story names that begin with `feat`
+
+#### Scenario: No fallback to filename completion
+
+- **WHEN** the user presses Tab after `swm story remove `
+- **THEN** the shell does NOT offer filenames as completion candidates
+
+#### Scenario: Store error degrades gracefully
+
+- **WHEN** the user presses Tab after `swm story remove ` and the story store returns an error
+- **THEN** no completion candidates are offered and the shell exits without error output


### PR DESCRIPTION
Commands that accept a story name positional argument had no shell
completion support, forcing users to type names verbatim or run
`swm story list` first.

Add `ValidArgsFunction` to `workspace open` and `story remove` using
cobra's dynamic completion API. Each function calls `store.List` and
returns all story names with `ShellCompDirectiveNoFileComp` so shells
offer dynamic candidates on Tab without falling back to filenames.
On store error the directive is set to `ShellCompDirectiveError` for
graceful degradation.

Also fix six pre-existing lint issues in pluginmgr (gosec false
positive, long line, unused param, whitespace violations).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>