### PR TITLE
fix: serialize go.work updates with flock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ plugins/*/swm-plugin-*
 
 # Go workspace file
 go.work
+go.work.lock
 go.work.sum
 
 # Go and Nix-related build result

--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -38,14 +38,14 @@
               if [[ ! -f go.work ]]; then
                 go work init
               fi
-              for __go_mod__ in cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod proto/go.mod; do
+              while IFS= read -r __go_mod__; do
                 go work use "$(dirname "$__go_mod__")"
-              done
-              for __go_mod__ in go.work cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod proto/go.mod; do
+              done < <(${pkgs.findutils}/bin/find cmd sdk plugins proto -name go.mod)
+              while IFS= read -r __go_mod__; do
                 if [[ "$(${pkgs.gnugrep}/bin/grep '^\(go \)[0-9.]*$' "$__go_mod__")" != "go ${goVersion}" ]]; then
                   ${pkgs.gnused}/bin/sed -e "s:^\(go \)[0-9.]*$:\1${goVersion}:" -i "$__go_mod__"
                 fi
-              done
+              done < <({ echo "go.work"; ${pkgs.findutils}/bin/find cmd sdk plugins proto -name go.mod; })
             ) 200>"$PWD/go.work.lock"
           '';
       };

--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -11,7 +11,6 @@
         buildInputs = [
           pkgs.buf
           pkgs.delve
-          pkgs.flock
           pkgs.go
           pkgs.go-task
           pkgs.golangci-lint
@@ -35,7 +34,7 @@
             ${config.pre-commit.installationScript}
 
             (
-              flock -x 200
+              ${pkgs.flock}/bin/flock -x 200
               if [[ ! -f go.work ]]; then
                 go work init
               fi

--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -11,6 +11,7 @@
         buildInputs = [
           pkgs.buf
           pkgs.delve
+          pkgs.flock
           pkgs.go
           pkgs.go-task
           pkgs.golangci-lint
@@ -33,20 +34,20 @@
 
             ${config.pre-commit.installationScript}
 
-            if [[ ! -f go.work ]]; then
-              go work init
-            fi
-            for __go_mod__ in cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod proto/go.mod; do
-              go work use "$(dirname "$__go_mod__")"
-            done
-
             (
+              flock -x 200
+              if [[ ! -f go.work ]]; then
+                go work init
+              fi
+              for __go_mod__ in cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod proto/go.mod; do
+                go work use "$(dirname "$__go_mod__")"
+              done
               for __go_mod__ in go.work cmd/**/go.mod sdk/**/go.mod plugins/**/go.mod proto/go.mod; do
                 if [[ "$(${pkgs.gnugrep}/bin/grep '^\(go \)[0-9.]*$' "$__go_mod__")" != "go ${goVersion}" ]]; then
                   ${pkgs.gnused}/bin/sed -e "s:^\(go \)[0-9.]*$:\1${goVersion}:" -i "$__go_mod__"
                 fi
               done
-            )
+            ) 200>"$PWD/go.work.lock"
           '';
       };
     };


### PR DESCRIPTION
Multiple concurrent direnv reloads race on go.work and go.mod files,
causing corruption. Consolidate all go work init/use and go-version
update steps into a single subshell guarded by flock(1) on
go.work.lock, serializing access across shells on both Linux and macOS.

Add pkgs.flock to devShells.default buildInputs (cross-platform via
nixpkgs) and ignore go.work.lock in .gitignore.