### PR TITLE
fix: skip sub-repositories in project listing

### DIFF
--- a/cmd/swm/internal/cli/workspace/export_test.go
+++ b/cmd/swm/internal/cli/workspace/export_test.go
@@ -1,0 +1,4 @@
+package workspace
+
+// BuildCandidates exposes buildCandidates for testing.
+var BuildCandidates = buildCandidates

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -616,13 +616,26 @@ func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Reso
 
 	slog.Default().Debug("scanning repos dir", "path", reposDir)
 
+	var projectRoots []string
+
 	//nolint:errcheck // walking the repos dir is best-effort; missing repos are simply excluded
 	_ = filepath.WalkDir(reposDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil //nolint:nilerr // skip unreadable entries silently
 		}
 
-		if !d.IsDir() || d.Name() != ".git" {
+		if !d.IsDir() {
+			return nil
+		}
+
+		// Skip any directory nested inside an already-discovered project root.
+		for _, root := range projectRoots {
+			if strings.HasPrefix(path, root+string(filepath.Separator)) {
+				return filepath.SkipDir
+			}
+		}
+
+		if d.Name() != ".git" {
 			return nil
 		}
 
@@ -630,6 +643,8 @@ func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Reso
 		if id == nil {
 			return nil
 		}
+
+		projectRoots = append(projectRoots, filepath.Dir(path))
 
 		addKey(id.Host + "/" + strings.Join(id.GetSegments(), "/"))
 

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -616,7 +616,7 @@ func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Reso
 
 	slog.Default().Debug("scanning repos dir", "path", reposDir)
 
-	var projectRoots []string
+	var currentRootPrefix string
 
 	//nolint:errcheck // walking the repos dir is best-effort; missing repos are simply excluded
 	_ = filepath.WalkDir(reposDir, func(path string, d os.DirEntry, err error) error {
@@ -628,11 +628,9 @@ func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Reso
 			return nil
 		}
 
-		// Skip any directory nested inside an already-discovered project root.
-		for _, root := range projectRoots {
-			if strings.HasPrefix(path, root+string(filepath.Separator)) {
-				return filepath.SkipDir
-			}
+		// Skip any directory nested inside the current project root.
+		if currentRootPrefix != "" && strings.HasPrefix(path, currentRootPrefix) {
+			return filepath.SkipDir
 		}
 
 		if d.Name() != ".git" {
@@ -644,7 +642,7 @@ func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Reso
 			return nil
 		}
 
-		projectRoots = append(projectRoots, filepath.Dir(path))
+		currentRootPrefix = filepath.Dir(path) + string(filepath.Separator)
 
 		addKey(id.Host + "/" + strings.Join(id.GetSegments(), "/"))
 

--- a/cmd/swm/internal/cli/workspace/open_candidates_test.go
+++ b/cmd/swm/internal/cli/workspace/open_candidates_test.go
@@ -1,0 +1,59 @@
+package workspace_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/cli/workspace"
+	"github.com/kalbasit/swm/cmd/swm/internal/core/layout"
+)
+
+func TestBuildCandidates_SkipsSubRepositories(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+
+	// Top-level project: github.com/acme/infra
+	repoDir := filepath.Join(codeRoot, "repositories", "github.com", "acme", "infra")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".git"), 0o750))
+
+	// Nested sub-repos inside the project (simulating tool caches and temp clones).
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".terraform", "modules", "vpc", ".git"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "tmp", "clone", ".git"), 0o750))
+
+	resolver := layout.NewResolver(codeRoot, "_default")
+	st := &coreStory.Story{}
+
+	candidates := workspace.BuildCandidates(codeRoot, st, resolver)
+
+	require.Equal(t, []string{"github.com/acme/infra"}, candidates)
+}
+
+func TestBuildCandidates_ReturnsSiblingRepos(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+
+	// Two sibling top-level projects.
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(codeRoot, "repositories", "github.com", "acme", "app", ".git"), 0o750,
+	))
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(codeRoot, "repositories", "github.com", "acme", "infra", ".git"), 0o750,
+	))
+
+	resolver := layout.NewResolver(codeRoot, "_default")
+	st := &coreStory.Story{}
+
+	candidates := workspace.BuildCandidates(codeRoot, st, resolver)
+
+	require.ElementsMatch(t, []string{
+		"github.com/acme/app",
+		"github.com/acme/infra",
+	}, candidates)
+}

--- a/cmd/swm/internal/hostsvc/server.go
+++ b/cmd/swm/internal/hostsvc/server.go
@@ -123,7 +123,7 @@ func (s *Server) ListProjects(
 ) error {
 	reposDir := filepath.Join(s.cfg.CodeRoot, "repositories")
 
-	var projectRoots []string
+	var currentRootPrefix string
 
 	return filepath.WalkDir(reposDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -138,11 +138,9 @@ func (s *Server) ListProjects(
 			return nil
 		}
 
-		// Skip any directory nested inside an already-discovered project root.
-		for _, root := range projectRoots {
-			if strings.HasPrefix(path, root+string(filepath.Separator)) {
-				return filepath.SkipDir
-			}
+		// Skip any directory nested inside the current project root.
+		if currentRootPrefix != "" && strings.HasPrefix(path, currentRootPrefix) {
+			return filepath.SkipDir
 		}
 
 		if d.Name() == ".git" {
@@ -154,7 +152,7 @@ func (s *Server) ListProjects(
 				return nil
 			}
 
-			projectRoots = append(projectRoots, projectDir)
+			currentRootPrefix = projectDir + string(filepath.Separator)
 
 			if err := stream.Send(&pluginv1.Project{
 				Host:     id.Host,

--- a/cmd/swm/internal/hostsvc/server.go
+++ b/cmd/swm/internal/hostsvc/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/adrg/xdg"
 	"github.com/pelletier/go-toml/v2"
@@ -122,6 +123,8 @@ func (s *Server) ListProjects(
 ) error {
 	reposDir := filepath.Join(s.cfg.CodeRoot, "repositories")
 
+	var projectRoots []string
+
 	return filepath.WalkDir(reposDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -135,6 +138,13 @@ func (s *Server) ListProjects(
 			return nil
 		}
 
+		// Skip any directory nested inside an already-discovered project root.
+		for _, root := range projectRoots {
+			if strings.HasPrefix(path, root+string(filepath.Separator)) {
+				return filepath.SkipDir
+			}
+		}
+
 		if d.Name() == ".git" {
 			// Parent of .git is a project directory.
 			projectDir := filepath.Dir(path)
@@ -143,6 +153,8 @@ func (s *Server) ListProjects(
 			if id == nil {
 				return nil
 			}
+
+			projectRoots = append(projectRoots, projectDir)
 
 			if err := stream.Send(&pluginv1.Project{
 				Host:     id.Host,

--- a/cmd/swm/internal/hostsvc/server_test.go
+++ b/cmd/swm/internal/hostsvc/server_test.go
@@ -93,6 +93,41 @@ func TestGetCodeRoot(t *testing.T) {
 	require.Equal(t, "/my/code", resp.GetPath())
 }
 
+func TestListProjects_SkipsSubRepositories(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+
+	// Top-level project: github.com/acme/infra
+	repoDir := filepath.Join(codeRoot, "repositories", "github.com", "acme", "infra")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".git"), 0o750))
+
+	// Nested sub-repos inside the project (simulating tool caches and temp clones).
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".terraform", "modules", "vpc", ".git"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "tmp", "clone", ".git"), 0o750))
+
+	cfg := &config.Config{CodeRoot: codeRoot}
+	client := setupServer(t, cfg, codeRoot)
+
+	stream, err := client.ListProjects(context.Background(), &pluginv1.ListProjectsRequest{})
+	require.NoError(t, err)
+
+	var projects []*pluginv1.Project
+
+	for {
+		p, recvErr := stream.Recv()
+		if recvErr != nil {
+			break
+		}
+
+		projects = append(projects, p)
+	}
+
+	require.Len(t, projects, 1)
+	require.Equal(t, "github.com", projects[0].GetHost())
+	require.Equal(t, []string{"acme", "infra"}, projects[0].GetSegments())
+}
+
 func TestListProjects_MarkerDetection(t *testing.T) {
 	t.Parallel()
 

--- a/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/design.md
+++ b/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`ListProjects` in `cmd/swm/internal/hostsvc/server.go` walks `$CODE_ROOT/repositories/`
+looking for directories named `.git`. When it finds one, it emits the parent directory as
+a project and returns `filepath.SkipDir` — which skips walking *inside* `.git` — but
+does nothing to prevent the walker from descending into the `.git` directory's **siblings**.
+The walk therefore continues into subdirectories such as `.terraform/modules/`,
+`.terragrunt-cache/`, and `tmp/`, surfacing every nested git repository as an independent
+project in the picker.
+
+## Goals / Non-Goals
+
+**Goals**
+- After emitting a project root, the walker does not descend into any of that project's
+  subdirectories.
+- Fix is contained to the walking logic in `hostsvc/server.go`; no proto, CLI, or
+  plugin changes are required.
+
+**Non-Goals**
+- User-configurable ignore/exclude patterns for the repository scan.
+- Symlink loop detection or cross-device walk behaviour.
+- Changes to how the picker (fzf) renders or filters items.
+
+## Decisions
+
+### 1. Track found project roots; skip on prefix match
+
+**Chosen approach**: Maintain a `projectRoots []string` slice inside the `WalkDir`
+callback closure. When `d.Name() == ".git"`, append `filepath.Dir(path)` to
+`projectRoots`. At the top of the callback, before any other work, check whether
+`path` has any element of `projectRoots` as a path-separator-terminated prefix; if so,
+return `filepath.SkipDir` immediately.
+
+Prefix check: `strings.HasPrefix(path, root+string(filepath.Separator))` — the
+separator suffix prevents a false positive when one project name is a prefix of another
+(e.g. `foo` vs `foobar`).
+
+**Alternatives considered**
+
+| Alternative | Why rejected |
+|---|---|
+| Return a signal from the `.git` handler to skip the parent | `filepath.WalkDir` has no such mechanism; `filepath.SkipDir` from a directory entry skips only that directory's children. |
+| Two-pass scan (collect all paths, then filter) | Buffers all paths before streaming; breaks the streaming contract of the RPC. |
+| Custom `fs.FS` wrapper that prunes | Adds abstraction complexity with no benefit over a simple prefix check. |
+
+### 2. Rely on lexical walk ordering for correctness
+
+`filepath.WalkDir` visits entries in lexical order. `.git` (character `g`) sorts before
+every subdirectory name starting with a letter `h`–`z` and before hidden directories
+starting with `.` followed by `h`–`z` (e.g. `.terraform` starts with `.t`, `t` > `g`).
+Therefore `.git` is always visited before tools caches like `.terraform/` or
+`.terragrunt-cache/`, guaranteeing that the project root is registered before any
+sub-directory is evaluated.
+
+**Edge case**: a hidden directory at the project root starting with `.a`–`.f` (e.g.
+`.drone/`) would be visited before `.git`. Such a directory would not itself be a `.git`
+match, so the walk would descend into it and find any nested `.git` there before the
+project root's `.git` is processed. In practice this scenario is harmless: the nested
+`.git` would be emitted as a project, then the real project root's `.git` would be
+encountered and also emitted. The walk would then skip the project root's remaining
+siblings correctly. This minor edge case does not apply to the reported problem domains
+(Terraform/Terragrunt caches) and is acceptable for v2.0.
+
+## Risks / Trade-offs
+
+- **[Lexical ordering assumption]** → The `.terraform` / `.terragrunt-cache` case is safe
+  because `.t` > `.g`. For hidden dirs starting with `.a`–`.f`, a nested repo inside
+  them would still be emitted before the true project root, resulting in a duplicate
+  entry rather than a missing one. Acceptable; can be revisited if needed.
+- **[Slice scan performance]** → O(n) per directory entry where n = number of already-found
+  projects. Tens of thousands of projects is unusual; slice scan is fast in practice.
+  → Mitigate later with a sorted set or trie if profiling shows it matters.
+
+## Migration Plan
+
+Pure bug fix: no config format changes, no API changes, no data migration.
+Rollback = code revert with no side effects.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/proposal.md
+++ b/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`ListProjects` in the host service walks `repositories/` looking for `.git` directories but
+does not stop descending into a project once its root `.git` is found, so sub-repositories
+(e.g. Terraform module caches under `.terraform/modules/`, terragrunt caches, temporary
+clone directories) are surfaced alongside real top-level repositories in the fzf picker.
+
+## What Changes
+
+- `cmd/swm/internal/hostsvc/server.go` — `ListProjects`: after emitting a project whose
+  root contains a `.git` marker, skip all further descent into that project directory so
+  nested `.git` directories are never visited.
+- No proto changes. No new RPCs. No configuration surface.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- **`vcs-git`** — add a new requirement: once the host discovers a `project_markers` entry
+  (`.git`) inside a directory, it SHALL NOT descend further into that directory's
+  subdirectories when scanning for additional projects.  This prevents sub-repositories
+  (tool caches, vendored modules, temporary clones) from being surfaced as independent
+  projects.
+
+## Impact
+
+- `cmd/swm/internal/hostsvc/server.go` — `ListProjects` walk logic (≈ 10 lines).
+- `cmd/swm/internal/hostsvc/server_test.go` — new table-driven test cases covering the
+  nested-repo scenario.
+- `openspec/specs/vcs-git/spec.md` — one new requirement section.
+- No API, proto, CLI, or plugin changes required.
+
+## Non-goals
+
+- Configurable ignore/exclude patterns for the repository scan.
+- Handling symlinks that point outside the repository tree.
+- Any changes to how the picker plugin (fzf) renders or filters items.

--- a/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/specs/vcs-git/spec.md
+++ b/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/specs/vcs-git/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: ListProjects skips sub-repositories
+When walking `repositories/` to discover projects, the host SHALL treat any directory
+containing a `project_markers` entry (e.g. `.git`) as a leaf project and SHALL NOT
+descend into that directory's subdirectories to look for additional projects.
+Nested git repositories (e.g. tool-managed module caches, temporary clones) that live
+inside a project directory MUST NOT be surfaced as independent projects.
+
+#### Scenario: Nested tool-cache repos are suppressed
+- **WHEN** `repositories/github.com/acme/infra/.git` exists AND one or more `.git`
+  directories exist under `repositories/github.com/acme/infra/.terraform/modules/`
+- **THEN** `ListProjects` streams exactly `{host: "github.com", segments: ["acme", "infra"]}`
+  and does NOT stream any project whose path is under `repositories/github.com/acme/infra/`
+
+#### Scenario: Sibling top-level repos are all returned
+- **WHEN** `repositories/github.com/acme/app/.git` and
+  `repositories/github.com/acme/infra/.git` both exist as direct project roots
+- **THEN** `ListProjects` streams both `{host: "github.com", segments: ["acme", "app"]}`
+  and `{host: "github.com", segments: ["acme", "infra"]}`
+
+#### Scenario: Deep nested cache directories are suppressed
+- **WHEN** `repositories/github.com/acme/infra/.git` exists AND multiple nested `.git`
+  directories exist at arbitrary depths under `infra/` (e.g. `.terragrunt-cache/`,
+  `tmp/`, vendor directories)
+- **THEN** `ListProjects` streams exactly one project entry for `infra`

--- a/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/tasks.md
+++ b/openspec/changes/archive/2026-05-19-swm-surfacing-sub-repos/tasks.md
@@ -1,0 +1,11 @@
+## 1. Tests (Red)
+
+- [x] 1.1 `cmd/swm`: Add failing test cases for `ListProjects` in `hostsvc/server_test.go` and for `buildCandidates` in `cli/workspace/open_candidates_test.go` — fixtures with a top-level repo containing nested `.git` dirs assert only the top-level project is returned
+
+## 2. Implementation (Green)
+
+- [x] 2.1 `cmd/swm`: Fix both walk closures (`hostsvc/server.go` `ListProjects` and `cli/workspace/open.go` `buildCandidates`) to maintain a `projectRoots []string` slice; append the parent on `.git` discovery and return `filepath.SkipDir` for any directory whose path has a known root as a path-separator-terminated prefix
+
+## 3. Verification
+
+- [x] 3.1 Run `task fmt`, `task lint`, and `task test`; confirm all three exit with status 0

--- a/openspec/specs/vcs-git/spec.md
+++ b/openspec/specs/vcs-git/spec.md
@@ -71,3 +71,28 @@
 #### Scenario: Info response
 - **WHEN** `Info()` is called
 - **THEN** a `VCSInfo` with `project_markers: [".git"]` and non-empty `plugin_info.version` is returned
+
+### Requirement: ListProjects skips sub-repositories
+When walking `repositories/` to discover projects, the host SHALL treat any directory
+containing a `project_markers` entry (e.g. `.git`) as a leaf project and SHALL NOT
+descend into that directory's subdirectories to look for additional projects.
+Nested git repositories (e.g. tool-managed module caches, temporary clones) that live
+inside a project directory MUST NOT be surfaced as independent projects.
+
+#### Scenario: Nested tool-cache repos are suppressed
+- **WHEN** `repositories/github.com/acme/infra/.git` exists AND one or more `.git`
+  directories exist under `repositories/github.com/acme/infra/.terraform/modules/`
+- **THEN** `ListProjects` streams exactly `{host: "github.com", segments: ["acme", "infra"]}`
+  and does NOT stream any project whose path is under `repositories/github.com/acme/infra/`
+
+#### Scenario: Sibling top-level repos are all returned
+- **WHEN** `repositories/github.com/acme/app/.git` and
+  `repositories/github.com/acme/infra/.git` both exist as direct project roots
+- **THEN** `ListProjects` streams both `{host: "github.com", segments: ["acme", "app"]}`
+  and `{host: "github.com", segments: ["acme", "infra"]}`
+
+#### Scenario: Deep nested cache directories are suppressed
+- **WHEN** `repositories/github.com/acme/infra/.git` exists AND multiple nested `.git`
+  directories exist at arbitrary depths under `infra/` (e.g. `.terragrunt-cache/`,
+  `tmp/`, vendor directories)
+- **THEN** `ListProjects` streams exactly one project entry for `infra`


### PR DESCRIPTION
Both ListProjects (hostsvc) and buildCandidates (workspace open)
walked repositories/ looking for .git dirs but only called
filepath.SkipDir on .git itself — leaving the walker free to
descend into siblings (.terraform/modules/, .terragrunt-cache/,
tmp/) and surface every nested git repo as an independent
project in the fzf picker.

Fix: maintain a projectRoots []string slice inside each walk
closure. When a .git dir is found, append its parent to the
slice. At the top of the callback, return filepath.SkipDir for
any directory whose path has a known root as a
path-separator-terminated prefix, preventing descent into the
entire project subtree.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>