### PR TITLE
fix: error when pane_group_command binary missing

### DIFF
--- a/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/design.md
+++ b/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/design.md
@@ -1,0 +1,45 @@
+## Context
+
+The `session-tmux` plugin's `OpenPaneGroup` accepts an optional `pane_group_command` from the host config. This command (e.g. `laio start ...`) is passed as the initial command to `tmux new-session`. When the binary in that command is missing from PATH, tmux creates the session but the command exits immediately — the user sees `[exited]` with no actionable error.
+
+The fix is localized to `plugins/session-tmux/internal/session/tmux.go`. No proto, config schema, or inter-plugin changes are needed.
+
+## Goals / Non-Goals
+
+**Goals**
+- Surface a clear error before the tmux session is created when `pane_group_command` names a binary not in PATH.
+
+**Non-Goals**
+- Validating arguments beyond the binary name.
+- Detecting runtime failures (the command launches but crashes later).
+- Changing how PATH is resolved (standard `exec.LookPath` only).
+
+## Decisions
+
+### Parse first token and call `exec.LookPath`
+
+In `OpenPaneGroup`, after `paneGroupCommand` returns a non-empty command string, split on whitespace to extract the first token and call `exec.LookPath` on it. If not found, return `codes.FailedPrecondition` with a message that names the missing binary and suggests the user check their PATH or install the tool.
+
+**Alternative considered**: shell-validate via `command -v` inside a subprocess — rejected because it adds a shell dependency and is slower than an in-process lookup.
+
+**Alternative considered**: let tmux report the failure and parse its stderr — rejected because tmux does not return a non-zero exit for "command not found in new-session"; it creates the session and lets the window exit.
+
+### Where to add the check
+
+In `OpenPaneGroup` immediately after `initialCmd := t.paneGroupCommand(ctx, req)` and before the `tmux has-session` call. A helper `validateCommandBinary(cmd string) error` keeps the logic separate and testable.
+
+### gRPC error code
+
+`codes.FailedPrecondition` — the request is valid; the environment is not ready. This maps to HTTP 400 and is surfaced as a user-visible error by the host CLI.
+
+## Risks / Trade-offs
+
+- **PATH divergence**: the plugin runs in the same process environment as `swm`, so if `laio` is in the user's PATH, `LookPath` finds it. If the user's shell profile adds a custom path not visible to `swm`, validation might reject a binary that would work inside the tmux session. This is the same limitation tmux itself has. → Acceptable; the common case (binary not installed at all) is caught cleanly.
+
+## Migration Plan
+
+No migration needed. The change is purely additive: new error path that was previously a silent failure.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/proposal.md
+++ b/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+When `pane_group_command` references a binary not in PATH (e.g. `laio`), the session-tmux plugin creates a tmux session successfully but the command exits immediately, leaving the user with a silent `[exited]` and no actionable error message.
+
+## What Changes
+
+- In `OpenPaneGroup`, after resolving `pane_group_command`, extract the first token and verify it exists in PATH via `exec.LookPath`. Return a descriptive gRPC error if the binary is missing.
+- No changes to proto, config schema, or other plugins.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `session-tmux` — add a new failure scenario to the existing `OpenPaneGroup` requirement: when `pane_group_command` is configured but its binary is not found in PATH, `OpenPaneGroup` SHALL return an error before creating the tmux session.
+
+## Non-goals
+
+- Validating the full pane_group_command argument list (only the binary is checked).
+- Modifying how tmux handles commands that exit after the session starts (runtime failures after successful launch are out of scope).
+- Any change to how the binary is resolved (PATH-based lookup only; no config override).
+
+## Impact
+
+- `plugins/session-tmux/internal/session/tmux.go` — `OpenPaneGroup` and `paneGroupCommand` (or a new helper).
+- `openspec/specs/session-tmux/` — delta spec for the new error scenario.
+- No API, proto, or config changes.

--- a/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/specs/session-tmux/spec.md
+++ b/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/specs/session-tmux/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: OpenPaneGroup in existing workspace
+`session-tmux` SHALL implement `Session.OpenPaneGroup({story_name, project_id, worktree_path})` by creating a new tmux session for the project within the story's socket (if it doesn't exist). The initial working directory SHALL be `worktree_path`. The default layout SHALL run `$EDITOR` (or `vim` if unset) in the first window and a shell in the second, unless `pane_group_command` is configured.
+
+When `pane_group_command` is configured, `session-tmux` SHALL validate that the first token of the command resolves to an executable via PATH lookup before creating the tmux session. If the binary is not found, `OpenPaneGroup` SHALL return a `FailedPrecondition` error naming the missing binary — no tmux session SHALL be created.
+
+#### Scenario: Default layout
+- **WHEN** `OpenPaneGroup` is called and no `pane_group_command` is configured
+- **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
+
+#### Scenario: Custom pane_group_command
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `laio start --file '<worktree_path>/.swm/laio.yaml' --tmux-socket '<tmux_socket>' --replace-current-session --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
+
+#### Scenario: Idempotent for existing session
+- **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket
+- **THEN** the existing session is reused and no new session is created
+
+#### Scenario: pane_group_command binary not found
+- **WHEN** `config.toml` has `pane_group_command = "laio start ..."` and `laio` is not present in PATH
+- **THEN** `OpenPaneGroup` returns a `FailedPrecondition` error with a message identifying the missing binary (e.g. `pane_group_command binary "laio" not found in PATH`)
+- **AND** no tmux session is created

--- a/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/tasks.md
+++ b/openspec/changes/archive/2026-05-19-swm-failing-when-laio-not-installed/tasks.md
@@ -1,0 +1,13 @@
+## 1. Test (Red)
+
+- [x] 1.1 In `plugins/session-tmux/internal/session/tmux_test.go`, add a table-driven test case for `OpenPaneGroup` where `pane_group_command` names a binary not present in PATH — assert the call returns a `FailedPrecondition` gRPC error and no tmux session is created
+
+## 2. Implementation (Green)
+
+- [x] 2.1 In `plugins/session-tmux/internal/session/tmux.go`, add a helper `validateCommandBinary(cmd string) error` that extracts the first whitespace-separated token from `cmd` and calls `exec.LookPath` on it, returning a `codes.FailedPrecondition` gRPC status error naming the missing binary if not found
+- [x] 2.2 In `OpenPaneGroup` (`plugins/session-tmux/internal/session/tmux.go`), after `initialCmd := t.paneGroupCommand(ctx, req)`, call `validateCommandBinary(initialCmd)` when `initialCmd` is non-empty and return the error immediately if it fails (before any `tmux has-session` call)
+
+## 3. Verify
+
+- [x] 3.1 Run `task fmt && task lint && task test` in `plugins/session-tmux/` — all must pass
+- [x] 3.2 Run `task fmt && task lint && task test` at repo root — all must pass

--- a/openspec/specs/session-tmux/spec.md
+++ b/openspec/specs/session-tmux/spec.md
@@ -68,6 +68,8 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 ### Requirement: OpenPaneGroup in existing workspace
 `session-tmux` SHALL implement `Session.OpenPaneGroup({story_name, project_id, worktree_path})` by creating a new tmux session for the project within the story's socket (if it doesn't exist). The initial working directory SHALL be `worktree_path`. The default layout SHALL run `$EDITOR` (or `vim` if unset) in the first window and a shell in the second, unless `pane_group_command` is configured.
 
+When `pane_group_command` is configured, `session-tmux` SHALL validate that the first token of the command resolves to an executable via PATH lookup before creating the tmux session. If the binary is not found, `OpenPaneGroup` SHALL return a `FailedPrecondition` error naming the missing binary — no tmux session SHALL be created.
+
 #### Scenario: Default layout
 - **WHEN** `OpenPaneGroup` is called and no `pane_group_command` is configured
 - **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
@@ -79,6 +81,11 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 #### Scenario: Idempotent for existing session
 - **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket
 - **THEN** the existing session is reused and no new session is created
+
+#### Scenario: pane_group_command binary not found
+- **WHEN** `config.toml` has `pane_group_command = "laio start ..."` and `laio` is not present in PATH
+- **THEN** `OpenPaneGroup` returns a `FailedPrecondition` error with a message identifying the missing binary (e.g. `pane_group_command binary "laio" not found in PATH`)
+- **AND** no tmux session is created
 
 ### Requirement: SwitchTo switches active pane group
 `session-tmux` SHALL implement `Session.SwitchTo({workspace_id, pane_group_id, close_origin_workspace_id, close_origin_pane_id})` by running `tmux -S <target_socket> switch-client -t <session-name>` if already inside a tmux session, or building an `exec_argv` of `["tmux", "-S", "<target_socket>", "attach-session", "-t", "<session-name>"]` otherwise.

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -195,6 +195,12 @@ func (t *Tmux) OpenPaneGroup(ctx context.Context, req *pluginv1.OpenPaneGroupReq
 	// Determine the initial command for the session.
 	initialCmd := t.paneGroupCommand(ctx, req)
 
+	if initialCmd != "" {
+		if err := validateCommandBinary(initialCmd); err != nil {
+			return nil, err
+		}
+	}
+
 	// Create session if it doesn't exist yet.
 	if _, err := t.run(ctx, "-S", sock, "has-session", "-t", name); err != nil {
 		args := []string{"-S", sock, "new-session", "-d", "-s", name, "-c", req.GetWorktreePath()}
@@ -353,6 +359,20 @@ func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroup
 	cmd = strings.ReplaceAll(cmd, "{{tmux_socket}}", req.GetWorkspaceId())
 
 	return cmd
+}
+
+// validateCommandBinary checks that the first token of cmd resolves to an
+// executable in PATH. Returns FailedPrecondition if not found, so callers can
+// surface a clear error before handing the command to tmux.
+func validateCommandBinary(cmd string) error {
+	binary := strings.Fields(cmd)[0]
+
+	if _, err := exec.LookPath(binary); err != nil {
+		return status.Errorf(codes.FailedPrecondition,
+			"pane_group_command binary %q not found in PATH: install it or update pane_group_command in config", binary)
+	}
+
+	return nil
 }
 
 func (t *Tmux) run(ctx context.Context, args ...string) (string, error) {

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -365,7 +365,12 @@ func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroup
 // executable in PATH. Returns FailedPrecondition if not found, so callers can
 // surface a clear error before handing the command to tmux.
 func validateCommandBinary(cmd string) error {
-	binary := strings.Fields(cmd)[0]
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return status.Errorf(codes.FailedPrecondition, "pane_group_command contains no command")
+	}
+
+	binary := fields[0]
 
 	if _, err := exec.LookPath(binary); err != nil {
 		return status.Errorf(codes.FailedPrecondition,

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -26,11 +26,6 @@ const (
 	testWorktree      = "/tmp/wt"
 	testPaneGroup     = testRepo
 	testPaneGroupFull = "github•com/kalbasit/swm"
-
-	// testLaioPaneGroupCommandTOML is the canonical pane_group_command used in tests.
-	testLaioPaneGroupCommandTOML = `pane_group_command = "laio start` +
-		` --file '{{worktree_path}}/.swm/laio.yaml'` +
-		` --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"`
 )
 
 var faketmuxBin string
@@ -356,8 +351,14 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 
 	sockPath := filepath.Join(socketDir, "feat-x.sock")
 
+	// Use faketmuxBin (guaranteed to exist) so binary validation passes.
+	// testLaioPaneGroupCommandTOML references laio, which may not be installed.
+	toml := `pane_group_command = "` + faketmuxBin +
+		` start --file '{{worktree_path}}/.swm/laio.yaml'` +
+		` --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"`
+
 	client := &fakeHostClient{
-		toml: []byte(testLaioPaneGroupCommandTOML),
+		toml: []byte(toml),
 	}
 
 	tmux := session.NewWithBinAndClient(faketmuxBin, socketDir, client)
@@ -378,7 +379,7 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
 	require.NoError(t, err)
 
-	wantCmd := "laio start --file '/tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml'" +
+	wantCmd := faketmuxBin + " start --file '/tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml'" +
 		" --tmux-socket '" + sockPath + "' --replace-current-session --skip-attach"
 
 	log := string(logBytes)
@@ -393,8 +394,13 @@ func TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution(t *testing.T) {
 
 	sockPath := filepath.Join(socketDir, "feat-sock.sock")
 
+	// Use faketmuxBin (guaranteed to exist) so binary validation passes.
+	toml := `pane_group_command = "` + faketmuxBin +
+		` start --file '{{worktree_path}}/.swm/laio.yaml'` +
+		` --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"`
+
 	client := &fakeHostClient{
-		toml: []byte(testLaioPaneGroupCommandTOML),
+		toml: []byte(toml),
 	}
 
 	tmux := session.NewWithBinAndClient(faketmuxBin, socketDir, client)

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
@@ -414,6 +416,41 @@ func TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution(t *testing.T) {
 	log := string(logBytes)
 	require.Contains(t, log, "--tmux-socket '"+sockPath+"'",
 		"{{tmux_socket}} must be substituted with the workspace socket path")
+}
+
+func TestOpenPaneGroup_PaneGroupCommandBinaryNotFound(t *testing.T) {
+	// Cannot be parallel — uses t.Setenv.
+	socketDir := t.TempDir()
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	sockPath := filepath.Join(socketDir, "feat-x.sock")
+
+	const missingBinaryTOML = `pane_group_command = "__swm_nonexistent_binary__ --some-flag"`
+
+	client := &fakeHostClient{toml: []byte(missingBinaryTOML)}
+	tmux := session.NewWithBinAndClient(faketmuxBin, socketDir, client)
+
+	if err := os.WriteFile(sockPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: testWorktree,
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err),
+		"expected FailedPrecondition when pane_group_command binary is not in PATH")
+	require.Contains(t, err.Error(), "__swm_nonexistent_binary__",
+		"error message must name the missing binary")
+
+	// No tmux session must have been created.
+	//nolint:gosec // G304: test-controlled path
+	logBytes, _ := os.ReadFile(logFile) //nolint:errcheck // log may not exist if tmux was never called
+	require.NotContains(t, string(logBytes), "new-session",
+		"no tmux session must be created when pane_group_command binary is missing")
 }
 
 func TestOpenPaneGroup_InvalidProjectID(t *testing.T) {

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -418,6 +418,32 @@ func TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution(t *testing.T) {
 		"{{tmux_socket}} must be substituted with the workspace socket path")
 }
 
+func TestOpenPaneGroup_PaneGroupCommandWhitespaceOnly(t *testing.T) {
+	// Cannot be parallel — uses t.Setenv.
+	socketDir := t.TempDir()
+	t.Setenv("FAKETMUX_LOG", filepath.Join(t.TempDir(), "tmux.log"))
+
+	sockPath := filepath.Join(socketDir, "feat-x.sock")
+
+	const whitespaceOnlyTOML = `pane_group_command = "   "`
+
+	client := &fakeHostClient{toml: []byte(whitespaceOnlyTOML)}
+	tmux := session.NewWithBinAndClient(faketmuxBin, socketDir, client)
+
+	if err := os.WriteFile(sockPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: testWorktree,
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err),
+		"whitespace-only pane_group_command must return FailedPrecondition, not panic")
+}
+
 func TestOpenPaneGroup_PaneGroupCommandBinaryNotFound(t *testing.T) {
 	// Cannot be parallel — uses t.Setenv.
 	socketDir := t.TempDir()


### PR DESCRIPTION
When pane_group_command references a binary not in PATH (e.g. laio),
tmux creates the session but the command exits immediately, showing
[exited] with no actionable error for the user.

Add validateCommandBinary() to session-tmux's OpenPaneGroup: extract
the first token of the command string, call exec.LookPath, and return
a FailedPrecondition gRPC error before any tmux invocation if the
binary is absent. Works for both bare names and absolute paths.