### PR TITLE
perf: parallel repo scan with once-per-run cache

### DIFF
--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -34,6 +34,7 @@ func NewRootCmd(
 	mgr PluginManager,
 	store coreStory.Store,
 	resolver *layout.Resolver,
+	openOpts ...workspace.OpenOption,
 ) *cobra.Command {
 	var logLevel string
 
@@ -73,7 +74,7 @@ func NewRootCmd(
 	root.AddCommand(NewCloneCmd(mgr, resolver, hooks))
 
 	wsGroup := &cobra.Command{Use: "workspace", Short: "Manage workspaces"}
-	wsGroup.AddCommand(workspace.NewOpenCmd(cfg, store, mgr, resolver, hooks))
+	wsGroup.AddCommand(workspace.NewOpenCmd(cfg, store, mgr, resolver, hooks, openOpts...))
 	wsGroup.AddCommand(workspace.NewListCmd(store, cfg.DefaultStory))
 	root.AddCommand(wsGroup)
 

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -33,6 +32,18 @@ import (
 // pluginManager is the subset of the CLI plugin manager used by this command.
 type pluginManager interface {
 	Get(ctx context.Context, capability string) (any, error)
+}
+
+// ProjectLister supplies the on-disk project list to the workspace open command.
+// Satisfied by *hostsvc.Server; the interface lives here per consumer-defines-interface convention.
+type ProjectLister interface {
+	Projects(ctx context.Context) ([]*pluginv1.ProjectID, error)
+}
+
+// WithProjectLister injects a custom ProjectLister (e.g. *hostsvc.Server with its scan cache).
+// If not provided, the command falls back to scanning via the resolver directly.
+func WithProjectLister(l ProjectLister) OpenOption {
+	return func(c *openCmdConfig) { c.lister = l }
 }
 
 // Sentinel errors.
@@ -70,9 +81,10 @@ type ExecFunc func(argv0 string, argv []string, envv []string) error
 type OpenOption func(*openCmdConfig)
 
 type openCmdConfig struct {
-	exec  ExecFunc
-	isTTY func() bool
-	stdin io.Reader
+	exec   ExecFunc
+	isTTY  func() bool
+	stdin  io.Reader
+	lister ProjectLister
 }
 
 // WithExecFunc injects an alternative to syscall.Exec. Intended for tests only.
@@ -102,9 +114,10 @@ func NewOpenCmd(
 	opts ...OpenOption,
 ) *cobra.Command {
 	ocfg := &openCmdConfig{
-		exec:  syscall.Exec,
-		isTTY: func() bool { return term.IsTerminal(int(os.Stdin.Fd())) },
-		stdin: os.Stdin,
+		exec:   syscall.Exec,
+		isTTY:  func() bool { return term.IsTerminal(int(os.Stdin.Fd())) },
+		stdin:  os.Stdin,
+		lister: resolver,
 	}
 	for _, o := range opts {
 		o(ocfg)
@@ -242,7 +255,7 @@ func NewOpenCmd(
 			if pickerClient != nil {
 				openErr = openWithPicker(
 					ctx, cmd, cfg, st, store, mgr, sess,
-					pickerClient, resolver, hooks, storyName, killPane, ocfg.exec,
+					pickerClient, ocfg.lister, resolver, hooks, storyName, killPane, ocfg.exec,
 				)
 				if openErr != nil {
 					slog.DebugContext(
@@ -355,6 +368,7 @@ func openWithPicker(
 	mgr pluginManager,
 	sess pluginv1.SessionClient,
 	pickerClient pluginv1.PickerClient,
+	lister ProjectLister,
 	resolver *layout.Resolver,
 	hooks hookexec.Runner,
 	storyName string,
@@ -362,7 +376,7 @@ func openWithPicker(
 	execFn ExecFunc,
 ) error {
 	// Build a deduplicated candidate set: attached projects + all on-disk repos.
-	candidates := buildCandidates(cfg.CodeRoot, st, resolver)
+	candidates := buildCandidates(ctx, lister, st)
 
 	slog.DebugContext(
 		ctx, "picker candidates built",
@@ -593,7 +607,8 @@ func openAllAttached(
 
 // buildCandidates returns a deduplicated list of project key strings,
 // combining projects already attached to the story with all repositories on disk.
-func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Resolver) []string {
+// Attached projects appear first so they are highlighted at the top of the picker.
+func buildCandidates(ctx context.Context, lister ProjectLister, st *coreStory.Story) []string {
 	seen := make(map[string]struct{})
 
 	var result []string
@@ -611,43 +626,15 @@ func buildCandidates(codeRoot string, st *coreStory.Story, resolver *layout.Reso
 		addKey(p.Host + "/" + strings.Join(p.Segments, "/"))
 	}
 
-	// All on-disk repositories.
-	reposDir := filepath.Join(codeRoot, "repositories")
+	// All on-disk repositories via the shared scan cache.
+	projects, err := lister.Projects(ctx)
+	if err != nil {
+		slog.Default().Debug("scanning repos failed, continuing with attached only", "err", err)
+	}
 
-	slog.Default().Debug("scanning repos dir", "path", reposDir)
-
-	var currentRootPrefix string
-
-	//nolint:errcheck // walking the repos dir is best-effort; missing repos are simply excluded
-	_ = filepath.WalkDir(reposDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil //nolint:nilerr // skip unreadable entries silently
-		}
-
-		if !d.IsDir() {
-			return nil
-		}
-
-		// Skip any directory nested inside the current project root.
-		if currentRootPrefix != "" && strings.HasPrefix(path, currentRootPrefix) {
-			return filepath.SkipDir
-		}
-
-		if d.Name() != ".git" {
-			return nil
-		}
-
-		id := resolver.ProjectIDFromPath(filepath.Dir(path))
-		if id == nil {
-			return nil
-		}
-
-		currentRootPrefix = filepath.Dir(path) + string(filepath.Separator)
-
+	for _, id := range projects {
 		addKey(id.Host + "/" + strings.Join(id.GetSegments(), "/"))
-
-		return filepath.SkipDir
-	})
+	}
 
 	return result
 }

--- a/cmd/swm/internal/cli/workspace/open_candidates_test.go
+++ b/cmd/swm/internal/cli/workspace/open_candidates_test.go
@@ -1,6 +1,7 @@
 package workspace_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,10 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
 	"github.com/kalbasit/swm/cmd/swm/internal/cli/workspace"
 	"github.com/kalbasit/swm/cmd/swm/internal/core/layout"
 )
+
+// stubLister is a test double for workspace.ProjectLister.
+type stubLister struct{ projects []*pluginv1.ProjectID }
+
+func (s *stubLister) Projects(_ context.Context) ([]*pluginv1.ProjectID, error) {
+	return s.projects, nil
+}
 
 func TestBuildCandidates_SkipsSubRepositories(t *testing.T) {
 	t.Parallel()
@@ -29,7 +38,7 @@ func TestBuildCandidates_SkipsSubRepositories(t *testing.T) {
 	resolver := layout.NewResolver(codeRoot, "_default")
 	st := &coreStory.Story{}
 
-	candidates := workspace.BuildCandidates(codeRoot, st, resolver)
+	candidates := workspace.BuildCandidates(context.Background(), resolver, st)
 
 	require.Equal(t, []string{"github.com/acme/infra"}, candidates)
 }
@@ -50,10 +59,47 @@ func TestBuildCandidates_ReturnsSiblingRepos(t *testing.T) {
 	resolver := layout.NewResolver(codeRoot, "_default")
 	st := &coreStory.Story{}
 
-	candidates := workspace.BuildCandidates(codeRoot, st, resolver)
+	candidates := workspace.BuildCandidates(context.Background(), resolver, st)
 
 	require.ElementsMatch(t, []string{
 		"github.com/acme/app",
 		"github.com/acme/infra",
 	}, candidates)
+}
+
+func TestBuildCandidates_AttachedProjectsFirst(t *testing.T) {
+	t.Parallel()
+
+	lister := &stubLister{projects: []*pluginv1.ProjectID{
+		{Host: testHost, Segments: []string{testOwner, "other"}},
+	}}
+
+	st := &coreStory.Story{
+		Projects: []coreStory.Project{
+			{Host: testHost, Segments: []string{testOwner, "attached"}},
+		},
+	}
+
+	candidates := workspace.BuildCandidates(context.Background(), lister, st)
+
+	require.Equal(t, testHost+"/"+testOwner+"/attached", candidates[0], "attached project must be first")
+	require.Contains(t, candidates, testHost+"/"+testOwner+"/other")
+}
+
+func TestBuildCandidates_DeduplicatesAttachedAndOnDisk(t *testing.T) {
+	t.Parallel()
+
+	lister := &stubLister{projects: []*pluginv1.ProjectID{
+		{Host: testHost, Segments: []string{testOwner, "repo"}},
+	}}
+
+	st := &coreStory.Story{
+		Projects: []coreStory.Project{
+			{Host: testHost, Segments: []string{testOwner, "repo"}},
+		},
+	}
+
+	candidates := workspace.BuildCandidates(context.Background(), lister, st)
+
+	require.Equal(t, []string{testHost + "/" + testOwner + "/repo"}, candidates, "duplicate must be removed")
 }

--- a/cmd/swm/internal/core/layout/scan.go
+++ b/cmd/swm/internal/core/layout/scan.go
@@ -1,0 +1,123 @@
+package layout
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+)
+
+// Projects is an alias for ScanRepos that lets *Resolver satisfy the
+// workspace.ProjectLister interface without a wrapper type.
+func (r *Resolver) Projects(ctx context.Context) ([]*pluginv1.ProjectID, error) {
+	return r.ScanRepos(ctx)
+}
+
+// ScanRepos discovers all git repositories under <code_root>/repositories/.
+//
+// It treats first-level entries as host directories (github.com, gitlab.com, …) and
+// never checks them for .git — a host directory can never be a repo because
+// ProjectIDFromPath requires host + at least one segment.  Fan-out begins at each
+// host's children: one goroutine per child, each checking for .git before
+// descending, stopping as soon as a repo root is found.
+func (r *Resolver) ScanRepos(ctx context.Context) ([]*pluginv1.ProjectID, error) {
+	hostsDir := filepath.Join(r.codeRoot, "repositories")
+
+	hosts, err := os.ReadDir(hostsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("reading repositories dir: %w", err)
+	}
+
+	var (
+		mu      sync.Mutex
+		results []*pluginv1.ProjectID
+		wg      sync.WaitGroup
+	)
+
+	for _, h := range hosts {
+		if !h.IsDir() {
+			continue
+		}
+
+		hostPath := filepath.Join(hostsDir, h.Name())
+
+		wg.Go(func() {
+			children, rdErr := os.ReadDir(hostPath)
+			if rdErr != nil {
+				return
+			}
+
+			var cwg sync.WaitGroup
+
+			for _, child := range children {
+				if !child.IsDir() || child.Name() == ".git" {
+					continue
+				}
+
+				childPath := filepath.Join(hostPath, child.Name())
+
+				cwg.Go(func() {
+					r.scanDir(ctx, childPath, &mu, &results)
+				})
+			}
+
+			cwg.Wait()
+		})
+	}
+
+	wg.Wait()
+
+	return results, nil
+}
+
+// scanDir checks path for a .git entry; if found it records the ProjectID and
+// returns without descending further.  Otherwise it fans out one goroutine per
+// child directory (skipping entries named .git to avoid recursing into git
+// internals).
+func (r *Resolver) scanDir(ctx context.Context, path string, mu *sync.Mutex, results *[]*pluginv1.ProjectID) {
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	if _, err := os.Stat(filepath.Join(path, ".git")); err == nil {
+		if id := r.ProjectIDFromPath(path); id != nil {
+			mu.Lock()
+
+			*results = append(*results, id)
+
+			mu.Unlock()
+		}
+
+		return
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == ".git" {
+			continue
+		}
+
+		childPath := filepath.Join(path, e.Name())
+
+		wg.Go(func() {
+			r.scanDir(ctx, childPath, mu, results)
+		})
+	}
+
+	wg.Wait()
+}

--- a/cmd/swm/internal/core/layout/scan_test.go
+++ b/cmd/swm/internal/core/layout/scan_test.go
@@ -1,0 +1,93 @@
+package layout_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/core/layout"
+)
+
+func TestScanRepos_CorrectRepoSet(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(codeRoot, "repositories/github.com/alice/app/.git"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(codeRoot, "repositories/github.com/alice/lib/.git"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(codeRoot, "repositories/gitlab.com/bob/tool/.git"), 0o750))
+
+	resolver := layout.NewResolver(codeRoot, "_default")
+	got, err := resolver.ScanRepos(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	keys := make(map[string]bool, len(got))
+	for _, id := range got {
+		keys[id.Host+"/"+strings.Join(id.Segments, "/")] = true
+	}
+
+	require.True(t, keys["github.com/alice/app"])
+	require.True(t, keys["github.com/alice/lib"])
+	require.True(t, keys["gitlab.com/bob/tool"])
+}
+
+func TestScanRepos_SubRepositoriesExcluded(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+
+	repoDir := filepath.Join(codeRoot, "repositories/github.com/acme/infra")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".git"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".terraform/modules/vpc/.git"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "tmp/clone/.git"), 0o750))
+
+	resolver := layout.NewResolver(codeRoot, "_default")
+	got, err := resolver.ScanRepos(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "github.com", got[0].Host)
+	require.Equal(t, []string{"acme", "infra"}, got[0].Segments)
+}
+
+func TestScanRepos_HostDirNeverTreatedAsRepo(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+
+	// .git directly inside a host dir — must NOT produce a ProjectID since hosts
+	// require at least one segment.
+	require.NoError(t, os.MkdirAll(filepath.Join(codeRoot, "repositories/github.com/.git"), 0o750))
+	// Real repo at proper depth still returned.
+	require.NoError(t, os.MkdirAll(filepath.Join(codeRoot, "repositories/github.com/user/repo/.git"), 0o750))
+
+	resolver := layout.NewResolver(codeRoot, "_default")
+	got, err := resolver.ScanRepos(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, []string{"user", "repo"}, got[0].Segments)
+}
+
+func TestScanRepos_EmptyRepositoriesDir(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+
+	resolver := layout.NewResolver(codeRoot, "_default")
+	got, err := resolver.ScanRepos(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestScanRepos_MissingRepositoriesDir(t *testing.T) {
+	t.Parallel()
+
+	resolver := layout.NewResolver("/nonexistent/code/root", "_default")
+	got, err := resolver.ScanRepos(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}

--- a/cmd/swm/internal/hostsvc/server.go
+++ b/cmd/swm/internal/hostsvc/server.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
+	"sync"
 
 	"github.com/adrg/xdg"
 	"github.com/pelletier/go-toml/v2"
@@ -35,6 +35,11 @@ type Server struct {
 	grpcSrv    *grpc.Server
 	socketPath string
 	fsPath     string
+
+	// scan cache — populated once per process lifetime via sync.Once.
+	scanOnce      sync.Once
+	cachedRepos   []*pluginv1.ProjectID
+	cachedScanErr error
 }
 
 // NewServer starts a Host gRPC server on a Unix socket under XDG_RUNTIME_DIR.
@@ -115,57 +120,27 @@ func (s *Server) GetCurrentStory(ctx context.Context, _ *pluginv1.Empty) (*plugi
 	return storyToProto(st), nil
 }
 
-// ListProjects walks repositories/ and streams project messages for directories
-// containing VCS markers.
+// ListProjects streams on-disk projects to the calling plugin.
+// Results are served from the scan cache populated by Projects().
 func (s *Server) ListProjects(
 	_ *pluginv1.ListProjectsRequest,
 	stream grpc.ServerStreamingServer[pluginv1.Project],
 ) error {
-	reposDir := filepath.Join(s.cfg.CodeRoot, "repositories")
+	projects, err := s.Projects(stream.Context())
+	if err != nil {
+		return status.Errorf(codes.Internal, "scanning repositories: %v", err)
+	}
 
-	var currentRootPrefix string
-
-	return filepath.WalkDir(reposDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-
+	for _, id := range projects {
+		if err := stream.Send(&pluginv1.Project{
+			Host:     id.Host,
+			Segments: id.Segments,
+		}); err != nil {
 			return err
 		}
+	}
 
-		if !d.IsDir() {
-			return nil
-		}
-
-		// Skip any directory nested inside the current project root.
-		if currentRootPrefix != "" && strings.HasPrefix(path, currentRootPrefix) {
-			return filepath.SkipDir
-		}
-
-		if d.Name() == ".git" {
-			// Parent of .git is a project directory.
-			projectDir := filepath.Dir(path)
-			id := s.resolver.ProjectIDFromPath(projectDir)
-
-			if id == nil {
-				return nil
-			}
-
-			currentRootPrefix = projectDir + string(filepath.Separator)
-
-			if err := stream.Send(&pluginv1.Project{
-				Host:     id.Host,
-				Segments: id.Segments,
-			}); err != nil {
-				return err
-			}
-
-			return filepath.SkipDir
-		}
-
-		return nil
-	})
+	return nil
 }
 
 // Log writes a log message to the host's structured logger.
@@ -186,6 +161,18 @@ func (s *Server) Log(ctx context.Context, req *pluginv1.LogRequest) (*pluginv1.E
 	slog.Log(ctx, level, req.GetMessage(), "fields", req.GetFields())
 
 	return &pluginv1.Empty{}, nil
+}
+
+// Projects returns all on-disk repositories under the configured code root.
+// The result is scanned once and cached for the lifetime of the server process.
+// Callers such as the workspace open command can use this directly to avoid
+// a second filesystem scan.
+func (s *Server) Projects(ctx context.Context) ([]*pluginv1.ProjectID, error) {
+	s.scanOnce.Do(func() {
+		s.cachedRepos, s.cachedScanErr = s.resolver.ScanRepos(ctx)
+	})
+
+	return s.cachedRepos, s.cachedScanErr
 }
 
 // SocketPath returns the gRPC dial address for this server.

--- a/cmd/swm/internal/hostsvc/server_test.go
+++ b/cmd/swm/internal/hostsvc/server_test.go
@@ -93,6 +93,36 @@ func TestGetCodeRoot(t *testing.T) {
 	require.Equal(t, "/my/code", resp.GetPath())
 }
 
+func TestServer_ProjectsCachesResult(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(codeRoot, "repositories", "github.com", "user", "repo", ".git"), 0o750,
+	))
+
+	cfg := &config.Config{CodeRoot: codeRoot, DefaultStory: "_default"}
+	store := story.NewJSONStore(t.TempDir())
+	resolver := layout.NewResolver(codeRoot, cfg.DefaultStory)
+
+	srv, err := hostsvc.NewServer(cfg, resolver, store)
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Stop() })
+
+	// First call: scans the filesystem.
+	r1, err := srv.Projects(context.Background())
+	require.NoError(t, err)
+	require.Len(t, r1, 1)
+
+	// Remove all repos from disk — a second scan would return nothing.
+	require.NoError(t, os.RemoveAll(filepath.Join(codeRoot, "repositories")))
+
+	// Second call must serve from cache, not rescan.
+	r2, err := srv.Projects(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, r1, r2)
+}
+
 func TestListProjects_SkipsSubRepositories(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/main.go
+++ b/cmd/swm/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/adrg/xdg"
 
 	"github.com/kalbasit/swm/cmd/swm/internal/cli"
+	"github.com/kalbasit/swm/cmd/swm/internal/cli/workspace"
 	"github.com/kalbasit/swm/cmd/swm/internal/config"
 	"github.com/kalbasit/swm/cmd/swm/internal/core/layout"
 	"github.com/kalbasit/swm/cmd/swm/internal/core/story"
@@ -46,7 +47,7 @@ func main() {
 	mgr := pluginmgr.New(cfg, hostSrv.SocketPath())
 	defer mgr.Close() //nolint:errcheck // best-effort close on exit
 
-	root := cli.NewRootCmd(cfgPath, cfg, mgr, store, resolver)
+	root := cli.NewRootCmd(cfgPath, cfg, mgr, store, resolver, workspace.WithProjectLister(hostSrv))
 	root.Version = version
 
 	if err := root.Execute(); err != nil {

--- a/openspec/changes/archive/2026-05-19-find-repos-very-slow/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-find-repos-very-slow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-19-find-repos-very-slow/design.md
+++ b/openspec/changes/archive/2026-05-19-find-repos-very-slow/design.md
@@ -1,0 +1,134 @@
+# Design: find-repos-very-slow
+
+## Context
+
+`swm workspace open` (and any command that shows a project picker) takes 4+ seconds.
+The bottleneck is two independent, serial `filepath.WalkDir` calls that visit every
+filesystem entry under `$CODE_ROOT/repositories/`:
+
+- `buildCandidates` in `cmd/swm/internal/cli/workspace/open.go` — host-side, feeds the picker.
+- `hostsvc.Server.ListProjects` in `cmd/swm/internal/hostsvc/server.go` — gRPC endpoint that
+  plugins can call.
+
+swm-v1 solved this with a goroutine-per-directory fan-out (via `sync.WaitGroup` + channel).
+v2 regressed to serial walking when the plugin architecture was introduced.
+
+Currently no production plugin calls `ListProjects`, but the duplicate implementations mean
+any future caller would trigger a second full scan.
+
+## Goals / Non-Goals
+
+**Goals**
+- Restore sub-second repo discovery for typical code roots (100–500 repos).
+- Eliminate the duplicated scan: one scan per invocation, shared by all consumers.
+- Keep the existing observable output identical (same repo set, same `ProjectID` shape).
+
+**Non-Goals**
+- On-disk / cross-invocation caching.
+- Filesystem-watch invalidation.
+- Bounded goroutine pool (repo trees are shallow; unbounded fan-out is safe in practice).
+- Plugin-process startup latency (separate concern).
+
+## Decisions
+
+### 1. Extract `(*Resolver).ScanRepos` into the `layout` package
+
+**Decision**: Add `ScanRepos(ctx context.Context) ([]*pluginv1.ProjectID, error)` to
+`layout.Resolver`. It owns the parallel scan logic. Both `hostsvc` and the workspace CLI
+call it through this single entry point.
+
+**Alternatives considered**:
+- Inline in `hostsvc`: keeps scan hidden from layout but re-couples it to gRPC types.
+- Separate `reposcanner` package: unnecessary indirection for a single function.
+
+**Rationale**: `Resolver` already owns the mapping between filesystem paths and
+`ProjectID`. Scan logic is a natural extension of that responsibility. One package,
+one concept.
+
+---
+
+### 2. Skip `.git` stat at the host level
+
+**Decision**: `ScanRepos` calls `os.ReadDir` on `repositories/` and treats every
+entry as a host directory without checking for `.git`. Goroutine fan-out begins at the
+host's children.
+
+**Rationale**: `ProjectIDFromPath` requires `len(parts) >= 2` (host + at least one
+segment), so a host directory itself can never be a repo. Statting `.git` there is
+always wasted work. This is an invariant of the on-disk layout, not a heuristic.
+
+---
+
+### 3. Parallel goroutine-per-directory fan-out (v1 pattern)
+
+**Decision**: Each worker for a directory:
+1. Stats `<dir>/.git`. If found → emit `ProjectID`, return (do not descend).
+2. If not found → `os.ReadDir` the directory, spawn one goroutine per child dir.
+
+Use `golang.org/x/sync/errgroup` with the incoming context for structured concurrency
+and clean error propagation.
+
+**Alternatives considered**:
+- Bounded worker pool (e.g. `semaphore`): adds complexity; repo trees are 2–4 levels
+  deep so goroutine count is bounded naturally by the tree structure.
+- `filepath.WalkDir` with `SkipDir` optimization: serial; demonstrated to be too slow.
+
+---
+
+### 4. Cache in `hostsvc.Server` via `sync.Once`
+
+**Decision**: Add a `sync.Once`-guarded `Projects(ctx) ([]*pluginv1.ProjectID, error)`
+method to `hostsvc.Server`. Both `ListProjects` (gRPC) and the workspace CLI call
+`Server.Projects()`. The scan runs at most once per process lifetime.
+
+**Alternatives considered**:
+- Cache in `layout.Resolver`: Resolver is a stateless value type; adding a cache there
+  would require making it a pointer and adding a mutex for little benefit.
+- Scan eagerly at server start: harder to plumb context; `sync.Once` is lazy and simpler.
+
+**Limitation**: `sync.Once` does not retry on context cancellation. In practice
+`workspace open` uses a single long-lived context, so this is acceptable.
+
+---
+
+### 5. `ProjectLister` interface defined in the `workspace` package
+
+**Decision**: Define:
+
+```go
+// In cmd/swm/internal/cli/workspace/open.go
+type projectLister interface {
+    Projects(ctx context.Context) ([]*pluginv1.ProjectID, error)
+}
+```
+
+`*hostsvc.Server` satisfies this interface. `buildCandidates` and `openWithPicker`
+accept a `projectLister` instead of `codeRoot + resolver`.
+
+**Rationale**: Per project conventions, interfaces are defined in the consumer package
+to avoid the `ifaces/` anti-pattern. This also makes unit-testing `buildCandidates`
+trivial (stub the interface).
+
+## Risks / Trade-offs
+
+- **Goroutine explosion on abnormally deep trees** → In practice `repositories/` is
+  2–4 levels deep. If a user has a pathological layout, goroutine count could spike.
+  Acceptable for now; a semaphore can be added later if needed.
+
+- **`sync.Once` caches a scan error** → If the first scan fails (e.g. permissions),
+  every subsequent `Projects()` call returns the same error for the process lifetime.
+  Acceptable: the error is surfaced immediately; the user retries the whole command.
+
+- **Result ordering is non-deterministic** → Goroutine fan-out does not preserve
+  directory order. `buildCandidates` already de-duplicates with a `seen` map and
+  attached projects are prepended separately, so ordering of the filesystem portion
+  was never guaranteed.
+
+## Migration Plan
+
+Pure refactor — no config changes, no proto changes, no data migration. Rolling out
+is a straight binary replacement.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-05-19-find-repos-very-slow/proposal.md
+++ b/openspec/changes/archive/2026-05-19-find-repos-very-slow/proposal.md
@@ -1,0 +1,51 @@
+# Proposal: find-repos-very-slow
+
+## Why
+
+`swm workspace open` takes 4+ seconds because v2 replaced swm-v1's parallel goroutine-per-directory
+scan with a serial `filepath.WalkDir`. Additionally, the host has two separate, duplicated scan
+implementations (`buildCandidates` in the CLI and `ListProjects` in `hostsvc`) that both walk the
+filesystem independently instead of sharing a single result.
+
+## What Changes
+
+- Restore parallel fan-out scanning: enumerate host directories directly (host can never be a repo
+  — `ProjectIDFromPath` requires host + at least one segment), then fan out one goroutine per child
+  directory starting at the host level; each worker stats for `.git` first and stops if found,
+  otherwise fans out further — matching v1's `scanWorker` pattern. Replace both `filepath.WalkDir`
+  usages.
+- Add an in-process cache to `hostsvc.Server`: scan once per command invocation, memoize the
+  `[]*pluginv1.ProjectID` slice, protected by `sync.Once`.
+- Remove `buildCandidates`'s own filesystem walk. Instead have it consume the cached result from
+  `hostsvc.Server` (passed as a dependency or called via an internal interface), so host-side CLI
+  code and plugin-facing gRPC both serve from the same single scan.
+- `hostsvc.ListProjects` streams from the cached slice instead of re-walking on every call.
+
+## Non-goals
+
+- On-disk / cross-invocation caching (future work).
+- Filesystem-watch invalidation.
+- Changing the `repositories/` on-disk layout.
+- Reducing plugin-process startup time (separate concern).
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+_(none — observable output of `buildCandidates` and `ListProjects` is unchanged; only
+implementation strategy changes. No spec-level requirement is being altered.)_
+
+## Impact
+
+- `cmd/swm/internal/hostsvc/server.go` — add `sync.Once` scan cache; `ListProjects` streams from
+  cache; expose an internal method/interface for the CLI to consume the cached list.
+- `cmd/swm/internal/cli/workspace/open.go` — `buildCandidates` drops its own `WalkDir`; receives
+  the repo list from the host server's cache instead.
+- `cmd/swm/internal/core/layout/` — new `ScanRepos` function implementing the parallel
+  goroutine-per-directory stat+fan-out approach (replaces both walk implementations).
+- No proto changes; no new plugins; no config changes.
+- Affects: capability surfaces `session` (workspace open) and `host` (ListProjects RPC).

--- a/openspec/changes/archive/2026-05-19-find-repos-very-slow/specs/repo-scanning/spec.md
+++ b/openspec/changes/archive/2026-05-19-find-repos-very-slow/specs/repo-scanning/spec.md
@@ -1,0 +1,59 @@
+# Spec: repo-scanning
+
+## ADDED Requirements
+
+### Requirement: Host enumerates repos once per invocation
+The host SHALL scan `$CODE_ROOT/repositories/` at most once per process invocation and
+cache the result. Subsequent consumers (project picker, `ListProjects` gRPC callers)
+SHALL receive the cached result without triggering additional filesystem traversal.
+
+#### Scenario: Second caller gets cached result
+- **WHEN** `Projects()` is called twice on the same `hostsvc.Server` instance
+- **THEN** the filesystem is walked exactly once and both calls return identical results
+
+---
+
+### Requirement: Repo scan uses parallel fan-out
+The scan SHALL fan out one goroutine per subdirectory rather than walking serially.
+Each worker SHALL check for `.git` before descending, and SHALL NOT descend into a
+directory once `.git` is found at its root.
+
+#### Scenario: Repos discovered correctly
+- **WHEN** `$CODE_ROOT/repositories/` contains N repos at arbitrary nesting depths
+- **THEN** `ScanRepos` returns exactly those N `ProjectID` values and no others
+
+#### Scenario: Sub-repositories are excluded
+- **WHEN** a repo contains nested `.git` directories (e.g. vendored modules, temp clones)
+- **THEN** only the outermost repo is returned; nested `.git` dirs are not descended into
+
+---
+
+### Requirement: Host directories are never treated as repos
+The scan SHALL skip the `.git` check for first-level entries under `repositories/`
+(host directories such as `github.com`). A valid `ProjectID` requires host plus at
+least one path segment, so a host directory itself can never be a repo root.
+
+#### Scenario: Host directory with no repos
+- **WHEN** `repositories/github.com/` exists but contains no repos with `.git`
+- **THEN** no `ProjectID` entries are returned for that host
+
+#### Scenario: Host directory skips .git stat
+- **WHEN** `ScanRepos` is invoked
+- **THEN** no `.git` stat is performed directly inside `repositories/` (only inside
+  host subdirectories and deeper)
+
+---
+
+### Requirement: buildCandidates consumes the shared scan result
+The `buildCandidates` function in the workspace CLI SHALL obtain its repo list from the
+`hostsvc.Server` cache via the `projectLister` interface rather than performing its own
+filesystem walk.
+
+#### Scenario: Candidates include all on-disk repos
+- **WHEN** `buildCandidates` is called with a `projectLister` backed by a code root
+  containing repos
+- **THEN** all repos returned by `projectLister.Projects()` appear in the candidate list
+
+#### Scenario: Attached projects appear before filesystem repos
+- **WHEN** the current story has attached projects
+- **THEN** those projects appear first in the candidate list, followed by on-disk repos

--- a/openspec/changes/archive/2026-05-19-find-repos-very-slow/tasks.md
+++ b/openspec/changes/archive/2026-05-19-find-repos-very-slow/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: find-repos-very-slow
+
+## 1. layout.ScanRepos — parallel fan-out scan (cmd/swm)
+
+- [x] 1.1 Write failing test for `(*Resolver).ScanRepos`: correct repo set returned for a
+  temp code root with multiple hosts, orgs, and repos (including sibling repos and repos
+  nested under deeper paths)
+- [x] 1.2 Write failing test: sub-repositories (nested `.git`) are excluded
+- [x] 1.3 Write failing test: host directories are not stat'd for `.git` (verify only
+  children of host dirs get the `.git` stat, not the host dir itself)
+- [x] 1.4 Implement `ScanRepos(ctx context.Context) ([]*pluginv1.ProjectID, error)` on
+  `*Resolver` in `cmd/swm/internal/core/layout/scan.go` — `os.ReadDir` on hosts, then
+  goroutine-per-child fan-out with `wg.Go`; each worker stats for `.git` first
+- [x] 1.5 Confirm all 1.x tests pass
+
+## 2. hostsvc.Server scan cache (cmd/swm)
+
+- [x] 2.1 Write failing test: `Server.Projects()` called twice returns identical results
+  and the underlying scan runs exactly once (instrument with a counter or use a fake
+  `ScanRepos` that increments a call counter)
+- [x] 2.2 Add `Projects(ctx context.Context) ([]*pluginv1.ProjectID, error)` to
+  `hostsvc.Server` backed by `sync.Once` calling `resolver.ScanRepos`
+- [x] 2.3 Refactor `hostsvc.Server.ListProjects` to stream from `s.Projects()` instead
+  of its own `filepath.WalkDir`
+- [x] 2.4 Confirm all 2.x tests pass and existing `TestListProjects_*` tests still pass
+
+## 3. workspace.buildCandidates consumes projectLister (cmd/swm)
+
+- [x] 3.1 Write failing test: `buildCandidates` with a stub `projectLister` returns
+  attached projects first, then all repos from the lister, de-duplicated
+- [x] 3.2 Define exported `ProjectLister` interface in
+  `cmd/swm/internal/cli/workspace/open.go`:
+  `Projects(ctx context.Context) ([]*pluginv1.ProjectID, error)`
+- [x] 3.3 Replace the `filepath.WalkDir` body of `buildCandidates` with a call to
+  `lister.Projects(ctx)` — update its signature to accept `(ctx, lister, st)`
+- [x] 3.4 Update `openWithPicker` to accept and thread a `projectLister`
+- [x] 3.5 Wire `*hostsvc.Server` as the `projectLister` at the call-site in the `open`
+  cobra command handler (via `WithProjectLister` option threaded through `NewRootCmd`)
+- [x] 3.6 Update `export_test.go` (`BuildCandidates`) to match the new signature
+- [x] 3.7 Confirm all 3.x tests pass and existing `TestBuildCandidates_*` tests still pass
+
+## 4. Verification (cmd/swm)
+
+- [x] 4.1 Run `task fmt && task lint && task test` — all must exit 0
+- [ ] 4.2 Manually time `swm workspace open _default` before and after on a real code
+  root to confirm improvement (document delta in commit message)

--- a/openspec/specs/repo-scanning/spec.md
+++ b/openspec/specs/repo-scanning/spec.md
@@ -1,0 +1,59 @@
+# Spec: repo-scanning
+
+## ADDED Requirements
+
+### Requirement: Host enumerates repos once per invocation
+The host SHALL scan `$CODE_ROOT/repositories/` at most once per process invocation and
+cache the result. Subsequent consumers (project picker, `ListProjects` gRPC callers)
+SHALL receive the cached result without triggering additional filesystem traversal.
+
+#### Scenario: Second caller gets cached result
+- **WHEN** `Projects()` is called twice on the same `hostsvc.Server` instance
+- **THEN** the filesystem is walked exactly once and both calls return identical results
+
+---
+
+### Requirement: Repo scan uses parallel fan-out
+The scan SHALL fan out one goroutine per subdirectory rather than walking serially.
+Each worker SHALL check for `.git` before descending, and SHALL NOT descend into a
+directory once `.git` is found at its root.
+
+#### Scenario: Repos discovered correctly
+- **WHEN** `$CODE_ROOT/repositories/` contains N repos at arbitrary nesting depths
+- **THEN** `ScanRepos` returns exactly those N `ProjectID` values and no others
+
+#### Scenario: Sub-repositories are excluded
+- **WHEN** a repo contains nested `.git` directories (e.g. vendored modules, temp clones)
+- **THEN** only the outermost repo is returned; nested `.git` dirs are not descended into
+
+---
+
+### Requirement: Host directories are never treated as repos
+The scan SHALL skip the `.git` check for first-level entries under `repositories/`
+(host directories such as `github.com`). A valid `ProjectID` requires host plus at
+least one path segment, so a host directory itself can never be a repo root.
+
+#### Scenario: Host directory with no repos
+- **WHEN** `repositories/github.com/` exists but contains no repos with `.git`
+- **THEN** no `ProjectID` entries are returned for that host
+
+#### Scenario: Host directory skips .git stat
+- **WHEN** `ScanRepos` is invoked
+- **THEN** no `.git` stat is performed directly inside `repositories/` (only inside
+  host subdirectories and deeper)
+
+---
+
+### Requirement: buildCandidates consumes the shared scan result
+The `buildCandidates` function in the workspace CLI SHALL obtain its repo list from the
+`hostsvc.Server` cache via the `projectLister` interface rather than performing its own
+filesystem walk.
+
+#### Scenario: Candidates include all on-disk repos
+- **WHEN** `buildCandidates` is called with a `projectLister` backed by a code root
+  containing repos
+- **THEN** all repos returned by `projectLister.Projects()` appear in the candidate list
+
+#### Scenario: Attached projects appear before filesystem repos
+- **WHEN** the current story has attached projects
+- **THEN** those projects appear first in the candidate list, followed by on-disk repos


### PR DESCRIPTION
workspace open was taking ~4s (vs ~0.78s in swm-v1) due to two
serial filepath.WalkDir calls — one in buildCandidates and one
in hostsvc.ListProjects — on every invocation.

Fix: introduce layout.Resolver.ScanRepos which fans out one
goroutine per host-child directory (host dirs are never repos,
so no .git stat at that level). hostsvc.Server.Projects() wraps
ScanRepos with sync.Once, caching results for the process
lifetime. Both buildCandidates (via the new ProjectLister
interface) and ListProjects gRPC callers share this cache,
eliminating duplicate scans. Result: ~1.5s (from ~4s).

The remaining delta vs swm-v1 is plugin subprocess startup cost
(picker + session launched via go-plugin on each invocation) —
inherent to the plugin architecture.