### PR TITLE
feat: parallel eager plugin warm-up

### DIFF
--- a/cmd/swm/internal/cli/clone.go
+++ b/cmd/swm/internal/cli/clone.go
@@ -24,6 +24,9 @@ func NewCloneCmd(mgr PluginManager, resolver *layout.Resolver, hooks hookexec.Ru
 		Use:   "clone <url>",
 		Short: "Clone a repository to its canonical path",
 		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return mgr.Warm(cmd.Context(), "vcs")
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := args[0]
 			ctx := cmd.Context()

--- a/cmd/swm/internal/cli/clone_test.go
+++ b/cmd/swm/internal/cli/clone_test.go
@@ -64,6 +64,35 @@ func TestCloneCmd_AlreadyCloned(t *testing.T) {
 	require.False(t, vcs.cloneCalled)
 }
 
+func TestCloneCmd_PreRunE_WarmsVCS(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+	resolver := layout.NewResolver(codeRoot, "_default")
+	vcs := &stubVCS{}
+
+	rec := &warmRecordingMgr{stubMgr: &stubMgr{vcs: vcs}}
+
+	cmd := cli.NewCloneCmd(rec, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testSSHURL})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, []string{"vcs"}, rec.warmedCaps,
+		"clone PreRunE must warm vcs")
+}
+
+// warmRecordingMgr wraps stubMgr and records capabilities passed to Warm.
+type warmRecordingMgr struct {
+	*stubMgr
+	warmedCaps []string
+}
+
+func (w *warmRecordingMgr) Warm(_ context.Context, caps ...string) error {
+	w.warmedCaps = append(w.warmedCaps, caps...)
+
+	return nil
+}
+
 func TestCloneCmd_CloneError(t *testing.T) {
 	t.Parallel()
 
@@ -101,6 +130,10 @@ func (s *stubMgr) Get(_ context.Context, capability string) (any, error) {
 
 func (s *stubMgr) GetForge(_ context.Context, _ string) (pluginv1.ForgeClient, error) {
 	return nil, fmt.Errorf("%w: no forge configured", errNoPlugin)
+}
+
+func (s *stubMgr) Warm(_ context.Context, _ ...string) error {
+	return nil
 }
 
 // stubVCS is a minimal VCSClient for clone tests.

--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -25,6 +25,7 @@ import (
 type PluginManager interface {
 	Get(ctx context.Context, capability string) (any, error)
 	GetForge(ctx context.Context, hostname string) (pluginv1.ForgeClient, error)
+	Warm(ctx context.Context, capabilities ...string) error
 }
 
 // NewRootCmd builds the top-level swm cobra.Command.

--- a/cmd/swm/internal/cli/story/remove.go
+++ b/cmd/swm/internal/cli/story/remove.go
@@ -23,6 +23,7 @@ import (
 // pluginManager is the subset of the CLI plugin manager used by this command.
 type pluginManager interface {
 	Get(ctx context.Context, capability string) (any, error)
+	Warm(ctx context.Context, capabilities ...string) error
 }
 
 // errRemovalFailed is returned when one or more steps during story removal fail.
@@ -44,6 +45,9 @@ func NewRemoveCmd(
 		Use:   "remove [<name>]",
 		Short: "Remove a story and all its worktrees",
 		Args:  cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return mgr.Warm(cmd.Context(), "vcs", "session")
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var name string
 			if len(args) == 1 {

--- a/cmd/swm/internal/cli/story/remove.go
+++ b/cmd/swm/internal/cli/story/remove.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
@@ -46,7 +47,19 @@ func NewRemoveCmd(
 		Short: "Remove a story and all its worktrees",
 		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return mgr.Warm(cmd.Context(), "vcs", "session")
+			// Warm session concurrently but discard its error — session is optional;
+			// RunE silently falls back when it is absent (closeStoryWorkspace is best-effort).
+			var wg sync.WaitGroup
+
+			wg.Go(func() {
+				_ = mgr.Warm(cmd.Context(), "session") //nolint:errcheck // session is optional
+			})
+
+			err := mgr.Warm(cmd.Context(), "vcs")
+
+			wg.Wait()
+
+			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var name string

--- a/cmd/swm/internal/cli/story/remove_test.go
+++ b/cmd/swm/internal/cli/story/remove_test.go
@@ -16,6 +16,34 @@ import (
 	"github.com/kalbasit/swm/cmd/swm/internal/hookexec"
 )
 
+func TestRemoveCmd_PreRunE_WarmsPlugins(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
+	resolver := layout.NewResolver("/code", "_default")
+
+	rec := &warmRecordingManager{stubManager: &stubManager{}}
+
+	cmd := story.NewRemoveCmd(store, rec, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testStoryName, testForceFlag})
+
+	require.NoError(t, cmd.Execute())
+	require.ElementsMatch(t, []string{"vcs", "session"}, rec.warmedCaps,
+		"story remove PreRunE must warm vcs and session")
+}
+
+// warmRecordingManager wraps stubManager and records capabilities passed to Warm.
+type warmRecordingManager struct {
+	*stubManager
+	warmedCaps []string
+}
+
+func (w *warmRecordingManager) Warm(_ context.Context, caps ...string) error {
+	w.warmedCaps = append(w.warmedCaps, caps...)
+
+	return nil
+}
+
 func TestRemoveCmd_Force_NoProjects(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/cli/story/remove_test.go
+++ b/cmd/swm/internal/cli/story/remove_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -28,20 +29,40 @@ func TestRemoveCmd_PreRunE_WarmsPlugins(t *testing.T) {
 	cmd.SetArgs([]string{testStoryName, testForceFlag})
 
 	require.NoError(t, cmd.Execute())
-	require.ElementsMatch(t, []string{"vcs", "session"}, rec.warmedCaps,
+	require.ElementsMatch(t, []string{capVCS, capSession}, rec.warmedCaps,
 		"story remove PreRunE must warm vcs and session")
 }
 
 // warmRecordingManager wraps stubManager and records capabilities passed to Warm.
+// mu guards warmedCaps because PreRunE may call Warm from concurrent goroutines.
 type warmRecordingManager struct {
 	*stubManager
+	mu         sync.Mutex
 	warmedCaps []string
 }
 
 func (w *warmRecordingManager) Warm(_ context.Context, caps ...string) error {
+	w.mu.Lock()
 	w.warmedCaps = append(w.warmedCaps, caps...)
+	w.mu.Unlock()
 
 	return nil
+}
+
+func TestRemoveCmd_PreRunE_SessionFailure_DoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
+	resolver := layout.NewResolver("/code", "_default")
+	mgr := &stubManager{
+		warmErrs: map[string]error{capSession: errFakeSession},
+	}
+
+	cmd := story.NewRemoveCmd(store, mgr, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testStoryName, testForceFlag})
+
+	require.NoError(t, cmd.Execute(), "session plugin failure must not abort story remove")
+	require.True(t, store.deleted, "story must be deleted even when session plugin is unavailable")
 }
 
 func TestRemoveCmd_Force_NoProjects(t *testing.T) {

--- a/cmd/swm/internal/cli/story/testhelpers_test.go
+++ b/cmd/swm/internal/cli/story/testhelpers_test.go
@@ -19,7 +19,11 @@ const (
 	testStoryName   = "feat-x"
 	testBugName     = "my-bug"
 	testForceFlag   = "--force"
+	capSession      = "session"
+	capVCS          = "vcs"
 )
+
+var errFakeSession = errors.New("session unavailable")
 
 // errNotFound is a sentinel used in tests.
 var errNotFound = errors.New("not found")
@@ -82,17 +86,18 @@ var _ coreStory.Store = (*stubStore)(nil)
 
 // stubManager implements the pluginManager interface for tests.
 type stubManager struct {
-	vcs  pluginv1.VCSClient
-	sess pluginv1.SessionClient
+	vcs      pluginv1.VCSClient
+	sess     pluginv1.SessionClient
+	warmErrs map[string]error // optional per-capability warm errors
 }
 
 func (s *stubManager) Get(_ context.Context, capability string) (any, error) {
 	switch capability {
-	case "vcs":
+	case capVCS:
 		if s.vcs != nil {
 			return s.vcs, nil
 		}
-	case "session":
+	case capSession:
 		if s.sess != nil {
 			return s.sess, nil
 		}
@@ -101,7 +106,13 @@ func (s *stubManager) Get(_ context.Context, capability string) (any, error) {
 	return nil, errNotFound
 }
 
-func (s *stubManager) Warm(_ context.Context, _ ...string) error {
+func (s *stubManager) Warm(_ context.Context, caps ...string) error {
+	for _, c := range caps {
+		if err, ok := s.warmErrs[c]; ok {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/swm/internal/cli/story/testhelpers_test.go
+++ b/cmd/swm/internal/cli/story/testhelpers_test.go
@@ -101,6 +101,10 @@ func (s *stubManager) Get(_ context.Context, capability string) (any, error) {
 	return nil, errNotFound
 }
 
+func (s *stubManager) Warm(_ context.Context, _ ...string) error {
+	return nil
+}
+
 // stubVCSClient implements pluginv1.VCSClient for tests.
 type stubVCSClient struct {
 	removeWorktreeCalled bool

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -134,8 +135,19 @@ func NewOpenCmd(
 			"environment variable, and then to the default story configured in swm.",
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			// picker is optional (error ignored in RunE), so only warm required plugins.
-			return mgr.Warm(cmd.Context(), "session", "vcs")
+			// Warm picker concurrently but discard its error — picker is optional;
+			// RunE silently falls back to non-interactive mode when it is absent.
+			var wg sync.WaitGroup
+
+			wg.Go(func() {
+				_ = mgr.Warm(cmd.Context(), "picker") //nolint:errcheck // picker is optional
+			})
+
+			err := mgr.Warm(cmd.Context(), "session", "vcs")
+
+			wg.Wait()
+
+			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -32,6 +32,7 @@ import (
 // pluginManager is the subset of the CLI plugin manager used by this command.
 type pluginManager interface {
 	Get(ctx context.Context, capability string) (any, error)
+	Warm(ctx context.Context, capabilities ...string) error
 }
 
 // ProjectLister supplies the on-disk project list to the workspace open command.
@@ -132,6 +133,10 @@ func NewOpenCmd(
 			"If [story-name] is omitted, the command falls back to the $SWM_STORY " +
 			"environment variable, and then to the default story configured in swm.",
 		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			// picker is optional (error ignored in RunE), so only warm required plugins.
+			return mgr.Warm(cmd.Context(), "session", "vcs")
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -1130,18 +1131,23 @@ func TestOpenCmd_PreRunE_WarmsPlugins(t *testing.T) {
 	cmd.SetArgs([]string{testStoryName})
 
 	require.NoError(t, cmd.Execute())
-	require.ElementsMatch(t, []string{"session", "vcs"}, rec.warmedCaps,
-		"workspace open PreRunE must warm session and vcs (picker is optional, warmed lazily)")
+	require.ElementsMatch(t, []string{"picker", "session", "vcs"}, rec.warmedCaps,
+		"workspace open PreRunE must warm session, vcs, and picker (picker error is discarded)")
 }
 
 // warmRecordingMgr wraps stubMgr and records capabilities passed to Warm.
+// Warm may be called from concurrent goroutines, so access to warmedCaps is
+// guarded by mu.
 type warmRecordingMgr struct {
 	*stubMgr
+	mu         sync.Mutex
 	warmedCaps []string
 }
 
 func (w *warmRecordingMgr) Warm(_ context.Context, caps ...string) error {
+	w.mu.Lock()
 	w.warmedCaps = append(w.warmedCaps, caps...)
+	w.mu.Unlock()
 
 	return nil
 }

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -1117,6 +1117,35 @@ func TestOpenCmd_Completion_ArgAlreadyProvided_NoMoreCompletions(t *testing.T) {
 	require.Empty(t, completions)
 }
 
+func TestOpenCmd_PreRunE_WarmsPlugins(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{Name: testStoryName}}
+	sess := &stubSess{}
+
+	rec := &warmRecordingMgr{stubMgr: &stubMgr{sess: sess}}
+
+	cmd := workspace.NewOpenCmd(cfg, store, rec, layout.NewResolver(testCodeRoot, testDefaultStory), hookexec.Noop)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.ElementsMatch(t, []string{"session", "vcs"}, rec.warmedCaps,
+		"workspace open PreRunE must warm session and vcs (picker is optional, warmed lazily)")
+}
+
+// warmRecordingMgr wraps stubMgr and records capabilities passed to Warm.
+type warmRecordingMgr struct {
+	*stubMgr
+	warmedCaps []string
+}
+
+func (w *warmRecordingMgr) Warm(_ context.Context, caps ...string) error {
+	w.warmedCaps = append(w.warmedCaps, caps...)
+
+	return nil
+}
+
 // stubStore is a minimal story.Store.
 type stubStore struct {
 	getStory     *coreStory.Story
@@ -1228,6 +1257,14 @@ func (s *stubMgr) Get(_ context.Context, capability string) (any, error) {
 	}
 
 	return nil, fmt.Errorf("%w: %s", errNoPlugin, capability)
+}
+
+func (s *stubMgr) GetForge(_ context.Context, _ string) (pluginv1.ForgeClient, error) {
+	return nil, fmt.Errorf("%w: no forge configured", errNoPlugin)
+}
+
+func (s *stubMgr) Warm(_ context.Context, _ ...string) error {
+	return nil
 }
 
 // stubSess records session plugin calls.

--- a/cmd/swm/internal/core/layout/scan.go
+++ b/cmd/swm/internal/core/layout/scan.go
@@ -3,9 +3,11 @@ package layout
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 )
@@ -24,6 +26,12 @@ func (r *Resolver) Projects(ctx context.Context) ([]*pluginv1.ProjectID, error) 
 // host's children: one goroutine per child, each checking for .git before
 // descending, stopping as soon as a repo root is found.
 func (r *Resolver) ScanRepos(ctx context.Context) ([]*pluginv1.ProjectID, error) {
+	start := time.Now()
+
+	defer func() {
+		slog.DebugContext(ctx, "ScanRepos complete", "duration", time.Since(start))
+	}()
+
 	hostsDir := filepath.Join(r.codeRoot, "repositories")
 
 	hosts, err := os.ReadDir(hostsDir)

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/adrg/xdg"
 
@@ -56,8 +57,11 @@ var (
 // launchOnce holds the result of a single plugin launch attempt.
 // once.Do ensures the launch runs exactly once; the result is cached permanently
 // (including errors — a failed launch is not retried).
+// done is set to true after once.Do's function returns; Close checks this instead of
+// calling once.Do(func(){}) (which would steal the Once if launch hasn't started yet).
 type launchOnce struct {
 	once   sync.Once
+	done   atomic.Bool
 	client *goplugin.Client
 	raw    any
 	err    error
@@ -119,10 +123,10 @@ func (m *Manager) Close() error {
 			return true
 		}
 
-		// Wait for any in-progress launch before killing, to avoid racing on lo.client.
-		lo.once.Do(func() {})
-
-		if lo.client != nil {
+		// Only kill if launch has fully completed; done is set after once.Do's function
+		// returns, ensuring client is visible without a data race.
+		// A launch that is in-progress or never started is skipped — the OS cleans up.
+		if lo.done.Load() && lo.client != nil {
 			lo.client.Kill()
 		}
 
@@ -157,6 +161,7 @@ func (m *Manager) Get(ctx context.Context, capability string) (any, error) {
 
 	entry.once.Do(func() {
 		entry.client, entry.raw, entry.err = m.launch(ctx, capability)
+		entry.done.Store(true)
 	})
 
 	return entry.raw, entry.err
@@ -186,26 +191,33 @@ func (m *Manager) GetForge(ctx context.Context, hostname string) (pluginv1.Forge
 }
 
 // Warm pre-starts the listed capabilities concurrently.
-// Each capability is launched in its own goroutine; the first error encountered is returned.
+// Each capability is launched in its own goroutine; the first error cancels the rest
+// and is returned after all goroutines finish.
 // Capabilities already running are reused without relaunching.
 func (m *Manager) Warm(ctx context.Context, capabilities ...string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var (
 		wg       sync.WaitGroup
-		firstMu  sync.Mutex
 		firstErr error
 		setFirst sync.Once
 	)
 
-	for _, cap := range capabilities {
-		wg.Go(func() {
-			if _, err := m.Get(ctx, cap); err != nil {
+	for _, c := range capabilities {
+		wg.Add(1)
+
+		go func(c string) {
+			defer wg.Done()
+
+			if _, err := m.Get(ctx, c); err != nil {
 				setFirst.Do(func() {
-					firstMu.Lock()
 					firstErr = err
-					firstMu.Unlock()
+
+					cancel()
 				})
 			}
-		})
+		}(c)
 	}
 
 	wg.Wait()

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -53,9 +53,14 @@ var (
 	errUnsupported        = errors.New("unsupported capability")
 )
 
-type entry struct {
+// launchOnce holds the result of a single plugin launch attempt.
+// once.Do ensures the launch runs exactly once; the result is cached permanently
+// (including errors — a failed launch is not retried).
+type launchOnce struct {
+	once   sync.Once
 	client *goplugin.Client
 	raw    any
+	err    error
 }
 
 type forgeEntry struct {
@@ -82,8 +87,11 @@ type Manager struct {
 	hostSocket string
 	stderr     io.Writer
 
-	mu           sync.Mutex
-	launched     map[string]*entry
+	// launched stores *launchOnce per capability, enabling per-capability locking
+	// so concurrent Get/Warm calls for different capabilities do not serialize.
+	launched sync.Map
+
+	mu           sync.Mutex // guards forge state only
 	forgeClients []*forgeEntry
 	forgesLoaded bool
 }
@@ -94,7 +102,6 @@ func New(cfg *config.Config, hostSocket string, opts ...Option) *Manager {
 		cfg:        cfg,
 		hostSocket: hostSocket,
 		stderr:     os.Stderr,
-		launched:   make(map[string]*entry),
 	}
 
 	for _, o := range opts {
@@ -106,16 +113,26 @@ func New(cfg *config.Config, hostSocket string, opts ...Option) *Manager {
 
 // Close terminates all launched plugin processes.
 func (m *Manager) Close() error {
+	m.launched.Range(func(k, v any) bool {
+		lo, ok := v.(*launchOnce)
+		if !ok {
+			return true
+		}
+
+		// Wait for any in-progress launch before killing, to avoid racing on lo.client.
+		lo.once.Do(func() {})
+
+		if lo.client != nil {
+			lo.client.Kill()
+		}
+
+		m.launched.Delete(k)
+
+		return true
+	})
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	var errs []error
-
-	for _, e := range m.launched {
-		e.client.Kill()
-	}
-
-	m.launched = make(map[string]*entry)
 
 	for _, fe := range m.forgeClients {
 		fe.client.Kill()
@@ -124,67 +141,25 @@ func (m *Manager) Close() error {
 	m.forgeClients = nil
 	m.forgesLoaded = false
 
-	return errors.Join(errs...)
+	return nil
 }
 
 // Get returns the client for the configured plugin of the given capability.
 // The plugin is lazily launched on the first call and cached for subsequent calls.
+// A failed launch is also cached — the same error is returned on every subsequent call.
 func (m *Manager) Get(ctx context.Context, capability string) (any, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	stored, _ := m.launched.LoadOrStore(capability, &launchOnce{})
 
-	if e, ok := m.launched[capability]; ok {
-		return e.raw, nil
+	entry, ok := stored.(*launchOnce)
+	if !ok {
+		return nil, fmt.Errorf("%w: launched map contains unexpected type %T", errUnknownCapability, stored)
 	}
 
-	// Look up the plugin name from config.
-	name, err := m.capabilityName(capability)
-	if err != nil {
-		return nil, err
-	}
+	entry.once.Do(func() {
+		entry.client, entry.raw, entry.err = m.launch(ctx, capability)
+	})
 
-	binary, err := m.discover(capability, name)
-	if err != nil {
-		return nil, err
-	}
-
-	set := pluginSet(capability)
-	if len(set) == 0 {
-		return nil, fmt.Errorf("%w: %s", errUnsupported, capability)
-	}
-
-	// Pre-populate Cmd.Env with the host socket address; go-plugin will append
-	// os.Environ() (since SkipHostEnv defaults to false), so this var stays first.
-	pluginCmd := exec.Command(binary) //nolint:gosec // binary is discovered from trusted sources
-	if m.hostSocket != "" {
-		pluginCmd.Env = []string{"SWM_HOST_SOCKET=" + m.hostSocket}
-	}
-
-	client := goplugin.NewClient(m.buildClientConfig(ctx, pluginCmd, set))
-
-	rpcClient, err := client.Client()
-	if err != nil {
-		client.Kill()
-
-		return nil, fmt.Errorf("connecting to plugin %s: %w", binary, err)
-	}
-
-	raw, err := rpcClient.Dispense(capability)
-	if err != nil {
-		client.Kill()
-
-		return nil, fmt.Errorf("dispensing capability %s: %w", capability, err)
-	}
-
-	if err := m.validateDeps(ctx, capability, raw); err != nil {
-		client.Kill()
-
-		return nil, err
-	}
-
-	m.launched[capability] = &entry{client: client, raw: raw}
-
-	return raw, nil
+	return entry.raw, entry.err
 }
 
 // GetForge returns the ForgeClient for the plugin claiming the given hostname.
@@ -208,6 +183,34 @@ func (m *Manager) GetForge(ctx context.Context, hostname string) (pluginv1.Forge
 	}
 
 	return nil, fmt.Errorf("%w: %q", errNoForgePlugin, hostname)
+}
+
+// Warm pre-starts the listed capabilities concurrently.
+// Each capability is launched in its own goroutine; the first error encountered is returned.
+// Capabilities already running are reused without relaunching.
+func (m *Manager) Warm(ctx context.Context, capabilities ...string) error {
+	var (
+		wg       sync.WaitGroup
+		firstMu  sync.Mutex
+		firstErr error
+		setFirst sync.Once
+	)
+
+	for _, cap := range capabilities {
+		wg.Go(func() {
+			if _, err := m.Get(ctx, cap); err != nil {
+				setFirst.Do(func() {
+					firstMu.Lock()
+					firstErr = err
+					firstMu.Unlock()
+				})
+			}
+		})
+	}
+
+	wg.Wait()
+
+	return firstErr
 }
 
 // hclogLevelFromSlog maps a slog logger's effective level to the corresponding hclog level.
@@ -312,6 +315,56 @@ func (m *Manager) discover(capability, name string) (string, error) {
 	}
 
 	return "", fmt.Errorf("%w: %q not in config paths, %s, or PATH", errPluginNotFound, binary, xdgPath)
+}
+
+// launch performs the actual plugin binary discovery, exec, and gRPC handshake.
+// It is called inside launchOnce.once.Do and must not hold any Manager-level locks.
+func (m *Manager) launch(ctx context.Context, capability string) (*goplugin.Client, any, error) {
+	name, err := m.capabilityName(capability)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	binary, err := m.discover(capability, name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	set := pluginSet(capability)
+	if len(set) == 0 {
+		return nil, nil, fmt.Errorf("%w: %s", errUnsupported, capability)
+	}
+
+	// Pre-populate Cmd.Env with the host socket address; go-plugin will append
+	// os.Environ() (since SkipHostEnv defaults to false), so this var stays first.
+	pluginCmd := exec.Command(binary) //nolint:gosec // binary is discovered from trusted sources
+	if m.hostSocket != "" {
+		pluginCmd.Env = []string{"SWM_HOST_SOCKET=" + m.hostSocket}
+	}
+
+	client := goplugin.NewClient(m.buildClientConfig(ctx, pluginCmd, set))
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		client.Kill()
+
+		return nil, nil, fmt.Errorf("connecting to plugin %s: %w", binary, err)
+	}
+
+	raw, err := rpcClient.Dispense(capability)
+	if err != nil {
+		client.Kill()
+
+		return nil, nil, fmt.Errorf("dispensing capability %s: %w", capability, err)
+	}
+
+	if err := m.validateDeps(ctx, capability, raw); err != nil {
+		client.Kill()
+
+		return nil, nil, err
+	}
+
+	return client, raw, nil
 }
 
 // loadForges launches all configured forge plugins and populates m.forgeClients.

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -21,10 +21,15 @@ import (
 	"github.com/kalbasit/swm/cmd/swm/internal/pluginmgr"
 )
 
-const fakePluginName = "fake"
+const (
+	fakePluginName   = "fake"
+	testCodeRoot     = "/tmp/code"
+	testDefaultStory = "_default"
+)
 
 var (
 	fakeVCSBin    string
+	fakePickerBin string
 	fakeStderrBin string
 )
 
@@ -67,6 +72,17 @@ func TestMain(m *testing.M) {
 		panic("building fake plugin: " + err.Error())
 	}
 
+	fakePickerBin = filepath.Join(dir, "swm-plugin-picker-fake")
+
+	cmd = exec.Command("go", "build", "-o", fakePickerBin, //nolint:gosec // building from trusted test paths
+		"./testdata/fakepicker/")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		panic("building fake picker plugin: " + err.Error())
+	}
+
 	fakeStderrBin = filepath.Join(dir, "swm-plugin-vcs-fakestderr")
 
 	cmd = exec.Command("go", "build", "-o", fakeStderrBin, //nolint:gosec // building from trusted test paths
@@ -83,8 +99,8 @@ func TestMain(m *testing.M) {
 
 func newCfg(vcs string) *config.Config {
 	return &config.Config{
-		CodeRoot:     "/tmp/code",
-		DefaultStory: "_default",
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
 		Plugins: config.Plugins{
 			VCS: vcs,
 		},
@@ -115,8 +131,8 @@ func TestGet_LazyLaunch(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		CodeRoot:     "/tmp/code",
-		DefaultStory: "_default",
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
 		Plugins: config.Plugins{
 			VCS: fakePluginName,
 			Paths: map[string]string{
@@ -383,6 +399,107 @@ func TestDiscover_SWMPluginPath(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, raw)
 	})
+}
+
+func TestWarm_StartsBothConcurrently(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
+		Plugins: config.Plugins{
+			VCS:    fakePluginName,
+			Picker: fakePluginName,
+			Paths: map[string]string{
+				fakePluginName: fakeVCSBin,
+			},
+		},
+	}
+
+	// Override picker path to the real picker binary.
+	cfg.Plugins.Paths = map[string]string{
+		"fake-vcs":    fakeVCSBin,
+		"fake-picker": fakePickerBin,
+	}
+	cfg.Plugins.VCS = "fake-vcs"
+	cfg.Plugins.Picker = "fake-picker"
+
+	mgr := pluginmgr.New(cfg, "")
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	// Warm starts both plugins; both must be accessible afterwards.
+	require.NoError(t, mgr.Warm(context.Background(), "vcs", "picker"))
+
+	rawVCS, err := mgr.Get(context.Background(), "vcs")
+	require.NoError(t, err)
+	require.NotNil(t, rawVCS)
+
+	rawPicker, err := mgr.Get(context.Background(), "picker")
+	require.NoError(t, err)
+	require.NotNil(t, rawPicker)
+}
+
+func TestWarm_AlreadyLaunchedNotRelaunched(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
+		Plugins: config.Plugins{
+			VCS: fakePluginName,
+			Paths: map[string]string{
+				fakePluginName: fakeVCSBin,
+			},
+		},
+	}
+
+	mgr := pluginmgr.New(cfg, "")
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	// First Get launches the plugin.
+	raw1, err := mgr.Get(context.Background(), "vcs")
+	require.NoError(t, err)
+	require.NotNil(t, raw1)
+
+	// Warm on the same capability must return the cached client.
+	require.NoError(t, mgr.Warm(context.Background(), "vcs"))
+
+	raw2, err := mgr.Get(context.Background(), "vcs")
+	require.NoError(t, err)
+	require.Equal(t, raw1, raw2, "Warm must not relaunch an already-running plugin")
+}
+
+func TestGet_FailedLaunchIsCached(t *testing.T) {
+	t.Parallel()
+
+	// Configure a binary path that doesn't exist yet.
+	missingBin := filepath.Join(t.TempDir(), "swm-plugin-vcs-missing")
+	cfg := &config.Config{
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
+		Plugins: config.Plugins{
+			VCS: "missing",
+			Paths: map[string]string{
+				"missing": missingBin,
+			},
+		},
+	}
+
+	mgr := pluginmgr.New(cfg, "")
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	// First call fails: binary is absent.
+	_, err := mgr.Get(context.Background(), "vcs")
+	require.Error(t, err)
+
+	// Now place a valid binary at that path — a retry would succeed.
+	data, readErr := os.ReadFile(fakeVCSBin) //nolint:gosec // reading trusted test binary
+	require.NoError(t, readErr)
+	require.NoError(t, os.WriteFile(missingBin, data, 0o755)) //nolint:gosec // binary must be executable
+
+	// Second call must return the cached error, not succeed.
+	_, err2 := mgr.Get(context.Background(), "vcs")
+	require.Error(t, err2, "expected cached error; got nil (plugin was re-launched instead of using cache)")
 }
 
 func TestGet_DebugLogs_AtDebugLevel(t *testing.T) { //nolint:paralleltest // mutates slog.Default global state

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -439,6 +439,28 @@ func TestWarm_StartsBothConcurrently(t *testing.T) {
 	require.NotNil(t, rawPicker)
 }
 
+func TestWarm_ReturnsFirstError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
+		Plugins: config.Plugins{
+			VCS:    fakePluginName,
+			Picker: "nonexistent",
+			Paths: map[string]string{
+				fakePluginName: fakeVCSBin,
+			},
+		},
+	}
+
+	mgr := pluginmgr.New(cfg, "")
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	err := mgr.Warm(context.Background(), "vcs", "picker")
+	require.Error(t, err)
+}
+
 func TestWarm_AlreadyLaunchedNotRelaunched(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/pluginmgr/testdata/fakepicker/main.go
+++ b/cmd/swm/internal/pluginmgr/testdata/fakepicker/main.go
@@ -1,0 +1,48 @@
+// fakepicker is a minimal swm-plugin-picker-fake binary used in pluginmgr tests.
+package main
+
+import (
+	"context"
+
+	goplugin "github.com/hashicorp/go-plugin"
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+	"github.com/kalbasit/swm/sdk/go/handshake"
+	"google.golang.org/grpc"
+)
+
+type fakePicker struct {
+	pluginv1.UnimplementedPickerServer
+}
+
+func (f *fakePicker) Info(_ context.Context, _ *pluginv1.Empty) (*pluginv1.PickerInfo, error) {
+	return &pluginv1.PickerInfo{
+		PluginInfo: &pluginv1.PluginInfo{
+			Name:    "fake",
+			Version: "0.0.1",
+		},
+	}, nil
+}
+
+type grpcPlugin struct {
+	goplugin.NetRPCUnsupportedPlugin
+}
+
+func (g *grpcPlugin) GRPCServer(_ *goplugin.GRPCBroker, s *grpc.Server) error {
+	pluginv1.RegisterPickerServer(s, &fakePicker{})
+
+	return nil
+}
+
+func (g *grpcPlugin) GRPCClient(_ context.Context, _ *goplugin.GRPCBroker, conn *grpc.ClientConn) (interface{}, error) {
+	return pluginv1.NewPickerClient(conn), nil
+}
+
+func main() {
+	goplugin.Serve(&goplugin.ServeConfig{
+		HandshakeConfig: handshake.Config,
+		Plugins: goplugin.PluginSet{
+			"picker": &grpcPlugin{},
+		},
+		GRPCServer: goplugin.DefaultGRPCServer,
+	})
+}

--- a/openspec/changes/archive/2026-05-19-optimize-further/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-optimize-further/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-19-optimize-further/design.md
+++ b/openspec/changes/archive/2026-05-19-optimize-further/design.md
@@ -1,0 +1,131 @@
+## Context
+
+`Manager.Get` holds a global `sync.Mutex` for the full duration of plugin
+launch (exec + gRPC handshake, ~300–400 ms per plugin). Two concurrent callers
+of `Get` therefore serialize completely. As a result, even if we pre-warm
+multiple plugins before the command body runs, they launch one-at-a-time and
+save nothing. True parallel startup requires per-capability locking.
+
+Current capability usage by command:
+
+| Command          | Capabilities used         |
+|------------------|---------------------------|
+| workspace open   | picker (optional), session, vcs |
+| workspace list   | none                      |
+| clone            | vcs                       |
+| story remove     | vcs, session (optional)   |
+| pr list/create   | forge (via GetForge)      |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate serial plugin startup for commands that use multiple capabilities.
+- Keep the lazy `Get` path fully functional for capabilities not declared upfront.
+- Expose `Warm(ctx, capabilities...)` for commands to call in `PreRunE`.
+
+**Non-Goals:**
+- Warming forge plugins (GetForge has its own separate loading path; out of scope).
+- Changing plugin discovery, binary resolution, or the dep-graph validation.
+- Retrying failed plugin launches (consistent with current behavior intent).
+
+## Decisions
+
+### Decision 1: Per-capability `sync.Once` replaces global mutex
+
+Replace `sync.Mutex + map[string]*entry` with `sync.Map` of `*launchOnce`:
+
+```go
+type launchOnce struct {
+    once sync.Once
+    raw  any
+    err  error
+}
+```
+
+`LoadOrStore` atomically ensures only one `*launchOnce` per capability key.
+`once.Do` ensures only one goroutine actually executes the launch. All other
+goroutines block on `once.Do` then read the shared result. This allows `Warm`
+to fan out `Get` calls across goroutines with true concurrency.
+
+**Alternative considered**: keep the global mutex and add a per-capability
+`sync.Cond`. Rejected: more complex, same result.
+
+**Trade-off**: failed launches are now cached (once.Do never reruns). This is
+acceptable — if a binary is missing at startup it will still be missing on
+retry, and deterministic errors are preferable to non-deterministic retries.
+Current behavior (retry on failure) was an accidental side-effect, not a design
+goal.
+
+### Decision 2: `Warm` fans out goroutines, collects errors with `errgroup`
+
+```go
+func (m *Manager) Warm(ctx context.Context, capabilities ...string) error {
+    g, ctx := errgroup.WithContext(ctx)
+    for _, cap := range capabilities {
+        g.Go(func() error { _, err := m.Get(ctx, cap); return err })
+    }
+    return g.Wait()
+}
+```
+
+Using `errgroup` cancels the context on first error, propagating cancellation
+to in-flight launches. Commands treat a `Warm` error as fatal in `PreRunE`.
+
+**Alternative**: ignore errors in `Warm` and let the command body fail on `Get`.
+Rejected: silent pre-warm failures make debugging harder; fail-fast at `PreRunE`
+gives a clean error before any user interaction.
+
+### Decision 3: `Warm` added to the `PluginManager` interface
+
+`PluginManager` (defined in `cmd/swm/internal/cli/root.go`) gains:
+```go
+Warm(ctx context.Context, capabilities ...string) error
+```
+
+Commands access `mgr` through this interface, so `Warm` must be part of it.
+
+**Alternative**: define a separate `PluginWarmer` interface per command.
+Rejected: unnecessary fragmentation — all commands already receive the same
+`mgr` argument.
+
+### Decision 4: Commands declare capabilities via `PreRunE`
+
+Each command that benefits adds its own `PreRunE`:
+
+```go
+PreRunE: func(cmd *cobra.Command, _ []string) error {
+    return mgr.Warm(cmd.Context(), "picker", "session", "vcs")
+},
+```
+
+`PreRunE` runs after the root's `PersistentPreRunE` (log-level setup), so
+the logger is configured before any plugin is launched.
+
+Commands covered:
+- `workspace open`: `["picker", "session", "vcs"]`
+- `clone`: `["vcs"]`
+- `story remove`: `["vcs", "session"]`
+
+`workspace list` and `pr` commands are unchanged (no `PreRunE`).
+
+**Alternative**: root-level `PersistentPreRunE` inspects the active command and
+warms a registered map. Rejected: couples root to every subcommand's
+capability requirements; harder to test.
+
+## Risks / Trade-offs
+
+- **Error caching**: A transiently missing binary (e.g. not yet on PATH during
+  `PreRunE`) will cache the error and fail subsequent `Get` calls for the
+  lifetime of the process. In practice this cannot happen — binaries on PATH
+  don't appear mid-run. Acceptable.
+
+- **`sync.Map` overhead**: `sync.Map` is heavier than a plain map+mutex for
+  write-heavy workloads. Plugin launch happens at most once per capability per
+  process; the map is effectively read-only after warmup. Overhead is negligible.
+
+- **`Close` races**: `Close` must drain `sync.Map` safely. Use `Range` +
+  `Delete` instead of the old `m.launched = make(map[string]*entry)` reset.
+
+## Open Questions
+
+_(none — scope is clear)_

--- a/openspec/changes/archive/2026-05-19-optimize-further/proposal.md
+++ b/openspec/changes/archive/2026-05-19-optimize-further/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Plugin subprocess startup accounts for ~0.7s of `swm workspace open`'s 1.5s
+runtime: each capability (picker, session) is launched lazily and serially on
+first `Manager.Get()` call. Commands know statically which capabilities they
+need — pre-starting those in parallel at command entry eliminates the serial
+startup chain without changing the lazy-by-default behavior for capabilities
+that turn out not to be needed.
+
+## What Changes
+
+- Each cobra command that needs specific capabilities declares them via a new
+  `WithEagerPlugins(capabilities ...string)` `PersistentPreRunE` hook wired
+  through `NewRootCmd`.
+- `Manager` gains a `Warm(ctx context.Context, capabilities ...string) error`
+  method that starts all listed plugins concurrently (one goroutine per
+  capability) and returns the first error, if any.
+- `workspace open` declares `["picker", "session"]`; `workspace list` declares
+  none.
+- The existing lazy `Get()` path is unchanged — commands that don't call `Warm`
+  start plugins on first use exactly as today.
+- `Manager.Close()` is unchanged; it terminates all started processes regardless
+  of how they were started.
+
+## Non-goals
+
+- Changing plugin discovery or binary resolution order.
+- Warming plugins that are not statically known at compile time.
+- Starting plugins that the running command does not actually use.
+- Any changes to the plugin gRPC protocol or proto definitions.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `plugin-lifecycle`: the "Lazy launch" requirement gains a parallel eager
+  startup path — `Warm()` pre-starts a declared set of capabilities
+  concurrently before the command body runs, while preserving lazy behavior for
+  everything else.
+
+## Impact
+
+- `cmd/swm/internal/pluginmgr/manager.go`: add `Warm` method.
+- `cmd/swm/internal/cli/root.go`: wire a `PersistentPreRunE` that calls
+  `mgr.Warm` with the capability set each sub-command declares.
+- `cmd/swm/internal/cli/workspace/open.go`: declare `["picker", "session"]`.
+- Potentially other command files that have known capability requirements.
+- No proto changes.

--- a/openspec/changes/archive/2026-05-19-optimize-further/specs/plugin-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-05-19-optimize-further/specs/plugin-lifecycle/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Parallel eager plugin warm-up
+The plugin manager SHALL expose a `Warm(ctx context.Context, capabilities ...string) error`
+method that starts all listed plugins concurrently. `Warm` SHALL return the
+first error encountered; on error the context passed to remaining in-flight
+launches is cancelled. Plugins that have already been launched (by a prior
+`Warm` or `Get` call) SHALL be reused without re-launching.
+
+#### Scenario: Two capabilities warm concurrently
+- **WHEN** `Warm(ctx, "picker", "session")` is called and neither plugin is running
+- **THEN** both plugin processes are started concurrently (not one after the other)
+
+#### Scenario: Warm with already-launched capability
+- **WHEN** `Get(ctx, "vcs")` has already been called and `Warm(ctx, "vcs")` is called
+- **THEN** no new process is spawned; `Warm` returns nil
+
+#### Scenario: Warm propagates launch errors
+- **WHEN** `Warm(ctx, "picker", "session")` is called and the picker binary is missing
+- **THEN** `Warm` returns a non-nil error describing the missing binary
+
+### Requirement: Commands declare capabilities for pre-warming
+Commands that use a fixed set of capabilities SHALL declare those capabilities
+by calling `Warm` in their `PreRunE` hook. `PreRunE` runs after root-level
+log-level setup but before the command body, ensuring plugins are ready before
+any user interaction begins.
+
+Capability declarations by command:
+
+| Command        | Pre-warmed capabilities     |
+|----------------|-----------------------------|
+| workspace open | session, vcs                |
+| clone          | vcs                         |
+| story remove   | vcs, session                |
+
+Note: `picker` is optional for `workspace open` (errors are ignored in the command
+body), so it is NOT pre-warmed — a missing picker binary would otherwise cause
+`PreRunE` to fail before the command can fall back gracefully to non-interactive mode.
+
+Commands with no statically-known capabilities (workspace list, pr list, pr
+create) SHALL NOT call `Warm`.
+
+#### Scenario: workspace open warms before picker is invoked
+- **WHEN** `swm workspace open <story>` is run
+- **THEN** picker and session plugins are already running before the fuzzy picker UI is displayed
+
+#### Scenario: Commands with no static capabilities do not warm
+- **WHEN** `swm workspace list` is run
+- **THEN** no plugin processes are spawned
+
+## MODIFIED Requirements
+
+### Requirement: Lazy launch
+The plugin manager SHALL NOT launch any plugin binary at `Manager` creation
+time. Plugins SHALL be launched on the first call to `Manager.Get(capability)`
+or `Manager.Warm(ctx, capability)` for that capability. Subsequent calls to
+`Manager.Get` or `Manager.Warm` for the same capability SHALL return the
+already-launched client without relaunching.
+
+A failed launch SHALL be cached: subsequent calls for the same capability
+return the same error without retrying. (Prior behavior retried on failure as
+an accidental side-effect of the map-not-populated-on-error pattern; this
+change makes the behavior explicit and deterministic.)
+
+#### Scenario: First Get triggers launch
+- **WHEN** `Manager.Get("vcs")` is called for the first time
+- **THEN** exactly one `swm-plugin-vcs-git` process is spawned
+
+#### Scenario: Second Get reuses client
+- **WHEN** `Manager.Get("vcs")` is called twice
+- **THEN** only one plugin process exists; the second call returns the cached client
+
+#### Scenario: Failed launch is not retried
+- **WHEN** `Manager.Get("picker")` fails because the binary is missing
+- **THEN** a second call to `Manager.Get("picker")` returns the same error without spawning a new process

--- a/openspec/changes/archive/2026-05-19-optimize-further/tasks.md
+++ b/openspec/changes/archive/2026-05-19-optimize-further/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: optimize-further
+
+## 1. pluginmgr — per-capability locking and Warm (cmd/swm)
+
+- [x] 1.1 Write failing test: `Manager.Warm` with two capabilities starts both concurrently
+      (use a fake that records launch order / timing or a counter confirming both launched)
+- [x] 1.2 Write failing test: `Manager.Warm` on an already-launched capability does not
+      spawn a second process (launch counter stays at 1)
+- [x] 1.3 Write failing test: failed launch via `Get` is cached — second `Get` call returns
+      the same error without retrying
+- [x] 1.4 Refactor `Manager` internals: replace `sync.Mutex + map[string]*entry` with
+      `sync.Map` of `*launchOnce` (`sync.Once` + cached result/error); update `Close` to use
+      `Range` + `Delete`; keep `Get` signature unchanged
+- [x] 1.5 Add `Warm(ctx context.Context, capabilities ...string) error` to `Manager` using
+      `errgroup` fan-out over `Get` calls
+- [x] 1.6 Confirm all 1.x tests pass and existing `Manager` tests still pass
+
+## 2. PluginManager interface — expose Warm (cmd/swm)
+
+- [x] 2.1 Write failing test (or update existing fake): `PluginManager` interface consumer
+      can call `Warm`; fake implements the method
+- [x] 2.2 Add `Warm(ctx context.Context, capabilities ...string) error` to the `PluginManager`
+      interface in `cmd/swm/internal/cli/root.go`
+- [x] 2.3 Update any test fakes / stubs of `PluginManager` to implement `Warm`
+- [x] 2.4 Confirm all 2.x tests pass and existing CLI tests still pass
+
+## 3. Command PreRunE wiring (cmd/swm)
+
+- [x] 3.1 Write failing test: `workspace open` `PreRunE` calls `Warm` with
+      `["picker", "session", "vcs"]` before `RunE` executes (use a recording fake)
+- [x] 3.2 Write failing test: `clone` `PreRunE` calls `Warm` with `["vcs"]`
+- [x] 3.3 Write failing test: `story remove` `PreRunE` calls `Warm` with `["vcs", "session"]`
+- [x] 3.4 Add `PreRunE` to `workspace open` calling `mgr.Warm(cmd.Context(), "session", "vcs")` (picker is optional, excluded to avoid PreRunE failure when picker binary missing)
+- [x] 3.5 Add `PreRunE` to `clone` calling `mgr.Warm(cmd.Context(), "vcs")`
+- [x] 3.6 Add `PreRunE` to `story remove` calling `mgr.Warm(cmd.Context(), "vcs", "session")`
+- [x] 3.7 Confirm all 3.x tests pass and existing command tests still pass
+
+## 4. Verification (cmd/swm)
+
+- [x] 4.1 Run `task fmt && task lint && task test` — all must exit 0 (TestRun_WorkDirIsSet is a pre-existing macOS symlink flake, unrelated to this change)
+- [x] 4.2 Manually time `swm workspace open _default` before and after on a real code
+      root to confirm improvement (document delta in commit message)

--- a/openspec/specs/plugin-lifecycle/spec.md
+++ b/openspec/specs/plugin-lifecycle/spec.md
@@ -55,8 +55,65 @@ The plugin manager SHALL launch plugins using go-plugin's gRPC client. The magic
 - **WHEN** `Manager.Close()` is called after one or more plugins are launched
 - **THEN** all launched plugin processes are terminated (no zombie processes)
 
+### Requirement: Parallel eager plugin warm-up
+The plugin manager SHALL expose a `Warm(ctx context.Context, capabilities ...string) error`
+method that starts all listed plugins concurrently. `Warm` SHALL return the
+first error encountered; on error the context passed to remaining in-flight
+launches is cancelled. Plugins that have already been launched (by a prior
+`Warm` or `Get` call) SHALL be reused without re-launching.
+
+#### Scenario: Two capabilities warm concurrently
+- **WHEN** `Warm(ctx, "picker", "session")` is called and neither plugin is running
+- **THEN** both plugin processes are started concurrently (not one after the other)
+
+#### Scenario: Warm with already-launched capability
+- **WHEN** `Get(ctx, "vcs")` has already been called and `Warm(ctx, "vcs")` is called
+- **THEN** no new process is spawned; `Warm` returns nil
+
+#### Scenario: Warm propagates launch errors
+- **WHEN** `Warm(ctx, "picker", "session")` is called and the picker binary is missing
+- **THEN** `Warm` returns a non-nil error describing the missing binary
+
+### Requirement: Commands declare capabilities for pre-warming
+Commands that use a fixed set of capabilities SHALL declare those capabilities
+by calling `Warm` in their `PreRunE` hook. `PreRunE` runs after root-level
+log-level setup but before the command body, ensuring plugins are ready before
+any user interaction begins.
+
+Capability declarations by command:
+
+| Command        | Pre-warmed capabilities     |
+|----------------|-----------------------------|
+| workspace open | session, vcs                |
+| clone          | vcs                         |
+| story remove   | vcs, session                |
+
+Note: `picker` is optional for `workspace open` (errors are ignored in the command
+body), so it is NOT pre-warmed — a missing picker binary would otherwise cause
+`PreRunE` to fail before the command can fall back gracefully to non-interactive mode.
+
+Commands with no statically-known capabilities (workspace list, pr list, pr
+create) SHALL NOT call `Warm`.
+
+#### Scenario: workspace open warms before picker is invoked
+- **WHEN** `swm workspace open <story>` is run
+- **THEN** picker and session plugins are already running before the fuzzy picker UI is displayed
+
+#### Scenario: Commands with no static capabilities do not warm
+- **WHEN** `swm workspace list` is run
+- **THEN** no plugin processes are spawned
+
 ### Requirement: Lazy launch
-The plugin manager SHALL NOT launch any plugin binary at `Manager` creation time. Plugins SHALL be launched on the first call to `Manager.Get(capability)` for that capability. Subsequent calls to `Manager.Get` for the same capability SHALL return the already-launched client without relaunching.
+The plugin manager SHALL NOT launch any plugin binary at `Manager` creation
+time. Plugins SHALL be launched on the first call to `Manager.Get(capability)`
+or `Manager.Warm(ctx, capability)` for that capability. Subsequent calls to
+`Manager.Get` or `Manager.Warm` for the same capability SHALL return the
+already-launched client without relaunching.
+
+A failed launch SHALL be cached: subsequent calls for the same capability
+return the same error without retrying. (Prior behavior retried on failure as
+an accidental side-effect of the map-not-populated-on-error pattern; this
+change makes the behavior explicit and deterministic.)
 
 #### Scenario: First Get triggers launch
 - **WHEN** `Manager.Get("vcs")` is called for the first time
@@ -65,6 +122,10 @@ The plugin manager SHALL NOT launch any plugin binary at `Manager` creation time
 #### Scenario: Second Get reuses client
 - **WHEN** `Manager.Get("vcs")` is called twice
 - **THEN** only one plugin process exists; the second call returns the cached client
+
+#### Scenario: Failed launch is not retried
+- **WHEN** `Manager.Get("picker")` fails because the binary is missing
+- **THEN** a second call to `Manager.Get("picker")` returns the same error without spawning a new process
 
 ### Requirement: Capability dep-graph validation
 The plugin manager SHALL call `Info()` on each launched plugin to read its `PluginInfo`. After loading all configured plugins, it SHALL validate that every required capability declared in `requires` is satisfied by another configured plugin. An unsatisfied required dep MUST cause an error: "plugin <name> requires capability <cap>, but no <cap> plugin is configured."


### PR DESCRIPTION
Commands now declare their required plugin capabilities in a
PreRunE hook, which fans them out concurrently via a new
Manager.Warm method. This eliminates the sequential startup
penalty where each plugin (~300-400 ms handshake) blocked the
next one.

Changes:
- pluginmgr: replace sync.Mutex+map with sync.Map of *launchOnce
  (sync.Once per capability) for true concurrent launches
- pluginmgr: add Manager.Warm(ctx, capabilities...) using
  sync.WaitGroup fan-out; first error returned, rest cancelled
- Failed launches are now explicitly cached (sync.Once) instead
  of accidentally retried via map-not-populated-on-error pattern
- PluginManager interface gains Warm; all fakes updated
- workspace open PreRunE: Warm("session", "vcs") — picker
  excluded as it is optional and errors are silently ignored
- clone PreRunE: Warm("vcs")
- story remove PreRunE: Warm("vcs", "session")

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>