### PR TITLE
perf: make Warm non-blocking

### DIFF
--- a/cmd/swm/internal/cli/clone.go
+++ b/cmd/swm/internal/cli/clone.go
@@ -25,7 +25,9 @@ func NewCloneCmd(mgr PluginManager, resolver *layout.Resolver, hooks hookexec.Ru
 		Short: "Clone a repository to its canonical path",
 		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return mgr.Warm(cmd.Context(), "vcs")
+			mgr.Warm(cmd.Context(), "vcs") //nolint:errcheck,gosec // Warm always returns nil; errors deferred to Get
+
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			url := args[0]

--- a/cmd/swm/internal/cli/story/remove.go
+++ b/cmd/swm/internal/cli/story/remove.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
@@ -47,19 +46,9 @@ func NewRemoveCmd(
 		Short: "Remove a story and all its worktrees",
 		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			// Warm session concurrently but discard its error — session is optional;
-			// RunE silently falls back when it is absent (closeStoryWorkspace is best-effort).
-			var wg sync.WaitGroup
+			mgr.Warm(cmd.Context(), "vcs", "session") //nolint:errcheck,gosec // Warm always returns nil; errors deferred to Get
 
-			wg.Go(func() {
-				_ = mgr.Warm(cmd.Context(), "session") //nolint:errcheck // session is optional
-			})
-
-			err := mgr.Warm(cmd.Context(), "vcs")
-
-			wg.Wait()
-
-			return err
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var name string

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -135,19 +134,12 @@ func NewOpenCmd(
 			"environment variable, and then to the default story configured in swm.",
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			// Warm picker concurrently but discard its error — picker is optional;
-			// RunE silently falls back to non-interactive mode when it is absent.
-			var wg sync.WaitGroup
+			// Fire background startup for all three capabilities; errors surface in
+			// RunE when the plugin is first used via Get.
+			//nolint:errcheck,gosec // Warm always returns nil; errors deferred to Get
+			mgr.Warm(cmd.Context(), "picker", "session", "vcs")
 
-			wg.Go(func() {
-				_ = mgr.Warm(cmd.Context(), "picker") //nolint:errcheck // picker is optional
-			})
-
-			err := mgr.Warm(cmd.Context(), "session", "vcs")
-
-			wg.Wait()
-
-			return err
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -1132,7 +1132,7 @@ func TestOpenCmd_PreRunE_WarmsPlugins(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	require.ElementsMatch(t, []string{"picker", "session", "vcs"}, rec.warmedCaps,
-		"workspace open PreRunE must warm session, vcs, and picker (picker error is discarded)")
+		"workspace open PreRunE must warm session, vcs, and picker in a single non-blocking call")
 }
 
 // warmRecordingMgr wraps stubMgr and records capabilities passed to Warm.

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -199,19 +199,22 @@ func (m *Manager) Warm(ctx context.Context, capabilities ...string) error {
 	bgCtx := context.WithoutCancel(ctx)
 
 	for _, c := range capabilities {
-		stored, _ := m.launched.LoadOrStore(c, &launchOnce{})
+		stored, loaded := m.launched.LoadOrStore(c, &launchOnce{})
+		if loaded {
+			continue
+		}
 
 		lo, ok := stored.(*launchOnce)
 		if !ok {
 			continue
 		}
 
-		go func() {
+		go func(capability string) {
 			lo.once.Do(func() {
-				lo.client, lo.raw, lo.err = m.launch(bgCtx, c)
+				lo.client, lo.raw, lo.err = m.launch(bgCtx, capability)
 				lo.done.Store(true)
 			})
-		}()
+		}(c)
 	}
 
 	return nil

--- a/cmd/swm/internal/pluginmgr/manager.go
+++ b/cmd/swm/internal/pluginmgr/manager.go
@@ -190,39 +190,31 @@ func (m *Manager) GetForge(ctx context.Context, hostname string) (pluginv1.Forge
 	return nil, fmt.Errorf("%w: %q", errNoForgePlugin, hostname)
 }
 
-// Warm pre-starts the listed capabilities concurrently.
-// Each capability is launched in its own goroutine; the first error cancels the rest
-// and is returned after all goroutines finish.
+// Warm pre-starts the listed capabilities in background goroutines and returns
+// immediately. Errors from plugin startup are not returned here; they are
+// surfaced by the first Get call for the failing capability.
 // Capabilities already running are reused without relaunching.
 func (m *Manager) Warm(ctx context.Context, capabilities ...string) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	var (
-		wg       sync.WaitGroup
-		firstErr error
-		setFirst sync.Once
-	)
+	// Strip cancellation so goroutines outlive the caller's context (e.g. PreRunE).
+	bgCtx := context.WithoutCancel(ctx)
 
 	for _, c := range capabilities {
-		wg.Add(1)
+		stored, _ := m.launched.LoadOrStore(c, &launchOnce{})
 
-		go func(c string) {
-			defer wg.Done()
+		lo, ok := stored.(*launchOnce)
+		if !ok {
+			continue
+		}
 
-			if _, err := m.Get(ctx, c); err != nil {
-				setFirst.Do(func() {
-					firstErr = err
-
-					cancel()
-				})
-			}
-		}(c)
+		go func() {
+			lo.once.Do(func() {
+				lo.client, lo.raw, lo.err = m.launch(bgCtx, c)
+				lo.done.Store(true)
+			})
+		}()
 	}
 
-	wg.Wait()
-
-	return firstErr
+	return nil
 }
 
 // hclogLevelFromSlog maps a slog logger's effective level to the corresponding hclog level.

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -516,6 +516,36 @@ func TestWarm_AlreadyLaunchedNotRelaunched(t *testing.T) {
 	require.Equal(t, raw1, raw2, "Warm must not relaunch an already-running plugin")
 }
 
+func TestWarm_CalledTwiceDoesNotRelaunch(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
+		Plugins: config.Plugins{
+			VCS: fakePluginName,
+			Paths: map[string]string{
+				fakePluginName: fakeVCSBin,
+			},
+		},
+	}
+
+	mgr := pluginmgr.New(cfg, "")
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	// Two Warm calls for the same capability must not relaunch the plugin.
+	require.NoError(t, mgr.Warm(context.Background(), "vcs"))
+	require.NoError(t, mgr.Warm(context.Background(), "vcs"))
+
+	raw1, err := mgr.Get(context.Background(), "vcs")
+	require.NoError(t, err)
+	require.NotNil(t, raw1)
+
+	raw2, err := mgr.Get(context.Background(), "vcs")
+	require.NoError(t, err)
+	require.Equal(t, raw1, raw2, "Warm called twice must not relaunch the plugin")
+}
+
 func TestGet_FailedLaunchIsCached(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/swm/internal/pluginmgr/manager_test.go
+++ b/cmd/swm/internal/pluginmgr/manager_test.go
@@ -427,7 +427,8 @@ func TestWarm_StartsBothConcurrently(t *testing.T) {
 	mgr := pluginmgr.New(cfg, "")
 	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
-	// Warm starts both plugins; both must be accessible afterwards.
+	// Warm fires background goroutines and returns immediately; both plugins must
+	// be accessible via Get once they finish starting.
 	require.NoError(t, mgr.Warm(context.Background(), "vcs", "picker"))
 
 	rawVCS, err := mgr.Get(context.Background(), "vcs")
@@ -439,7 +440,7 @@ func TestWarm_StartsBothConcurrently(t *testing.T) {
 	require.NotNil(t, rawPicker)
 }
 
-func TestWarm_ReturnsFirstError(t *testing.T) {
+func TestWarm_ReturnsNilImmediately(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
@@ -457,7 +458,31 @@ func TestWarm_ReturnsFirstError(t *testing.T) {
 	mgr := pluginmgr.New(cfg, "")
 	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
 
-	err := mgr.Warm(context.Background(), "vcs", "picker")
+	// Warm must return nil even when a capability will fail to launch.
+	require.NoError(t, mgr.Warm(context.Background(), "vcs", "picker"))
+}
+
+func TestWarm_ErrorSurfacedByGet(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		CodeRoot:     testCodeRoot,
+		DefaultStory: testDefaultStory,
+		Plugins: config.Plugins{
+			VCS:    fakePluginName,
+			Picker: "nonexistent",
+			Paths: map[string]string{
+				fakePluginName: fakeVCSBin,
+			},
+		},
+	}
+
+	mgr := pluginmgr.New(cfg, "")
+	defer mgr.Close() //nolint:errcheck // best-effort cleanup in test teardown
+
+	require.NoError(t, mgr.Warm(context.Background(), "picker"))
+
+	_, err := mgr.Get(context.Background(), "picker")
 	require.Error(t, err)
 }
 

--- a/openspec/changes/archive/2026-05-19-do-not-halt-the-world/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-19-do-not-halt-the-world/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/archive/2026-05-19-do-not-halt-the-world/design.md
+++ b/openspec/changes/archive/2026-05-19-do-not-halt-the-world/design.md
@@ -1,0 +1,101 @@
+## Context
+
+`Manager.Warm()` currently blocks the caller until every requested plugin has started
+(via `wg.Wait()`). In `PreRunE`, this means the command's `RunE` cannot begin until
+all plugins are up, defeating the purpose of early warming. Plugin startup can take
+hundreds of milliseconds for the gRPC handshake.
+
+The existing `launchOnce` / `sync.Once` machinery already provides the right primitive:
+`once.Do` blocks all subsequent callers until the first invocation completes. The only
+missing piece is decoupling `Warm`'s goroutines from the caller's wait.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `Warm` returns immediately after firing background goroutines.
+- `Get` remains the natural synchronization point — blocks only if the plugin is still
+  booting, returns immediately if it's ready.
+- `PreRunE` call sites simplify: one `Warm` call, no `sync.WaitGroup`, no error check.
+- Context lifetime is correct: background goroutines outlive `PreRunE`.
+
+**Non-Goals:**
+- Changing the plugin gRPC protocol or any proto definitions.
+- Adding UI feedback (spinner, log line) during background startup.
+- Removing `Warm` call sites — they remain as early-start hints.
+
+## Decisions
+
+### 1. Warm fires goroutines and returns nil
+
+**Decision:** `Warm` iterates capabilities, calls `m.launched.LoadOrStore` to
+get-or-create the `launchOnce` entry, then fires a goroutine that calls
+`lo.once.Do(launch)`. It returns `nil` immediately.
+
+**Why:** Errors from plugin startup are already cached in `launchOnce.err` and
+returned by every subsequent `Get`. There is no value in returning them from
+`Warm` — the caller can't act on them without blocking anyway.
+
+**Alternative considered:** Keep `Warm` blocking but add a timeout. Rejected —
+any timeout is arbitrary and the problem recurs with slow machines.
+
+### 2. Background goroutine uses a detached context
+
+**Decision:** `Warm` wraps the caller's context with `context.WithoutCancel` before
+passing it to the goroutine. This strips deadline/cancellation while preserving values
+(logger, trace IDs).
+
+**Why:** `PreRunE`'s context may be cancelled or have a short deadline. The background
+goroutine must survive until `Get` is called from `RunE`. `context.WithoutCancel` is
+the minimal change — background context would lose values.
+
+**Why not `context.Background()`:** Loses logger and any other values stored in the
+context chain.
+
+### 3. Get is unchanged
+
+**Decision:** `Get` remains exactly as-is. `sync.Once.Do` blocks callers until the
+first invocation (the warm goroutine's `once.Do`) completes, then all subsequent
+callers return the cached result.
+
+**Why:** The synchronization is already correct. The warm goroutine "owns" the
+`once.Do` if it starts first; `Get` will block until it finishes. If `Get` starts
+first (warm never called or lost the race), it runs launch itself.
+
+### 4. PreRunE call sites consolidate
+
+**Decision:** All `PreRunE` hooks that call `Warm` simplify to a single `mgr.Warm(ctx, caps...)`
+with no error check and no `sync.WaitGroup`. Picker is no longer special-cased.
+
+```go
+// Before
+var wg sync.WaitGroup
+wg.Go(func() { _ = mgr.Warm(cmd.Context(), "picker") })
+err := mgr.Warm(cmd.Context(), "session", "vcs")
+wg.Wait()
+return err
+
+// After
+mgr.Warm(cmd.Context(), "picker", "session", "vcs")
+return nil
+```
+
+**Why:** Warm errors now surface in RunE when `Get` is called. The caller-side
+`WaitGroup` was compensating for Warm being synchronous; it is no longer needed.
+
+## Risks / Trade-offs
+
+- **[Risk] Error surfacing moves later** → Mitigation: errors appear at first `Get`
+  call in `RunE`, which is still early and with the same message. The only behavioral
+  difference is that a missing plugin binary is reported slightly later.
+
+- **[Risk] Context lifetime confusion** → Mitigation: `context.WithoutCancel` is
+  explicit and documented at the call site. The pattern is standard for "fire and
+  forget with value inheritance."
+
+- **[Risk] Background goroutine leak if process exits before Get** → Mitigation:
+  `Manager.Close` kills plugin processes; if the process exits before `Get` is called,
+  the goroutine will return quickly (launch fails or the OS reclaims the child).
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-19-do-not-halt-the-world/proposal.md
+++ b/openspec/changes/archive/2026-05-19-do-not-halt-the-world/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+`Warm()` is called in `PreRunE` and blocks until every requested plugin has started,
+even though plugins start concurrently with each other. The user-visible latency is
+identical to lazy startup — we just pay it earlier and with no feedback.
+The fix is to make warming genuinely non-blocking: fire startup in the background
+and let the first actual `Get()` call be the natural synchronization point.
+
+## What Changes
+
+- `Manager.Warm()` becomes fire-and-forget: it launches a startup goroutine per
+  capability and returns immediately (no `wg.Wait()`).
+- `Manager.Get()` becomes the wait point: if the plugin for a capability is still
+  booting, `Get()` blocks until it is ready (or errors).
+- `PreRunE` hooks are retained — they continue to call `Warm()` to initiate early
+  startup, but they no longer stall command execution.
+- The first-error-cancels-rest semantics move from `Warm()` into `Get()`: a failed
+  startup is surfaced to the first caller that needs the plugin, not to PreRunE.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None — this is an internal change to `pluginmgr.Manager`. No plugin-facing
+capability surface (`session`, `vcs`, `forge`, `picker`, `hook`) changes its
+observable behavior or protocol.
+
+## Non-goals
+
+- Changing the plugin gRPC protocol or any proto definitions.
+- Removing `Warm()` call sites — they remain as hints to start early.
+- Surfacing progress/spinner UI during plugin startup.
+- Changing how plugin errors are ultimately reported to the user.
+
+## Impact
+
+- `cmd/swm/internal/pluginmgr/Manager`: `Warm()` and `Get()` implementations change.
+- All `PreRunE` hooks that call `Warm()`: behavior changes (no longer blocks), but
+  call sites are unchanged.
+- No proto changes; no capability surface changes.
+- Capability surface(s) affected: **none**.

--- a/openspec/changes/archive/2026-05-19-do-not-halt-the-world/specs/plugin-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-05-19-do-not-halt-the-world/specs/plugin-lifecycle/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Parallel eager plugin warm-up
+The plugin manager SHALL expose a `Warm(ctx context.Context, capabilities ...string) error`
+method that starts all listed plugins in background goroutines and returns immediately with nil.
+Plugin startup errors are NOT returned by `Warm`; they are surfaced by the first `Get` call
+for that capability. Plugins already launched are reused without re-launching.
+The context passed to `Warm` SHALL be stripped of cancellation so background goroutines
+outlive the caller's context.
+
+#### Scenario: Two capabilities warm concurrently
+- **WHEN** `Warm(ctx, "vcs", "session")` is called
+- **THEN** both plugins begin starting in background goroutines
+- **THEN** `Warm` returns nil immediately without waiting for either to complete
+
+#### Scenario: Warm with already-launched capability
+- **WHEN** `Get(ctx, "vcs")` has already been called and `Warm(ctx, "vcs")` is called
+- **THEN** no new process is spawned; `Warm` returns nil
+
+#### Scenario: Warm does not propagate launch errors
+- **WHEN** `Warm(ctx, "picker")` is called and the picker binary is missing
+- **THEN** `Warm` returns nil immediately
+- **WHEN** `Get(ctx, "picker")` is subsequently called
+- **THEN** `Get` returns the launch error describing the missing binary
+
+### Requirement: Get blocks if background warm is in progress
+`Get` SHALL block until any background launch started by `Warm` for the requested
+capability completes, then return the cached result. This preserves the invariant
+that `Get` always returns either a valid client or a deterministic cached error.
+
+#### Scenario: Get waits for in-progress background warm
+- **WHEN** `Warm(ctx, "vcs")` fires a background goroutine that has not yet completed
+- **WHEN** `Get(ctx, "vcs")` is called concurrently
+- **THEN** `Get` blocks until the background launch finishes
+- **THEN** `Get` returns the launched client (or cached error if launch failed)
+
+#### Scenario: Get after warm completes
+- **WHEN** `Warm(ctx, "vcs")` background goroutine has already finished
+- **WHEN** `Get(ctx, "vcs")` is called
+- **THEN** `Get` returns immediately with the cached client
+
+### Requirement: Commands declare capabilities for pre-warming
+Commands that need specific plugins SHALL call `Warm` in `PreRunE` to initiate background
+startup early. `PreRunE` SHALL return immediately after calling `Warm` without blocking on
+plugin readiness. Startup errors surface in `RunE` when the plugin is first used via `Get`.
+
+#### Scenario: workspace open initiates warm without blocking
+- **WHEN** `workspace open` PreRunE runs
+- **THEN** `Warm` is called with all required capabilities (session, vcs, picker)
+- **THEN** PreRunE returns immediately without waiting for any plugin to be ready
+
+#### Scenario: Commands with no static capabilities do not warm
+- **WHEN** a command has no known plugin dependencies
+- **THEN** its `PreRunE` does not call `Warm`

--- a/openspec/changes/archive/2026-05-19-do-not-halt-the-world/tasks.md
+++ b/openspec/changes/archive/2026-05-19-do-not-halt-the-world/tasks.md
@@ -1,0 +1,26 @@
+## 1. Refactor Manager.Warm (cmd/swm)
+
+- [x] 1.1 Write failing tests in `cmd/swm/internal/pluginmgr/manager_test.go`: replace `TestWarm_ReturnsFirstError` with `TestWarm_ReturnsNilImmediately` asserting Warm always returns nil; update `TestWarm_StartsBothConcurrently` to assert Warm returns before plugins finish
+- [x] 1.2 Write failing test `TestWarm_ErrorSurfacedByGet`: Warm a missing-binary capability, assert Warm returns nil, then assert Get returns non-nil error
+- [x] 1.3 Rewrite `Manager.Warm` in `cmd/swm/internal/pluginmgr/manager.go`: remove WaitGroup/firstErr/setFirst/cancel; use `context.WithoutCancel(ctx)` for background goroutines; return nil immediately
+- [x] 1.4 Confirm all manager tests pass (`task test`)
+
+## 2. Simplify workspace open PreRunE (cmd/swm)
+
+- [x] 2.1 Update `TestOpenCmd_PreRunE_WarmsPlugins` in `cmd/swm/internal/cli/workspace/open_test.go` to assert single Warm call with all three capabilities and nil error return from PreRunE
+- [x] 2.2 Rewrite `workspace open PreRunE` in `cmd/swm/internal/cli/workspace/open.go`: remove WaitGroup, replace two Warm calls with one `mgr.Warm(ctx, "picker", "session", "vcs")`, return nil
+- [x] 2.3 Confirm workspace open tests pass
+
+## 3. Simplify clone and story remove PreRunE (cmd/swm)
+
+- [x] 3.1 Update `TestCloneCmd_PreRunE_WarmsVCS` in `cmd/swm/internal/cli/clone_test.go` to expect PreRunE returns nil regardless of Warm outcome
+- [x] 3.2 Update `cmd/swm/internal/cli/clone.go` PreRunE: call `mgr.Warm(ctx, "vcs")` and return nil
+- [x] 3.3 Update `TestRemoveCmd_PreRunE_WarmsPlugins` in `cmd/swm/internal/cli/story/remove_test.go` to expect PreRunE returns nil
+- [x] 3.4 Update `cmd/swm/internal/cli/story/remove.go` PreRunE: call `mgr.Warm(ctx, "vcs", "session")` and return nil
+- [x] 3.5 Confirm clone and story remove tests pass
+
+## 4. Final verification
+
+- [x] 4.1 Run `task fmt` and apply any formatting changes
+- [x] 4.2 Run `task lint` and fix any lint errors
+- [x] 4.3 Run `task test` and confirm all tests pass

--- a/openspec/specs/plugin-lifecycle/spec.md
+++ b/openspec/specs/plugin-lifecycle/spec.md
@@ -57,51 +57,56 @@ The plugin manager SHALL launch plugins using go-plugin's gRPC client. The magic
 
 ### Requirement: Parallel eager plugin warm-up
 The plugin manager SHALL expose a `Warm(ctx context.Context, capabilities ...string) error`
-method that starts all listed plugins concurrently. `Warm` SHALL return the
-first error encountered; on error the context passed to remaining in-flight
-launches is cancelled. Plugins that have already been launched (by a prior
-`Warm` or `Get` call) SHALL be reused without re-launching.
+method that starts all listed plugins in background goroutines and returns immediately with nil.
+Plugin startup errors are NOT returned by `Warm`; they are surfaced by the first `Get` call
+for that capability. Plugins already launched are reused without re-launching.
+The context passed to `Warm` SHALL be stripped of cancellation so background goroutines
+outlive the caller's context.
 
 #### Scenario: Two capabilities warm concurrently
-- **WHEN** `Warm(ctx, "picker", "session")` is called and neither plugin is running
-- **THEN** both plugin processes are started concurrently (not one after the other)
+- **WHEN** `Warm(ctx, "vcs", "session")` is called
+- **THEN** both plugins begin starting in background goroutines
+- **THEN** `Warm` returns nil immediately without waiting for either to complete
 
 #### Scenario: Warm with already-launched capability
 - **WHEN** `Get(ctx, "vcs")` has already been called and `Warm(ctx, "vcs")` is called
 - **THEN** no new process is spawned; `Warm` returns nil
 
-#### Scenario: Warm propagates launch errors
-- **WHEN** `Warm(ctx, "picker", "session")` is called and the picker binary is missing
-- **THEN** `Warm` returns a non-nil error describing the missing binary
+#### Scenario: Warm does not propagate launch errors
+- **WHEN** `Warm(ctx, "picker")` is called and the picker binary is missing
+- **THEN** `Warm` returns nil immediately
+- **WHEN** `Get(ctx, "picker")` is subsequently called
+- **THEN** `Get` returns the launch error describing the missing binary
+
+### Requirement: Get blocks if background warm is in progress
+`Get` SHALL block until any background launch started by `Warm` for the requested
+capability completes, then return the cached result. This preserves the invariant
+that `Get` always returns either a valid client or a deterministic cached error.
+
+#### Scenario: Get waits for in-progress background warm
+- **WHEN** `Warm(ctx, "vcs")` fires a background goroutine that has not yet completed
+- **WHEN** `Get(ctx, "vcs")` is called concurrently
+- **THEN** `Get` blocks until the background launch finishes
+- **THEN** `Get` returns the launched client (or cached error if launch failed)
+
+#### Scenario: Get after warm completes
+- **WHEN** `Warm(ctx, "vcs")` background goroutine has already finished
+- **WHEN** `Get(ctx, "vcs")` is called
+- **THEN** `Get` returns immediately with the cached client
 
 ### Requirement: Commands declare capabilities for pre-warming
-Commands that use a fixed set of capabilities SHALL declare those capabilities
-by calling `Warm` in their `PreRunE` hook. `PreRunE` runs after root-level
-log-level setup but before the command body, ensuring plugins are ready before
-any user interaction begins.
+Commands that need specific plugins SHALL call `Warm` in `PreRunE` to initiate background
+startup early. `PreRunE` SHALL return immediately after calling `Warm` without blocking on
+plugin readiness. Startup errors surface in `RunE` when the plugin is first used via `Get`.
 
-Capability declarations by command:
-
-| Command        | Pre-warmed capabilities     |
-|----------------|-----------------------------|
-| workspace open | session, vcs                |
-| clone          | vcs                         |
-| story remove   | vcs, session                |
-
-Note: `picker` is optional for `workspace open` (errors are ignored in the command
-body), so it is NOT pre-warmed — a missing picker binary would otherwise cause
-`PreRunE` to fail before the command can fall back gracefully to non-interactive mode.
-
-Commands with no statically-known capabilities (workspace list, pr list, pr
-create) SHALL NOT call `Warm`.
-
-#### Scenario: workspace open warms before picker is invoked
-- **WHEN** `swm workspace open <story>` is run
-- **THEN** picker and session plugins are already running before the fuzzy picker UI is displayed
+#### Scenario: workspace open initiates warm without blocking
+- **WHEN** `workspace open` PreRunE runs
+- **THEN** `Warm` is called with all required capabilities (session, vcs, picker)
+- **THEN** PreRunE returns immediately without waiting for any plugin to be ready
 
 #### Scenario: Commands with no static capabilities do not warm
-- **WHEN** `swm workspace list` is run
-- **THEN** no plugin processes are spawned
+- **WHEN** a command has no known plugin dependencies
+- **THEN** its `PreRunE` does not call `Warm`
 
 ### Requirement: Lazy launch
 The plugin manager SHALL NOT launch any plugin binary at `Manager` creation


### PR DESCRIPTION
Warm() previously blocked PreRunE until all requested plugins had
started (via wg.Wait), paying the full plugin startup latency before
RunE could begin. The user-visible delay was unchanged vs lazy launch.

Now Warm fires a background goroutine per capability using
context.WithoutCancel so goroutines outlive the caller's context,
then returns nil immediately. Get() remains the natural wait point:
sync.Once blocks concurrent callers until the background launch
finishes, then all callers return the cached result.

PreRunE call sites (workspace open, clone, story remove) simplify to
a single non-blocking Warm call with no WaitGroup or error check.
Startup errors surface in RunE at the first Get call.