### PR TITLE
fix: close plugins before exec to prevent orphans

### DIFF
--- a/cmd/swm/internal/cli/clone_test.go
+++ b/cmd/swm/internal/cli/clone_test.go
@@ -113,6 +113,10 @@ type stubMgr struct {
 	sess pluginv1.SessionClient
 }
 
+func (s *stubMgr) Close() error {
+	return nil
+}
+
 func (s *stubMgr) Get(_ context.Context, capability string) (any, error) {
 	switch capability {
 	case "vcs":

--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -26,6 +26,7 @@ type PluginManager interface {
 	Get(ctx context.Context, capability string) (any, error)
 	GetForge(ctx context.Context, hostname string) (pluginv1.ForgeClient, error)
 	Warm(ctx context.Context, capabilities ...string) error
+	Close() error
 }
 
 // NewRootCmd builds the top-level swm cobra.Command.

--- a/cmd/swm/internal/cli/workspace/open.go
+++ b/cmd/swm/internal/cli/workspace/open.go
@@ -33,6 +33,7 @@ import (
 type pluginManager interface {
 	Get(ctx context.Context, capability string) (any, error)
 	Warm(ctx context.Context, capabilities ...string) error
+	Close() error
 }
 
 // ProjectLister supplies the on-disk project list to the workspace open command.
@@ -260,11 +261,21 @@ func NewOpenCmd(
 				return fmt.Errorf("pre-workspace-open hook: %w", err)
 			}
 
+			// Wrap exec so plugins are terminated before the process image is replaced.
+			// Close errors are logged but do not prevent exec.
+			closingExec := ExecFunc(func(argv0 string, argv, envv []string) error {
+				if err := mgr.Close(); err != nil {
+					slog.WarnContext(ctx, "error closing plugins before exec", "err", err)
+				}
+
+				return ocfg.exec(argv0, argv, envv)
+			})
+
 			var openErr error
 			if pickerClient != nil {
 				openErr = openWithPicker(
 					ctx, cmd, cfg, st, store, mgr, sess,
-					pickerClient, ocfg.lister, resolver, hooks, storyName, killPane, ocfg.exec,
+					pickerClient, ocfg.lister, resolver, hooks, storyName, killPane, closingExec,
 				)
 				if openErr != nil {
 					slog.DebugContext(
@@ -276,13 +287,13 @@ func NewOpenCmd(
 					if grpcCode(openErr) == codes.FailedPrecondition {
 						slog.DebugContext(ctx, "falling back to openAllAttached (no TTY)")
 						openErr = openAllAttached(
-							ctx, cmd, cfg, st, sess, resolver, hooks, storyName, killPane, ocfg.exec,
+							ctx, cmd, cfg, st, sess, resolver, hooks, storyName, killPane, closingExec,
 						)
 					}
 				}
 			} else {
 				openErr = openAllAttached(
-					ctx, cmd, cfg, st, sess, resolver, hooks, storyName, killPane, ocfg.exec,
+					ctx, cmd, cfg, st, sess, resolver, hooks, storyName, killPane, closingExec,
 				)
 			}
 

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -38,13 +38,16 @@ const (
 	eventPreWorktreeCreate  = "pre-worktree-create"
 	eventPostWorktreeCreate = "post-worktree-create"
 
-	flagKillPane = "--kill-pane"
+	flagKillPane          = "--kill-pane"
+	testTmuxBin           = "/usr/bin/tmux"
+	testTmuxAttachSession = "attach-session"
 )
 
 var (
 	errNoPlugin  = errors.New("no plugin")
 	errFakeHook  = errors.New("hook error")
 	errFakeStore = errors.New("store unavailable")
+	errFakeClose = errors.New("close failed")
 )
 
 func TestOpenCmd_WithPositionalArg(t *testing.T) {
@@ -617,7 +620,7 @@ func TestOpenCmd_WithPicker_ExecArgvIsExeced(t *testing.T) {
 
 	const selectedKey = "github.com/kalbasit/swm"
 
-	wantArgv := []string{"/usr/bin/tmux", "-S", "/tmp/feat-x.sock", "attach-session", "-t", "swm"}
+	wantArgv := []string{testTmuxBin, "-S", "/tmp/feat-x.sock", testTmuxAttachSession, "-t", testSegment}
 
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
 	store := &stubStore{getStory: &coreStory.Story{
@@ -674,7 +677,7 @@ func TestOpenCmd_NoPicker_FallsBackToPhase1(t *testing.T) {
 func TestOpenCmd_NoPicker_ExecArgvIsExeced(t *testing.T) {
 	t.Parallel()
 
-	wantArgv := []string{"/usr/bin/tmux", "attach-session", "-t", testStoryName}
+	wantArgv := []string{testTmuxBin, testTmuxAttachSession, "-t", testStoryName}
 
 	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
 	store := &stubStore{getStory: &coreStory.Story{
@@ -1118,6 +1121,132 @@ func TestOpenCmd_Completion_ArgAlreadyProvided_NoMoreCompletions(t *testing.T) {
 	require.Empty(t, completions)
 }
 
+func TestOpenCmd_WithPicker_ExecArgvIsExeced_ClosesPluginsFirst(t *testing.T) {
+	t.Parallel()
+
+	const selectedKey = "github.com/kalbasit/swm"
+
+	wantArgv := []string{testTmuxBin, "-S", testTargetWorkspaceID, testTmuxAttachSession, "-t", testSegment}
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name: testStoryName,
+		Projects: []coreStory.Project{
+			{Host: testHost, Segments: []string{testOwner, testSegment}},
+		},
+	}}
+
+	var callOrder []string
+
+	sess := &stubSess{switchToExecArgv: wantArgv}
+	picker := &stubPickerClient{selectedKey: selectedKey}
+
+	mgr := &closeRecordingMgr{
+		stubMgr: &stubMgr{sess: sess, picker: picker},
+		onClose: func() { callOrder = append(callOrder, "close") },
+	}
+
+	testExec := workspace.ExecFunc(func(_ string, _ []string, _ []string) error {
+		callOrder = append(callOrder, "exec")
+
+		return nil
+	})
+
+	cmd := workspace.NewOpenCmd(
+		cfg, store, mgr,
+		layout.NewResolver(testCodeRoot, testDefaultStory),
+		hookexec.Noop,
+		workspace.WithExecFunc(testExec),
+	)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, []string{"close", "exec"}, callOrder, "mgr.Close() must be called before execFn")
+}
+
+func TestOpenCmd_NoPicker_ExecArgvIsExeced_ClosesPluginsFirst(t *testing.T) {
+	t.Parallel()
+
+	wantArgv := []string{testTmuxBin, testTmuxAttachSession, "-t", testStoryName}
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name: testStoryName,
+		Projects: []coreStory.Project{
+			{Host: testHost, Segments: []string{testOwner, testSegment}},
+		},
+	}}
+
+	var callOrder []string
+
+	sess := &stubSess{switchToExecArgv: wantArgv}
+
+	mgr := &closeRecordingMgr{
+		stubMgr: &stubMgr{sess: sess}, // no picker
+		onClose: func() { callOrder = append(callOrder, "close") },
+	}
+
+	testExec := workspace.ExecFunc(func(_ string, _ []string, _ []string) error {
+		callOrder = append(callOrder, "exec")
+
+		return nil
+	})
+
+	cmd := workspace.NewOpenCmd(
+		cfg, store, mgr,
+		layout.NewResolver(testCodeRoot, testDefaultStory),
+		hookexec.Noop,
+		workspace.WithExecFunc(testExec),
+	)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, []string{"close", "exec"}, callOrder, "mgr.Close() must be called before execFn in no-picker path")
+}
+
+func TestOpenCmd_ExecPath_CloseError_DoesNotPreventExec(t *testing.T) {
+	t.Parallel()
+
+	const selectedKey = "github.com/kalbasit/swm"
+
+	wantArgv := []string{testTmuxBin, "-S", testTargetWorkspaceID, testTmuxAttachSession, "-t", testSegment}
+
+	cfg := &config.Config{CodeRoot: testCodeRoot, DefaultStory: testDefaultStory}
+	store := &stubStore{getStory: &coreStory.Story{
+		Name: testStoryName,
+		Projects: []coreStory.Project{
+			{Host: testHost, Segments: []string{testOwner, testSegment}},
+		},
+	}}
+
+	var execCalled bool
+
+	sess := &stubSess{switchToExecArgv: wantArgv}
+	picker := &stubPickerClient{selectedKey: selectedKey}
+
+	mgr := &closeRecordingMgr{
+		stubMgr:  &stubMgr{sess: sess, picker: picker},
+		closeErr: errFakeClose,
+	}
+
+	testExec := workspace.ExecFunc(func(_ string, _ []string, _ []string) error {
+		execCalled = true
+
+		return nil
+	})
+
+	cmd := workspace.NewOpenCmd(
+		cfg, store, mgr,
+		layout.NewResolver(testCodeRoot, testDefaultStory),
+		hookexec.Noop,
+		workspace.WithExecFunc(testExec),
+	)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.True(t, execCalled, "exec must still be called even when mgr.Close() returns an error")
+}
+
 func TestOpenCmd_PreRunE_WarmsPlugins(t *testing.T) {
 	t.Parallel()
 
@@ -1133,6 +1262,21 @@ func TestOpenCmd_PreRunE_WarmsPlugins(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	require.ElementsMatch(t, []string{"picker", "session", "vcs"}, rec.warmedCaps,
 		"workspace open PreRunE must warm session, vcs, and picker in a single non-blocking call")
+}
+
+// closeRecordingMgr wraps stubMgr, adds Close(), and invokes onClose when closed.
+type closeRecordingMgr struct {
+	*stubMgr
+	onClose  func()
+	closeErr error
+}
+
+func (m *closeRecordingMgr) Close() error {
+	if m.onClose != nil {
+		m.onClose()
+	}
+
+	return m.closeErr
 }
 
 // warmRecordingMgr wraps stubMgr and records capabilities passed to Warm.
@@ -1246,6 +1390,10 @@ type stubMgr struct {
 	picker pluginv1.PickerClient
 }
 
+func (s *stubMgr) Close() error {
+	return nil
+}
+
 func (s *stubMgr) Get(_ context.Context, capability string) (any, error) {
 	switch capability {
 	case "session":
@@ -1340,7 +1488,7 @@ func (s *stubSess) OpenPaneGroup(
 	s.lastPaneGroupReq = req
 
 	return &pluginv1.PaneGroup{
-		PaneGroupId: "swm",
+		PaneGroupId: testSegment,
 		WorkspaceId: req.GetWorkspaceId(),
 	}, nil
 }

--- a/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/design.md
+++ b/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`swm workspace open` discovers, warms, and uses plugins (picker, session, vcs)
+to drive the workspace selection flow. At the end of a successful run it calls
+`syscall.Exec` to replace the swm process with `tmux attach-session`. Because
+`exec` replaces the process image, all deferred calls — including the
+`defer mgr.Close()` in `main.go` — are skipped. Plugin subprocesses inherit
+the exec'd process's PID ancestry and become children of the tmux client;
+when the user detaches, the client exits and they are reparented to init as
+orphans.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure no plugin subprocess outlives a `swm workspace open` invocation.
+- Minimal change: touch only the `pluginManager` interface and the exec call site.
+
+**Non-Goals:**
+- Reusing existing plugin processes across invocations.
+- Tying plugin lifetime to the tmux session or tmux server.
+- Changes to plugin discovery, launch, or warm logic.
+
+## Decisions
+
+### Add `Close() error` to the `pluginManager` interface
+
+The `pluginManager` interface in `cmd/swm/internal/cli/workspace/open.go`
+currently exposes only `Get` and `Warm`. `*pluginmgr.Manager` already
+implements `Close() error`; it just isn't part of the interface the open
+command uses.
+
+**Why not pass a separate `closePlugins func()`?** An extra function parameter
+adds surface area for tests and callers. Extending the existing interface keeps
+the dependency injection pattern uniform and requires zero new wiring in
+`main.go`.
+
+**Alternatives considered:**
+- Call `mgr.Close()` inside `execFn` wrapper — leaks lifecycle concerns into
+  a function whose only job is process replacement; makes testing harder.
+- Remove the `defer mgr.Close()` in `main.go` and rely solely on the explicit
+  call — the defer is a useful safety net for error paths that return before
+  exec; keeping it is cheap and correct (double-close is a no-op in go-plugin).
+
+### Call `mgr.Close()` immediately before `execFn()`
+
+The call goes just before the `execFn` invocation at the end of the open flow,
+after the post-workspace-open hook has run. A `Close()` error is logged but
+does not block the exec — the user's workflow should not be interrupted because
+a plugin cleanup returned an error.
+
+**Why not return the error?** After `SwitchTo` has already switched the tmux
+client, there is no useful recovery action. The workspace is open; the exec
+is the only remaining step. Surfacing the error would leave the user with a
+confusing failure message after their pane group is already visible.
+
+## Risks / Trade-offs
+
+- **Double-close on error paths**: If `workspace open` returns an error before
+  exec, the deferred `mgr.Close()` in `main.go` closes the manager. If a future
+  code path calls `mgr.Close()` explicitly and then hits the defer, the second
+  close is a no-op per go-plugin's `Kill()` contract. No risk.
+- **Log noise on Close error**: Logging a Close error just before exec could
+  appear after the user's terminal is handed to tmux. Acceptable: it's
+  unexpected and worth surfacing.
+
+## Open Questions
+
+None. The change is small and the decision space is exhausted.

--- a/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/proposal.md
+++ b/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+When `swm workspace open` completes, it calls `syscall.Exec` to replace the
+swm process with `tmux attach-session`. Because `exec` replaces the process
+image, all deferred calls — including `mgr.Close()` — are skipped, leaving
+plugin subprocesses alive as orphaned children of the tmux client. Each
+subsequent `swm workspace open` invocation spawns a fresh set of plugins,
+accumulating orphans across days of use.
+
+## What Changes
+
+- Add `Close() error` to the `pluginManager` interface consumed by
+  `cmd/swm/internal/cli/workspace/open.go`.
+- Call `mgr.Close()` explicitly in the exec path (just before `execFn()`) so
+  all plugin subprocesses are terminated before the process image is replaced.
+- The existing `defer mgr.Close()` in `main.go` remains as a safety net for
+  error paths that return before reaching exec.
+
+Non-goals:
+- Re-using already-running plugins across `swm workspace open` invocations.
+- Plugin lifetime tied to the tmux session or tmux server lifecycle.
+- Any changes to how plugins are discovered, launched, or warmed.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `plugin-lifecycle`: Add a requirement that the host explicitly closes all
+  plugins before calling `exec` to replace the process, so no plugin
+  subprocess outlives the `swm workspace open` invocation.
+
+## Impact
+
+- `cmd/swm/internal/cli/workspace/open.go` — `pluginManager` interface gains
+  `Close() error`; exec path calls `mgr.Close()`.
+- `cmd/swm/internal/cli/workspace/open_test.go` — test double updated to
+  implement `Close()`.
+- No proto changes. No API surface changes. No other packages affected.
+
+Capability surface affected: **none** (host-internal change only).

--- a/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/specs/plugin-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/specs/plugin-lifecycle/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Plugin manager interface exposes Close
+The `pluginManager` interface consumed by any command that may call `exec`
+SHALL include a `Close() error` method. This ensures the command can
+explicitly terminate plugin subprocesses before replacing the process image.
+
+#### Scenario: Close method present on pluginManager interface
+- **WHEN** `workspace open` is compiled
+- **THEN** the `pluginManager` interface in the `workspace` package includes `Close() error`
+
+#### Scenario: Concrete manager satisfies extended interface
+- **WHEN** `*pluginmgr.Manager` is assigned to a `pluginManager` variable
+- **THEN** the assignment compiles without error (i.e. `Manager` already implements `Close()`)
+
+### Requirement: Plugins are terminated before exec replaces the process
+When `workspace open` is about to call `exec` to replace the swm process
+with a terminal multiplexer client, it SHALL call `mgr.Close()` first.
+No plugin subprocess SHALL outlive the `swm workspace open` invocation.
+
+#### Scenario: No plugin processes remain after successful workspace open
+- **WHEN** `swm workspace open` completes successfully and exec replaces the process
+- **THEN** all plugin subprocesses spawned during that invocation have been terminated
+
+#### Scenario: Close is called before exec
+- **WHEN** `SwitchTo` returns an exec argv and `execFn` is about to be called
+- **THEN** `mgr.Close()` is called before `execFn` is invoked
+
+#### Scenario: Close error does not prevent exec
+- **WHEN** `mgr.Close()` returns a non-nil error
+- **THEN** the error is logged but does not prevent `execFn` from being called
+- **THEN** the workspace open flow continues to exec
+
+#### Scenario: Defer still covers non-exec error paths
+- **WHEN** `workspace open` returns an error before reaching the exec path
+- **THEN** the deferred `mgr.Close()` in `main.go` still terminates plugin subprocesses

--- a/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/tasks.md
+++ b/openspec/changes/archive/2026-05-21-plugins-surviving-for-a-long-time/tasks.md
@@ -1,0 +1,18 @@
+## 1. Spec — delta spec for plugin-lifecycle (cmd/swm)
+
+- [x] 1.1 Write failing test in `open_test.go` asserting `pluginManager` interface includes `Close() error`
+- [x] 1.2 Write failing test asserting `mgr.Close()` is called before `execFn` in the happy path
+
+## 2. Interface (cmd/swm)
+
+- [x] 2.1 Add `Close() error` to the `pluginManager` interface in `cmd/swm/internal/cli/workspace/open.go`
+- [x] 2.2 Update the fake/stub `pluginManager` in `open_test.go` to implement `Close() error`
+
+## 3. Exec-path cleanup (cmd/swm)
+
+- [x] 3.1 In `open.go`, call `mgr.Close()` immediately before `execFn(argv[0], argv, os.Environ())` in the exec branch; log but do not return on error
+- [x] 3.2 Confirm existing `defer mgr.Close()` in `main.go` remains untouched (safety net for error paths)
+
+## 4. Verification
+
+- [x] 4.1 Run `task fmt && task lint && task test` — all must pass with exit 0

--- a/openspec/specs/plugin-lifecycle/spec.md
+++ b/openspec/specs/plugin-lifecycle/spec.md
@@ -196,3 +196,38 @@ Plugin-internal variables:
 #### Scenario: Plugin-internal vars are not required in hook processes
 - **WHEN** the hook executor launches a hook binary
 - **THEN** `SWM_HOST_SOCKET`, `SWM_LOG_LEVEL`, and `SWM_PLUGIN_MAGIC_COOKIE` are absent from that process's environment
+
+### Requirement: Plugin manager interface exposes Close
+The `pluginManager` interface consumed by any command that may call `exec`
+SHALL include a `Close() error` method. This ensures the command can
+explicitly terminate plugin subprocesses before replacing the process image.
+
+#### Scenario: Close method present on pluginManager interface
+- **WHEN** `workspace open` is compiled
+- **THEN** the `pluginManager` interface in the `workspace` package includes `Close() error`
+
+#### Scenario: Concrete manager satisfies extended interface
+- **WHEN** `*pluginmgr.Manager` is assigned to a `pluginManager` variable
+- **THEN** the assignment compiles without error (i.e. `Manager` already implements `Close()`)
+
+### Requirement: Plugins are terminated before exec replaces the process
+When `workspace open` is about to call `exec` to replace the swm process
+with a terminal multiplexer client, it SHALL call `mgr.Close()` first.
+No plugin subprocess SHALL outlive the `swm workspace open` invocation.
+
+#### Scenario: No plugin processes remain after successful workspace open
+- **WHEN** `swm workspace open` completes successfully and exec replaces the process
+- **THEN** all plugin subprocesses spawned during that invocation have been terminated
+
+#### Scenario: Close is called before exec
+- **WHEN** `SwitchTo` returns an exec argv and `execFn` is about to be called
+- **THEN** `mgr.Close()` is called before `execFn` is invoked
+
+#### Scenario: Close error does not prevent exec
+- **WHEN** `mgr.Close()` returns a non-nil error
+- **THEN** the error is logged but does not prevent `execFn` from being called
+- **THEN** the workspace open flow continues to exec
+
+#### Scenario: Defer still covers non-exec error paths
+- **WHEN** `workspace open` returns an error before reaching the exec path
+- **THEN** the deferred `mgr.Close()` in `main.go` still terminates plugin subprocesses


### PR DESCRIPTION
Plugins were left running as orphaned processes after
`swm workspace open` replaced itself with tmux via
syscall.Exec. The deferred mgr.Close() never fired
because exec replaces the process image.

Fix: wrap the execFn with a closingExec that calls
mgr.Close() immediately before exec. This applies to
both the picker and no-picker code paths through a
single wrapper in RunE. A Close error is logged as a
warning but does not block exec.

Adds Close() to the pluginManager interface (both the
unexported workspace-local one and the public cli one)
and three new tests asserting close-before-exec order.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>