### PR TITLE
chore: migrate languages input to explicit targets shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   ci:
-    uses: kalbasit/gh-actions/.github/workflows/ci.yml@feat-generate-configurable-targets
+    uses: kalbasit/gh-actions/.github/workflows/ci.yml@user/wnasreddine/ci-jobs
     with:
       cachix_cache: swm
       oci: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,17 @@ permissions:
 
 jobs:
   ci:
-    uses: kalbasit/gh-actions/.github/workflows/ci.yml@main
+    uses: kalbasit/gh-actions/.github/workflows/ci.yml@feat-generate-configurable-targets
     with:
       cachix_cache: swm
       oci: false
       languages: |
-        {"go":{"packages":[
-          "swm",
-          "swm-plugin-forge-github",
-          "swm-plugin-picker-fzf",
-          "swm-plugin-session-tmux",
-          "swm-plugin-vcs-git"
+        {"go":{"targets":[
+          {"attr":"swm",                     "file":"nix/packages/swm/default.nix"},
+          {"attr":"swm-plugin-forge-github", "file":"nix/packages/swm-plugin-forge-github/default.nix"},
+          {"attr":"swm-plugin-picker-fzf",   "file":"nix/packages/swm-plugin-picker-fzf/default.nix"},
+          {"attr":"swm-plugin-session-tmux", "file":"nix/packages/swm-plugin-session-tmux/default.nix"},
+          {"attr":"swm-plugin-vcs-git",      "file":"nix/packages/swm-plugin-vcs-git/default.nix"}
         ]}}
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
gh-actions/generate.yml renamed `packages` to `targets` and
removed the implicit nix/packages/<pkg>/default.nix convention;
every target now names its Nix attribute path and the file holding
its vendorHash explicitly. Update the caller to the new shape: 5
targets, one per swm/swm-plugin-*. Temporarily pin to
@feat-generate-configurable-targets; will repin to @main once that
PR merges.

No behavior change — every target points at the same file the
convention used to imply.