### PR TITLE
feat(session-tmux): replace Laio with internal layout engine

### DIFF
--- a/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/design.md
+++ b/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/design.md
@@ -2,7 +2,7 @@
 
 `session-tmux` currently delegates window/pane layout to Laio via `pane_group_command`:
 
-```
+```toml
 pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"
 ```
 
@@ -50,7 +50,7 @@ The `OpenPaneGroup` RPC already receives everything needed — `workspace_id` (t
 
 **Chosen**: Mirror the hook resolution model. `OpenPaneGroup` probes in this order and uses the first match:
 
-```
+```text
 1. pane_group_command in config.toml           (backward compat — wins if set)
 2. <worktree_path>/.swm/session-tmux.toml      (per-repo — overrides global)
 3. $XDG_CONFIG_HOME/swm/session-tmux.toml      (global default)
@@ -70,7 +70,7 @@ The global config uses the same TOML schema as the per-repo config. Template var
 
 Panes form a recursive tree (`Pane.Panes []Pane`). At each node:
 
-```
+```text
 totalFlex = Σ flex(child)
 For i = 0; i < len(children)-1; i++:
     remainingFlex = Σ flex(children[i+1:])

--- a/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/design.md
+++ b/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/design.md
@@ -1,0 +1,127 @@
+## Context
+
+`session-tmux` currently delegates window/pane layout to Laio via `pane_group_command`:
+
+```
+pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"
+```
+
+Laio is an external Rust binary that reads a YAML layout config, connects to the given tmux socket, replaces the bare session with a fully-laid-out one (named windows, nested pane splits, startup commands), and exits. It is the only piece SWM cannot influence and the only reason users must install a second tool.
+
+The `OpenPaneGroup` RPC already receives everything needed — `workspace_id` (the socket path), `worktree_path`, `project_id`, `story_name` — to apply a layout without external help.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `OpenPaneGroup` resolves a layout config from a two-tier lookup (global then per-repo, per-repo wins) and applies the window/pane layout using direct tmux commands.
+- Global layout at `$XDG_CONFIG_HOME/swm/session-tmux.toml` acts as a user-wide default for every project that has no per-repo config — the same tier model as hooks.
+- Per-repo layout at `.swm/session-tmux.toml` inside the worktree overrides the global config for that repository.
+- Layout supports: named windows with per-window `path`, nested pane splits with `flex`/`flex_direction`, per-pane `commands`, `env`, `shell`, `focus`, `zoom`, and per-session `startup` commands.
+- Template variable substitution (`worktree_path`, `story_name`, `tmux_socket`) via `text/template`.
+- No config file at either tier → existing default behavior (editor + shell). `pane_group_command` still takes priority for users who haven't migrated.
+- Zero new Go module dependencies.
+
+**Non-Goals:**
+- Zellij support (out of scope for v2.0).
+- Serializing an existing tmux session back to TOML.
+- Array template variables (Laio's `--var k=v` repeated); flat string map only in this pass.
+- Changing the gRPC protocol or proto definitions.
+- Migrating users automatically — the opt-in is adding `.swm/session-tmux.toml`.
+
+## Decisions
+
+### 1. Layout logic lives inside `session-tmux` (no new plugin, no proto changes)
+
+**Chosen**: New sub-package `plugins/session-tmux/internal/layout/` called from `OpenPaneGroup`. No gRPC surface changes.
+
+**Alternatives considered**:
+- *New `session-layout` capability plugin* — adds a new RPC surface, deployment complexity, and inter-plugin coordination. Rejected: over-engineering for what is tmux-specific logic.
+- *Host-side layout via new proto RPC* — would require proto version bump and host changes. Rejected: host should not know tmux window geometry.
+
+### 2. Config format is TOML, not YAML
+
+**Chosen**: `.swm/session-tmux.toml` — consistent with SWM's entire config stack (pelletier/go-toml/v2 already in the workspace module graph).
+
+**Alternatives considered**:
+- *Retain Laio's YAML format* — allows copy-paste migration, but would require a new YAML dependency (gopkg.in/yaml.v3) and creates inconsistency in the project config story. Rejected.
+- *JSON* — machine-friendly but poor for humans writing layout configs. Rejected.
+
+### 3. Two-tier config resolution: global then per-repo (per-repo wins)
+
+**Chosen**: Mirror the hook resolution model. `OpenPaneGroup` probes in this order and uses the first match:
+
+```
+1. pane_group_command in config.toml           (backward compat — wins if set)
+2. <worktree_path>/.swm/session-tmux.toml      (per-repo — overrides global)
+3. $XDG_CONFIG_HOME/swm/session-tmux.toml      (global default)
+4. built-in default (editor + shell)
+```
+
+Unlike hooks (which are composing — all tiers run), layout is an override chain — only the first matching tier applies. Two configs cannot meaningfully be merged into a single window layout.
+
+The global config uses the same TOML schema as the per-repo config. Template variables (`worktree_path`, `story_name`, `tmux_socket`) are injected into both tiers identically, so a single global layout can adapt to each project's paths.
+
+**Alternatives considered**:
+- *Compose tiers (merge windows from global + per-repo)* — ambiguous semantics (duplicate window names, ordering). Rejected.
+- *Per-repo only* — forces every project to have a config file; no sensible user-wide default. Rejected.
+- *Per-story tier* (like hooks have) — layout is a project property, not a story property; the same repo should look the same regardless of which story checked it out. Rejected for this surface.
+
+### 4. Flex-split algorithm: recursive percentage split
+
+Panes form a recursive tree (`Pane.Panes []Pane`). At each node:
+
+```
+totalFlex = Σ flex(child)
+For i = 0; i < len(children)-1; i++:
+    remainingFlex = Σ flex(children[i+1:])
+    splitPercent  = remainingFlex * 100 / (remainingFlex + flex(children[i]))
+    tmux split-window -p <splitPercent> [-h if row direction]
+```
+
+This keeps children[i] at `flex[i]/total` of the parent and recurses into the remainder. Rounding errors accumulate to the last pane (same as Laio's behavior).
+
+**Alternatives considered**:
+- *Absolute size in cells* — more precise, but terminal size at creation time is unknown and may change. Rejected.
+- *Flat percentage in config* — defeats the purpose of flex; manual and error-prone. Rejected.
+
+### 5. `pane_group_command` takes precedence over layout file
+
+If `pane_group_command` is set in `config.toml`, `OpenPaneGroup` behaves exactly as today (no layout file read). This preserves backward compatibility for anyone already using a custom command.
+
+Migration path: remove `pane_group_command` from `config.toml` and add `.swm/session-tmux.toml`.
+
+### 6. Template engine: `text/template` (stdlib)
+
+Variables `worktree_path`, `story_name`, `tmux_socket` are injected. Syntax matches the existing `pane_group_command` template format already in `tmux.go` — consistent, zero new dependencies.
+
+**Alternative**: Sprig (rich function library) — over-kill for three string substitutions. Rejected.
+
+### 7. Layout is applied only on session creation (idempotent)
+
+`OpenPaneGroup` is already idempotent: if the tmux session exists it returns immediately. Layout is therefore applied exactly once per session lifetime. No state file is written.
+
+## Risks / Trade-offs
+
+- **[Risk] Flex rounding produces non-pixel-perfect splits** → Acceptable: Laio has the same constraint. Last pane absorbs rounding error. Document clearly.
+- **[Risk] Layout config references a relative `path` that doesn't exist in the worktree** → Mitigation: validate paths during config load; return a descriptive error before touching tmux.
+- **[Risk] User has both `pane_group_command` and a layout config file (either tier)** → The command silently wins. Mitigation: log a warning naming the ignored file.
+- **[Risk] Global config uses a path like `./src` that only makes sense for some repos** → Template variables (`worktree_path`) let users write absolute paths or expressions; document that relative paths in global config resolve from `worktree_path`.
+- **[Risk] Startup commands in config produce stderr that corrupts the pane** → Identical risk in Laio; user responsibility. No mitigation needed.
+- **[Risk] `split-window -p` argument rounds to 0 or 100 for extreme flex ratios** → Mitigation: clamp to [1, 99] and document.
+
+## Migration Plan
+
+1. Ship the layout engine in `session-tmux` with zero default impact.
+2. Users who want to migrate: copy `.swm/laio.yaml` content into `.swm/session-tmux.toml` (format is structurally identical, keys map 1:1; only difference is YAML→TOML syntax).
+3. Remove `pane_group_command` from `config.toml` to activate the internal layout.
+4. Rollback: re-add `pane_group_command` — the old Laio path still works as long as the binary is installed.
+5. Once satisfied: uninstall Laio and delete the old `.swm/laio.yaml`.
+
+## Open Questions
+
+*(none)*
+
+## Resolved Decisions
+
+- **No `shutdown` commands in layout config** — SWM's hooks system (`close-workspace.d/`) already handles teardown at the right moment. Adding a second shutdown mechanism in the layout config would create two parallel teardown systems with no clear guidance on which to use. Users who need teardown logic use hooks.
+- **`zoom` and `focus` are creation-time only** — the layout config describes initial state, not a persistent constraint. `SwitchTo` does not re-apply them. Users can freely change focus and zoom after opening without swm fighting them.

--- a/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/proposal.md
+++ b/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The `session-tmux` plugin currently creates one bare tmux session per project but does no window or pane layout — users rely on Laio (a separate Rust binary) to lay out windows and panes from a YAML config. Laio's author is unwilling to make the integration changes needed for SWM, creating an unresolvable external dependency on a tool we cannot influence.
+
+## What Changes
+
+- **NEW**: Two-tier layout config (global at `$XDG_CONFIG_HOME/swm/session-tmux.toml`, per-repo at `.swm/session-tmux.toml`), both TOML and using the same schema. Per-repo wins; global is the user-wide default. Same tier model as hooks.
+- **NEW**: `plugins/session-tmux` reads that config file during `OpenPaneGroup` and applies the layout to the newly created tmux session.
+- **NEW**: Layout supports: named windows, nested pane splits with `flex`/`flex_direction` (row/column), per-window/pane working directories, startup commands, environment variables, and focus/zoom flags.
+- **NEW**: Go text/template variable substitution in the config (replaces Laio's Tera template support), with `worktree_path` and `story_name` auto-injected.
+- **REMOVE** (optional/gradual): Laio as a hard runtime requirement for users who relied on it via external hooks.
+
+No proto changes are required. The plugin resolves and applies the config internally without any new gRPC surface.
+
+## Capabilities
+
+### New Capabilities
+
+- `session-tmux-layout` — window/pane layout management built into the `session-tmux` plugin. Covers: config parsing, flex-split calculation, tmux command sequencing (new-window, split-window, resize-pane, send-keys). Lives in a new sub-package `plugins/session-tmux/internal/layout/`.
+
+### Modified Capabilities
+
+- `session-tmux` (`openspec/specs/session-tmux/spec.md`) — `OpenPaneGroup` now applies the layout config after session creation if `.swm/session-tmux.toml` exists. Behavior is additive: absence of the config file leaves existing behavior unchanged.
+
+## Impact
+
+- **Code**: `plugins/session-tmux/internal/session/tmux.go` (`OpenPaneGroup` extended); new package `plugins/session-tmux/internal/layout/` (~400–600 lines).
+- **Config**: New optional file `.swm/session-tmux.toml` per repository (not global config).
+- **Dependencies**: No new Go modules; uses `pelletier/go-toml/v2` (already a workspace dep) and `text/template` (stdlib).
+- **Nix hashes**: `vendorHash` in `nix/packages/swm-plugin-session-tmux/default.nix` will need updating only if a new dep is added (unlikely).
+- **Laio**: No code change to Laio. Users who migrate get the same feature set from SWM directly.
+- **Non-goals**: Zellij support, serializing an existing tmux session to TOML, template variable arrays (Laio supports `--var k=v` repeated; SWM's first pass will use a flat string map only), GUI pane preview.

--- a/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/specs/session-tmux-layout/spec.md
+++ b/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/specs/session-tmux-layout/spec.md
@@ -35,7 +35,7 @@ Only the first matching source is used. Configs are never merged across tiers.
 ### Requirement: Layout config TOML schema
 The layout config file SHALL be valid TOML conforming to this schema:
 
-```
+```toml
 # Top-level (session-scoped) fields — all optional
 path         = string          # base path; defaults to worktree_path
 shell        = string          # shell binary for panes without an explicit command
@@ -149,7 +149,7 @@ Rounding error accumulates to the last pane.
 
 #### Scenario: Three equal panes split into thirds
 - **WHEN** a window has three panes each with `flex = 1`
-- **THEN** `split-window -p 67` is called first (leaving ~33% for the first pane), then `split-window -p 50` on the remainder
+- **THEN** `split-window -p 66` is called first (leaving ~34% for the first pane via floor division), then `split-window -p 50` on the remainder
 
 #### Scenario: Weighted flex produces proportional splits
 - **WHEN** a window has two panes with `flex = 2` and `flex = 1`

--- a/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/specs/session-tmux-layout/spec.md
+++ b/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/specs/session-tmux-layout/spec.md
@@ -1,0 +1,193 @@
+## ADDED Requirements
+
+### Requirement: Layout config resolution
+`session-tmux` SHALL resolve a layout config for `OpenPaneGroup` using the following priority order (first match wins):
+
+1. `pane_group_command` set in `config.toml` — existing behavior; a warning SHALL be logged if a layout config file exists at either tier and is being ignored.
+2. `<worktree_path>/.swm/session-tmux.toml` — per-repo config (overrides global).
+3. `$XDG_CONFIG_HOME/swm/session-tmux.toml` — global config (user-wide default).
+4. Built-in default — `$EDITOR` (or `vim` if unset) in the first window, a shell in the second.
+
+Only the first matching source is used. Configs are never merged across tiers.
+
+#### Scenario: Per-repo config used when present
+- **WHEN** `<worktree_path>/.swm/session-tmux.toml` exists and `pane_group_command` is not set
+- **THEN** the per-repo config is loaded and applied; the global config (if any) is not read
+
+#### Scenario: Global config used when no per-repo config
+- **WHEN** `$XDG_CONFIG_HOME/swm/session-tmux.toml` exists, `pane_group_command` is not set, and no per-repo config exists
+- **THEN** the global config is loaded and applied
+
+#### Scenario: Per-repo config wins over global
+- **WHEN** both `<worktree_path>/.swm/session-tmux.toml` and `$XDG_CONFIG_HOME/swm/session-tmux.toml` exist and `pane_group_command` is not set
+- **THEN** only the per-repo config is applied; the global config is not read
+
+#### Scenario: pane_group_command wins and warning logged
+- **WHEN** `pane_group_command` is set in `config.toml` and `<worktree_path>/.swm/session-tmux.toml` also exists
+- **THEN** `pane_group_command` is used and a warning is logged naming the ignored layout config file
+
+#### Scenario: No config at either tier falls back to default
+- **WHEN** neither `pane_group_command` nor any layout config file is present
+- **THEN** the default layout is applied (`$EDITOR` in window 1, shell in window 2)
+
+---
+
+### Requirement: Layout config TOML schema
+The layout config file SHALL be valid TOML conforming to this schema:
+
+```
+# Top-level (session-scoped) fields — all optional
+path         = string          # base path; defaults to worktree_path
+shell        = string          # shell binary for panes without an explicit command
+pane_cmd_delay = int           # milliseconds to wait between send-keys calls (default: 0)
+
+[env]                          # environment variables injected into every pane
+KEY = "value"
+
+[[startup]]                    # commands run in the first pane of the first window before layout
+command = string
+args    = [string]
+
+[[windows]]                    # at least one window required
+name           = string        # required; must be non-empty
+path           = string        # optional; resolved relative to session path
+flex_direction = "row"|"column" # direction for child pane splits (default: "column")
+
+  [[windows.panes]]            # optional; defaults to one full-size pane
+  flex           = int         # relative size weight (default: 1, minimum: 1)
+  flex_direction = "row"|"column"
+  path           = string
+  zoom           = bool        # zoom this pane at creation time (default: false)
+  focus          = bool        # focus this pane at creation time (default: false)
+  shell          = string
+  commands       = [string]    # commands sent via send-keys
+
+  [windows.panes.env]
+  KEY = "value"
+
+    [[windows.panes.panes]]    # nested panes (recursive)
+    # same fields as [[windows.panes]]
+```
+
+Constraints:
+- At least one `[[windows]]` entry is required.
+- `flex` must be ≥ 1.
+- At most one pane per window tree may have `focus = true`.
+- At most one pane per window tree may have `zoom = true`.
+
+#### Scenario: Config with no windows is rejected
+- **WHEN** a layout config file contains no `[[windows]]` entries
+- **THEN** `OpenPaneGroup` returns an `InvalidArgument` error before any tmux commands are issued
+
+#### Scenario: Config with flex less than 1 is rejected
+- **WHEN** a layout config file contains a pane with `flex = 0`
+- **THEN** `OpenPaneGroup` returns an `InvalidArgument` error before any tmux commands are issued
+
+#### Scenario: Config with two focused panes in the same window is rejected
+- **WHEN** a window's pane tree contains two panes both with `focus = true`
+- **THEN** `OpenPaneGroup` returns an `InvalidArgument` error before any tmux commands are issued
+
+---
+
+### Requirement: Template variable substitution in layout config
+Before parsing, the raw TOML bytes SHALL be rendered through `text/template` with the following variables auto-injected:
+
+| Variable       | Value                                      |
+|----------------|--------------------------------------------|
+| `worktree_path`| The `worktree_path` from `OpenPaneGroupRequest` |
+| `story_name`   | The story name from `OpenPaneGroupRequest`  |
+| `tmux_socket`  | The workspace socket path (`workspace_id`)  |
+
+#### Scenario: worktree_path substituted in window path
+- **WHEN** a layout config contains `path = "{{.worktree_path}}/src"` and `worktree_path` is `/home/user/code/stories/feat/github.com/org/repo`
+- **THEN** the resolved window path is `/home/user/code/stories/feat/github.com/org/repo/src`
+
+#### Scenario: story_name substituted in a command
+- **WHEN** a layout config contains `commands = ["echo {{.story_name}}"]` and `story_name` is `feat-x`
+- **THEN** `send-keys` is called with `echo feat-x`
+
+#### Scenario: tmux_socket substituted
+- **WHEN** a layout config contains `commands = ["tmux -S {{.tmux_socket}} list-sessions"]` and `workspace_id` is `/run/user/1000/swm/tmux/feat-x.sock`
+- **THEN** `send-keys` is called with `tmux -S /run/user/1000/swm/tmux/feat-x.sock list-sessions`
+
+---
+
+### Requirement: Layout application — windows
+`session-tmux` SHALL apply the layout config to a newly created tmux session by:
+1. Renaming the default window to the first window's `name`.
+2. Setting the first window's working directory to the resolved `path`.
+3. Creating subsequent windows with `new-window -n <name> -c <path>`.
+
+Window creation order matches the order of `[[windows]]` entries in the config.
+
+#### Scenario: Single window created with correct name and path
+- **WHEN** a layout config has one window with `name = "editor"` and `path = "{{.worktree_path}}"` and `OpenPaneGroup` creates a new session
+- **THEN** the tmux session has exactly one window named `editor` with working directory set to `worktree_path`
+
+#### Scenario: Multiple windows created in order
+- **WHEN** a layout config has windows named `["editor", "shell", "test"]` and `OpenPaneGroup` creates a new session
+- **THEN** the tmux session has three windows in that order with those names
+
+---
+
+### Requirement: Layout application — pane splits
+`session-tmux` SHALL split panes using a recursive percentage algorithm:
+
+For each group of sibling panes (ordered by position in config):
+- `totalFlex = Σ flex(sibling)`
+- For each sibling except the last:
+  - `remainingFlex = Σ flex(following siblings)`
+  - `splitPercent = clamp(remainingFlex * 100 / (flex(current) + remainingFlex), 1, 99)`
+  - Run `tmux split-window -p <splitPercent>` (add `-h` for `flex_direction = "row"`)
+- The last sibling takes whatever space remains.
+
+Rounding error accumulates to the last pane.
+
+#### Scenario: Two equal panes split 50/50
+- **WHEN** a window has two panes each with `flex = 1` and `flex_direction = "column"` (default)
+- **THEN** `split-window -p 50` is called once, producing two vertically equal panes
+
+#### Scenario: Three equal panes split into thirds
+- **WHEN** a window has three panes each with `flex = 1`
+- **THEN** `split-window -p 67` is called first (leaving ~33% for the first pane), then `split-window -p 50` on the remainder
+
+#### Scenario: Weighted flex produces proportional splits
+- **WHEN** a window has two panes with `flex = 2` and `flex = 1`
+- **THEN** `split-window -p 33` is called, giving the first pane ~67% and the second ~33%
+
+#### Scenario: Row direction uses horizontal split
+- **WHEN** a window has panes with `flex_direction = "row"`
+- **THEN** `split-window -h` is used instead of the default vertical split
+
+#### Scenario: Extreme flex ratio is clamped
+- **WHEN** a pane split would compute a `splitPercent` of 0 or 100
+- **THEN** the value is clamped to 1 or 99 respectively
+
+---
+
+### Requirement: Layout application — pane commands, focus, and zoom
+After creating each pane, `session-tmux` SHALL:
+- Send each entry in `commands` via `tmux send-keys <cmd> Enter`, waiting `pane_cmd_delay` ms between each.
+- If `focus = true`: run `tmux select-pane -t <pane>` after all panes in the window are created.
+- If `zoom = true`: run `tmux resize-pane -Z -t <pane>` after focus is applied.
+- Both `focus` and `zoom` are applied at creation time only; `SwitchTo` does not re-apply them.
+
+#### Scenario: Commands sent to pane
+- **WHEN** a pane has `commands = ["git status", "git log --oneline"]`
+- **THEN** `send-keys "git status" Enter` and `send-keys "git log --oneline" Enter` are called in sequence for that pane
+
+#### Scenario: pane_cmd_delay respected between commands
+- **WHEN** `pane_cmd_delay = 200` and a pane has two commands
+- **THEN** a 200 ms delay is observed between the two `send-keys` calls
+
+#### Scenario: focus pane selected after window layout
+- **WHEN** a window's third pane has `focus = true`
+- **THEN** `select-pane` targets that pane after all splits and commands in the window are applied
+
+#### Scenario: zoom applied after focus
+- **WHEN** a pane has both `focus = true` and `zoom = true`
+- **THEN** `select-pane` is called first, then `resize-pane -Z`
+
+#### Scenario: SwitchTo does not re-apply focus or zoom
+- **WHEN** `SwitchTo` is called for a session whose layout config has `focus = true` on a pane
+- **THEN** no `select-pane` command is issued by `SwitchTo`

--- a/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/specs/session-tmux/spec.md
+++ b/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/specs/session-tmux/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: OpenPaneGroup in existing workspace
+`session-tmux` SHALL implement `Session.OpenPaneGroup({story_name, project_id, worktree_path})` by creating a new tmux session for the project within the story's socket (if it doesn't exist). The initial working directory SHALL be `worktree_path`.
+
+`OpenPaneGroup` SHALL resolve the layout using the following priority order (first match wins):
+
+1. If `pane_group_command` is set in `config.toml`: run that command (existing behavior). A warning SHALL be logged if a layout config file also exists at either tier.
+2. If `<worktree_path>/.swm/session-tmux.toml` exists: apply the per-repo layout (see `session-tmux-layout` spec).
+3. If `$XDG_CONFIG_HOME/swm/session-tmux.toml` exists: apply the global layout (see `session-tmux-layout` spec).
+4. Default: run `$EDITOR` (or `vim` if unset) in the first window and a shell in the second.
+
+When `pane_group_command` is configured, `session-tmux` SHALL validate that the first token of the command resolves to an executable via PATH lookup before creating the tmux session. If the binary is not found, `OpenPaneGroup` SHALL return a `FailedPrecondition` error naming the missing binary — no tmux session SHALL be created.
+
+#### Scenario: Default layout
+- **WHEN** no `pane_group_command` is configured and no layout config exists at either tier
+- **THEN** the tmux session is created with two windows: the first running `$EDITOR` (or `vim`), the second running a shell
+
+#### Scenario: Custom pane_group_command
+- **WHEN** `config.toml` has `pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `laio start --file '<worktree_path>/.swm/laio.yaml' --tmux-socket '<tmux_socket>' --replace-current-session --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
+
+#### Scenario: Per-repo layout config applied
+- **WHEN** `<worktree_path>/.swm/session-tmux.toml` exists and `pane_group_command` is not set
+- **THEN** the layout defined in that file is applied to the newly created tmux session
+
+#### Scenario: Global layout config applied
+- **WHEN** `$XDG_CONFIG_HOME/swm/session-tmux.toml` exists, `pane_group_command` is not set, and no per-repo config exists
+- **THEN** the layout defined in the global config is applied to the newly created tmux session
+
+#### Scenario: Per-repo layout wins over global
+- **WHEN** both `<worktree_path>/.swm/session-tmux.toml` and `$XDG_CONFIG_HOME/swm/session-tmux.toml` exist and `pane_group_command` is not set
+- **THEN** only the per-repo config is applied
+
+#### Scenario: pane_group_command wins when layout config also present
+- **WHEN** `pane_group_command` is set and `<worktree_path>/.swm/session-tmux.toml` also exists
+- **THEN** `pane_group_command` is used, a warning is logged naming the ignored layout file, and the layout config is not read
+
+#### Scenario: Idempotent for existing session
+- **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket
+- **THEN** the existing session is reused and no new session is created
+
+#### Scenario: pane_group_command binary not found
+- **WHEN** `pane_group_command` is set to a command whose binary does not exist in `PATH`
+- **THEN** `OpenPaneGroup` returns a `FailedPrecondition` error naming the missing binary, and no tmux session is created

--- a/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/tasks.md
+++ b/openspec/changes/archive/2026-05-25-replace-laio-with-internal-support/tasks.md
@@ -1,0 +1,40 @@
+## 1. Layout config types and parsing (plugins/session-tmux)
+
+- [x] 1.1 Create `plugins/session-tmux/internal/layout/config.go` — define `Config`, `Window`, `Pane`, `Command` TOML structs with all fields from the spec schema
+- [x] 1.2 Add `LoadConfig(worktreePath, xdgConfigHome string) (*Config, error)` that implements the two-tier resolution (per-repo → global → nil)
+- [x] 1.3 Implement `text/template` rendering of raw TOML bytes before parsing, injecting `worktree_path`, `story_name`, `tmux_socket`
+- [x] 1.4 Add config validation: at least one window, `flex >= 1`, at most one `focus` and one `zoom` per window tree; return `InvalidArgument` on failure
+- [x] 1.5 Write table-driven unit tests for `LoadConfig` covering: per-repo wins, global fallback, both absent, template substitution, all validation error cases
+
+## 2. Flex-split algorithm (plugins/session-tmux)
+
+- [x] 2.1 Create `plugins/session-tmux/internal/layout/split.go` — implement `splitPercent(currentFlex, remainingFlex int) int` with [1, 99] clamping
+- [x] 2.2 Write unit tests for `splitPercent`: equal pairs, thirds, weighted ratios, extreme values that trigger clamping
+
+## 3. Layout application engine (plugins/session-tmux)
+
+- [x] 3.1 Create `plugins/session-tmux/internal/layout/apply.go` — implement `Apply(ctx context.Context, run RunFunc, sock, sessionName string, cfg *Config) error` that orchestrates all tmux commands
+- [x] 3.2 Implement window creation: rename default window, create additional windows with `new-window -n <name> -c <path>`
+- [x] 3.3 Implement recursive pane splitting: depth-first traversal, `split-window -p <pct> [-h]` per the flex algorithm
+- [x] 3.4 Implement post-split actions per pane: `send-keys` for each command (with `pane_cmd_delay` sleep), `select-pane` for `focus`, `resize-pane -Z` for `zoom`
+- [x] 3.5 Implement `env` injection: set variables via `tmux setenv -t <session>` before window creation
+- [x] 3.6 Implement `startup` commands: send to first pane of first window before other layout steps
+- [x] 3.7 Write unit tests for `Apply` using a fake `RunFunc` that records commands; cover: single window/pane, multi-window, nested panes, focus, zoom, commands with delay, row vs column direction
+
+## 4. Wire layout into OpenPaneGroup (plugins/session-tmux)
+
+- [x] 4.1 In `plugins/session-tmux/internal/session/tmux.go`, update `OpenPaneGroup` to call `layout.LoadConfig` after session creation; apply resolved config or fall back to default layout
+- [x] 4.2 Add warning log when `pane_group_command` is set and a layout config file also exists at either tier
+- [x] 4.3 Update existing `OpenPaneGroup` unit tests in `tmux_test.go` to cover: per-repo layout applied, global layout fallback, per-repo wins over global, `pane_group_command` wins with warning, no config → default layout unchanged
+
+## 5. Update specs (openspec)
+
+- [ ] 5.1 Run `openspec sync --change replace-laio-with-internal-support` to merge delta specs into main specs
+- [ ] 5.2 Verify `openspec/specs/session-tmux/spec.md` reflects the updated `OpenPaneGroup` requirement
+- [ ] 5.3 Verify `openspec/specs/session-tmux-layout/spec.md` is created as a new main spec
+
+## 6. Verification
+
+- [ ] 6.1 Run `task fmt` and confirm zero diff
+- [ ] 6.2 Run `task lint` and confirm zero findings
+- [ ] 6.3 Run `task test` and confirm all tests pass

--- a/openspec/specs/session-tmux-layout/spec.md
+++ b/openspec/specs/session-tmux-layout/spec.md
@@ -1,0 +1,197 @@
+# session-tmux-layout Specification
+
+## Purpose
+TBD - created by archiving change replace-laio-with-internal-support. Update Purpose after archive.
+## Requirements
+### Requirement: Layout config resolution
+`session-tmux` SHALL resolve a layout config for `OpenPaneGroup` using the following priority order (first match wins):
+
+1. `pane_group_command` set in `config.toml` — existing behavior; a warning SHALL be logged if a layout config file exists at either tier and is being ignored.
+2. `<worktree_path>/.swm/session-tmux.toml` — per-repo config (overrides global).
+3. `$XDG_CONFIG_HOME/swm/session-tmux.toml` — global config (user-wide default).
+4. Built-in default — `$EDITOR` (or `vim` if unset) in the first window, a shell in the second.
+
+Only the first matching source is used. Configs are never merged across tiers.
+
+#### Scenario: Per-repo config used when present
+- **WHEN** `<worktree_path>/.swm/session-tmux.toml` exists and `pane_group_command` is not set
+- **THEN** the per-repo config is loaded and applied; the global config (if any) is not read
+
+#### Scenario: Global config used when no per-repo config
+- **WHEN** `$XDG_CONFIG_HOME/swm/session-tmux.toml` exists, `pane_group_command` is not set, and no per-repo config exists
+- **THEN** the global config is loaded and applied
+
+#### Scenario: Per-repo config wins over global
+- **WHEN** both `<worktree_path>/.swm/session-tmux.toml` and `$XDG_CONFIG_HOME/swm/session-tmux.toml` exist and `pane_group_command` is not set
+- **THEN** only the per-repo config is applied; the global config is not read
+
+#### Scenario: pane_group_command wins and warning logged
+- **WHEN** `pane_group_command` is set in `config.toml` and `<worktree_path>/.swm/session-tmux.toml` also exists
+- **THEN** `pane_group_command` is used and a warning is logged naming the ignored layout config file
+
+#### Scenario: No config at either tier falls back to default
+- **WHEN** neither `pane_group_command` nor any layout config file is present
+- **THEN** the default layout is applied (`$EDITOR` in window 1, shell in window 2)
+
+---
+
+### Requirement: Layout config TOML schema
+The layout config file SHALL be valid TOML conforming to this schema:
+
+```
+# Top-level (session-scoped) fields — all optional
+path         = string          # base path; defaults to worktree_path
+shell        = string          # shell binary for panes without an explicit command
+pane_cmd_delay = int           # milliseconds to wait between send-keys calls (default: 0)
+
+[env]                          # environment variables injected into every pane
+KEY = "value"
+
+[[startup]]                    # commands run in the first pane of the first window before layout
+command = string
+args    = [string]
+
+[[windows]]                    # at least one window required
+name           = string        # required; must be non-empty
+path           = string        # optional; resolved relative to session path
+flex_direction = "row"|"column" # direction for child pane splits (default: "column")
+
+  [[windows.panes]]            # optional; defaults to one full-size pane
+  flex           = int         # relative size weight (default: 1, minimum: 1)
+  flex_direction = "row"|"column"
+  path           = string
+  zoom           = bool        # zoom this pane at creation time (default: false)
+  focus          = bool        # focus this pane at creation time (default: false)
+  shell          = string
+  commands       = [string]    # commands sent via send-keys
+
+  [windows.panes.env]
+  KEY = "value"
+
+    [[windows.panes.panes]]    # nested panes (recursive)
+    # same fields as [[windows.panes]]
+```
+
+Constraints:
+- At least one `[[windows]]` entry is required.
+- `flex` must be ≥ 1.
+- At most one pane per window tree may have `focus = true`.
+- At most one pane per window tree may have `zoom = true`.
+
+#### Scenario: Config with no windows is rejected
+- **WHEN** a layout config file contains no `[[windows]]` entries
+- **THEN** `OpenPaneGroup` returns an `InvalidArgument` error before any tmux commands are issued
+
+#### Scenario: Config with flex less than 1 is rejected
+- **WHEN** a layout config file contains a pane with `flex = 0`
+- **THEN** `OpenPaneGroup` returns an `InvalidArgument` error before any tmux commands are issued
+
+#### Scenario: Config with two focused panes in the same window is rejected
+- **WHEN** a window's pane tree contains two panes both with `focus = true`
+- **THEN** `OpenPaneGroup` returns an `InvalidArgument` error before any tmux commands are issued
+
+---
+
+### Requirement: Template variable substitution in layout config
+Before parsing, the raw TOML bytes SHALL be rendered through `text/template` with the following variables auto-injected:
+
+| Variable       | Value                                      |
+|----------------|--------------------------------------------|
+| `worktree_path`| The `worktree_path` from `OpenPaneGroupRequest` |
+| `story_name`   | The story name from `OpenPaneGroupRequest`  |
+| `tmux_socket`  | The workspace socket path (`workspace_id`)  |
+
+#### Scenario: worktree_path substituted in window path
+- **WHEN** a layout config contains `path = "{{.worktree_path}}/src"` and `worktree_path` is `/home/user/code/stories/feat/github.com/org/repo`
+- **THEN** the resolved window path is `/home/user/code/stories/feat/github.com/org/repo/src`
+
+#### Scenario: story_name substituted in a command
+- **WHEN** a layout config contains `commands = ["echo {{.story_name}}"]` and `story_name` is `feat-x`
+- **THEN** `send-keys` is called with `echo feat-x`
+
+#### Scenario: tmux_socket substituted
+- **WHEN** a layout config contains `commands = ["tmux -S {{.tmux_socket}} list-sessions"]` and `workspace_id` is `/run/user/1000/swm/tmux/feat-x.sock`
+- **THEN** `send-keys` is called with `tmux -S /run/user/1000/swm/tmux/feat-x.sock list-sessions`
+
+---
+
+### Requirement: Layout application — windows
+`session-tmux` SHALL apply the layout config to a newly created tmux session by:
+1. Renaming the default window to the first window's `name`.
+2. Setting the first window's working directory to the resolved `path`.
+3. Creating subsequent windows with `new-window -n <name> -c <path>`.
+
+Window creation order matches the order of `[[windows]]` entries in the config.
+
+#### Scenario: Single window created with correct name and path
+- **WHEN** a layout config has one window with `name = "editor"` and `path = "{{.worktree_path}}"` and `OpenPaneGroup` creates a new session
+- **THEN** the tmux session has exactly one window named `editor` with working directory set to `worktree_path`
+
+#### Scenario: Multiple windows created in order
+- **WHEN** a layout config has windows named `["editor", "shell", "test"]` and `OpenPaneGroup` creates a new session
+- **THEN** the tmux session has three windows in that order with those names
+
+---
+
+### Requirement: Layout application — pane splits
+`session-tmux` SHALL split panes using a recursive percentage algorithm:
+
+For each group of sibling panes (ordered by position in config):
+- `totalFlex = Σ flex(sibling)`
+- For each sibling except the last:
+  - `remainingFlex = Σ flex(following siblings)`
+  - `splitPercent = clamp(remainingFlex * 100 / (flex(current) + remainingFlex), 1, 99)`
+  - Run `tmux split-window -p <splitPercent>` (add `-h` for `flex_direction = "row"`)
+- The last sibling takes whatever space remains.
+
+Rounding error accumulates to the last pane.
+
+#### Scenario: Two equal panes split 50/50
+- **WHEN** a window has two panes each with `flex = 1` and `flex_direction = "column"` (default)
+- **THEN** `split-window -p 50` is called once, producing two vertically equal panes
+
+#### Scenario: Three equal panes split into thirds
+- **WHEN** a window has three panes each with `flex = 1`
+- **THEN** `split-window -p 67` is called first (leaving ~33% for the first pane), then `split-window -p 50` on the remainder
+
+#### Scenario: Weighted flex produces proportional splits
+- **WHEN** a window has two panes with `flex = 2` and `flex = 1`
+- **THEN** `split-window -p 33` is called, giving the first pane ~67% and the second ~33%
+
+#### Scenario: Row direction uses horizontal split
+- **WHEN** a window has panes with `flex_direction = "row"`
+- **THEN** `split-window -h` is used instead of the default vertical split
+
+#### Scenario: Extreme flex ratio is clamped
+- **WHEN** a pane split would compute a `splitPercent` of 0 or 100
+- **THEN** the value is clamped to 1 or 99 respectively
+
+---
+
+### Requirement: Layout application — pane commands, focus, and zoom
+After creating each pane, `session-tmux` SHALL:
+- Send each entry in `commands` via `tmux send-keys <cmd> Enter`, waiting `pane_cmd_delay` ms between each.
+- If `focus = true`: run `tmux select-pane -t <pane>` after all panes in the window are created.
+- If `zoom = true`: run `tmux resize-pane -Z -t <pane>` after focus is applied.
+- Both `focus` and `zoom` are applied at creation time only; `SwitchTo` does not re-apply them.
+
+#### Scenario: Commands sent to pane
+- **WHEN** a pane has `commands = ["git status", "git log --oneline"]`
+- **THEN** `send-keys "git status" Enter` and `send-keys "git log --oneline" Enter` are called in sequence for that pane
+
+#### Scenario: pane_cmd_delay respected between commands
+- **WHEN** `pane_cmd_delay = 200` and a pane has two commands
+- **THEN** a 200 ms delay is observed between the two `send-keys` calls
+
+#### Scenario: focus pane selected after window layout
+- **WHEN** a window's third pane has `focus = true`
+- **THEN** `select-pane` targets that pane after all splits and commands in the window are applied
+
+#### Scenario: zoom applied after focus
+- **WHEN** a pane has both `focus = true` and `zoom = true`
+- **THEN** `select-pane` is called first, then `resize-pane -Z`
+
+#### Scenario: SwitchTo does not re-apply focus or zoom
+- **WHEN** `SwitchTo` is called for a session whose layout config has `focus = true` on a pane
+- **THEN** no `select-pane` command is issued by `SwitchTo`
+

--- a/openspec/specs/session-tmux-layout/spec.md
+++ b/openspec/specs/session-tmux-layout/spec.md
@@ -1,7 +1,7 @@
 # session-tmux-layout Specification
 
 ## Purpose
-TBD - created by archiving change replace-laio-with-internal-support. Update Purpose after archive.
+Specifies the built-in tmux window/pane layout system for `session-tmux`, replacing the external Laio dependency. Covers two-tier config resolution (per-repo `.swm/session-tmux.toml` > global `$XDG_CONFIG_HOME/swm/session-tmux.toml` > built-in default), the TOML schema, `text/template` variable substitution, the recursive flex-split algorithm, and per-pane command/focus/zoom application.
 ## Requirements
 ### Requirement: Layout config resolution
 `session-tmux` SHALL resolve a layout config for `OpenPaneGroup` using the following priority order (first match wins):
@@ -38,7 +38,7 @@ Only the first matching source is used. Configs are never merged across tiers.
 ### Requirement: Layout config TOML schema
 The layout config file SHALL be valid TOML conforming to this schema:
 
-```
+```toml
 # Top-level (session-scoped) fields — all optional
 path         = string          # base path; defaults to worktree_path
 shell        = string          # shell binary for panes without an explicit command
@@ -152,7 +152,7 @@ Rounding error accumulates to the last pane.
 
 #### Scenario: Three equal panes split into thirds
 - **WHEN** a window has three panes each with `flex = 1`
-- **THEN** `split-window -p 67` is called first (leaving ~33% for the first pane), then `split-window -p 50` on the remainder
+- **THEN** `split-window -p 66` is called first (leaving ~34% for the first pane via floor division), then `split-window -p 50` on the remainder
 
 #### Scenario: Weighted flex produces proportional splits
 - **WHEN** a window has two panes with `flex = 2` and `flex = 1`

--- a/openspec/specs/session-tmux/spec.md
+++ b/openspec/specs/session-tmux/spec.md
@@ -66,26 +66,48 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 - **THEN** the default layout is used and `{{tmux_socket}}` substitution does not occur
 
 ### Requirement: OpenPaneGroup in existing workspace
-`session-tmux` SHALL implement `Session.OpenPaneGroup({story_name, project_id, worktree_path})` by creating a new tmux session for the project within the story's socket (if it doesn't exist). The initial working directory SHALL be `worktree_path`. The default layout SHALL run `$EDITOR` (or `vim` if unset) in the first window and a shell in the second, unless `pane_group_command` is configured.
+`session-tmux` SHALL implement `Session.OpenPaneGroup({story_name, project_id, worktree_path})` by creating a new tmux session for the project within the story's socket (if it doesn't exist). The initial working directory SHALL be `worktree_path`.
+
+`OpenPaneGroup` SHALL resolve the layout using the following priority order (first match wins):
+
+1. If `pane_group_command` is set in `config.toml`: run that command (existing behavior). A warning SHALL be logged if a layout config file also exists at either tier.
+2. If `<worktree_path>/.swm/session-tmux.toml` exists: apply the per-repo layout (see `session-tmux-layout` spec).
+3. If `$XDG_CONFIG_HOME/swm/session-tmux.toml` exists: apply the global layout (see `session-tmux-layout` spec).
+4. Default: run `$EDITOR` (or `vim` if unset) in the first window and a shell in the second.
 
 When `pane_group_command` is configured, `session-tmux` SHALL validate that the first token of the command resolves to an executable via PATH lookup before creating the tmux session. If the binary is not found, `OpenPaneGroup` SHALL return a `FailedPrecondition` error naming the missing binary — no tmux session SHALL be created.
 
 #### Scenario: Default layout
-- **WHEN** `OpenPaneGroup` is called and no `pane_group_command` is configured
-- **THEN** a tmux session is created with a first window running `$EDITOR` and a second window running `$SHELL` in `worktree_path`
+- **WHEN** no `pane_group_command` is configured and no layout config exists at either tier
+- **THEN** the tmux session is created with two windows: the first running `$EDITOR` (or `vim`), the second running a shell
 
 #### Scenario: Custom pane_group_command
 - **WHEN** `config.toml` has `pane_group_command = "laio start --file '{{worktree_path}}/.swm/laio.yaml' --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"` and `OpenPaneGroup` is called
 - **THEN** the session's first window runs `laio start --file '<worktree_path>/.swm/laio.yaml' --tmux-socket '<tmux_socket>' --replace-current-session --skip-attach` with `{{worktree_path}}` and `{{tmux_socket}}` both expanded
+
+#### Scenario: Per-repo layout config applied
+- **WHEN** `<worktree_path>/.swm/session-tmux.toml` exists and `pane_group_command` is not set
+- **THEN** the layout defined in that file is applied to the newly created tmux session
+
+#### Scenario: Global layout config applied
+- **WHEN** `$XDG_CONFIG_HOME/swm/session-tmux.toml` exists, `pane_group_command` is not set, and no per-repo config exists
+- **THEN** the layout defined in the global config is applied to the newly created tmux session
+
+#### Scenario: Per-repo layout wins over global
+- **WHEN** both `<worktree_path>/.swm/session-tmux.toml` and `$XDG_CONFIG_HOME/swm/session-tmux.toml` exist and `pane_group_command` is not set
+- **THEN** only the per-repo config is applied
+
+#### Scenario: pane_group_command wins when layout config also present
+- **WHEN** `pane_group_command` is set and `<worktree_path>/.swm/session-tmux.toml` also exists
+- **THEN** `pane_group_command` is used, a warning is logged naming the ignored layout file, and the layout config is not read
 
 #### Scenario: Idempotent for existing session
 - **WHEN** `OpenPaneGroup` is called for a project whose session already exists on the socket
 - **THEN** the existing session is reused and no new session is created
 
 #### Scenario: pane_group_command binary not found
-- **WHEN** `config.toml` has `pane_group_command = "laio start ..."` and `laio` is not present in PATH
-- **THEN** `OpenPaneGroup` returns a `FailedPrecondition` error with a message identifying the missing binary (e.g. `pane_group_command binary "laio" not found in PATH`)
-- **AND** no tmux session is created
+- **WHEN** `pane_group_command` is set to a command whose binary does not exist in `PATH`
+- **THEN** `OpenPaneGroup` returns a `FailedPrecondition` error naming the missing binary, and no tmux session is created
 
 ### Requirement: SwitchTo switches active pane group
 `session-tmux` SHALL implement `Session.SwitchTo({workspace_id, pane_group_id, close_origin_workspace_id, close_origin_pane_id})` by running `tmux -S <target_socket> switch-client -t <session-name>` if already inside a tmux session, or building an `exec_argv` of `["tmux", "-S", "<target_socket>", "attach-session", "-t", "<session-name>"]` otherwise.

--- a/plugins/session-tmux/internal/layout/apply.go
+++ b/plugins/session-tmux/internal/layout/apply.go
@@ -126,7 +126,8 @@ func layoutPanes(ctx context.Context, run RunFunc, sock string, panes []Pane, pa
 		if i < len(panes)-1 {
 			// split-window -p N: current pane keeps (100-N)%, new pane gets N%.
 			pct := splitPercent(eFlex, remainingFlex)
-			newID, err := run(ctx, buildSplitArgs(sock, pct, currentID, dir)...)
+			nextPath := resolvePath(panes[i+1].Path, parentPath)
+			newID, err := run(ctx, buildSplitArgs(sock, pct, currentID, dir, nextPath)...)
 			if err != nil {
 				return nil, fmt.Errorf("splitting pane %s: %w", currentID, err)
 			}
@@ -183,7 +184,11 @@ func applyPaneContent(ctx context.Context, run RunFunc, sock string, p Pane, pan
 
 func sendKeys(ctx context.Context, run RunFunc, sock, paneID, cmd string, delayMs int) error {
 	if delayMs > 0 {
-		time.Sleep(time.Duration(delayMs) * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(delayMs) * time.Millisecond):
+		}
 	}
 
 	if _, err := run(ctx, "-S", sock, "send-keys", "-t", paneID, cmd, "Enter"); err != nil {
@@ -202,10 +207,14 @@ func getPaneID(ctx context.Context, run RunFunc, sock, target string) (string, e
 	return strings.TrimSpace(id), nil
 }
 
-func buildSplitArgs(sock string, pct int, targetPaneID string, dir FlexDirection) []string {
+func buildSplitArgs(sock string, pct int, targetPaneID string, dir FlexDirection, path string) []string {
 	args := []string{"-S", sock, "split-window", "-P", "-F", "#{pane_id}", "-p", strconv.Itoa(pct)}
 	if dir == FlexDirectionRow {
 		args = append(args, "-h")
+	}
+
+	if path != "" {
+		args = append(args, "-c", path)
 	}
 
 	return append(args, "-t", targetPaneID)
@@ -234,5 +243,24 @@ func cmdString(c Command) string {
 		return c.Command
 	}
 
-	return c.Command + " " + strings.Join(c.Args, " ")
+	quoted := make([]string, len(c.Args))
+	for i, arg := range c.Args {
+		quoted[i] = shellQuote(arg)
+	}
+
+	return c.Command + " " + strings.Join(quoted, " ")
+}
+
+// shellQuote wraps arg in single quotes if it contains shell metacharacters.
+// Single quotes inside the arg are escaped using the ”\” idiom.
+func shellQuote(arg string) string {
+	if arg == "" {
+		return "''"
+	}
+
+	if !strings.ContainsAny(arg, " \t\n&*;<>|'\"()$[]?~`{}!\\") {
+		return arg
+	}
+
+	return "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
 }

--- a/plugins/session-tmux/internal/layout/apply.go
+++ b/plugins/session-tmux/internal/layout/apply.go
@@ -1,0 +1,238 @@
+package layout
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RunFunc executes a tmux subcommand and returns its stdout.
+// It mirrors the signature of (*Tmux).run so callers can pass it directly.
+type RunFunc func(ctx context.Context, args ...string) (string, error)
+
+// paneResult holds the ID and config of a leaf pane after layout application.
+type paneResult struct {
+	paneID string
+	pane   Pane
+}
+
+// Apply applies the layout defined in cfg to an already-created tmux session.
+// sock is the tmux socket path; sessionName is the pane group session name.
+func Apply(ctx context.Context, run RunFunc, sock, sessionName string, cfg *Config) error {
+	sessionPath := cfg.Path
+
+	// Apply session-level env vars before creating any panes.
+	for k, v := range cfg.Env {
+		if _, err := run(ctx, "-S", sock, "setenv", "-t", sessionName, k, v); err != nil {
+			return fmt.Errorf("setting session env %s: %w", k, err)
+		}
+	}
+
+	// Apply startup commands to the initial pane before any layout steps.
+	if len(cfg.Startup) > 0 {
+		initialPaneID, err := getPaneID(ctx, run, sock, sessionName+":0")
+		if err != nil {
+			return err
+		}
+
+		for _, cmd := range cfg.Startup {
+			if err := sendKeys(ctx, run, sock, initialPaneID, cmdString(cmd), cfg.PaneCmdDelay); err != nil {
+				return err
+			}
+		}
+	}
+
+	for i, w := range cfg.Windows {
+		winPath := resolvePath(w.Path, sessionPath)
+
+		if i == 0 {
+			// Rename the existing default window.
+			if _, err := run(ctx, "-S", sock, "rename-window", "-t", sessionName+":0", w.Name); err != nil {
+				return fmt.Errorf("renaming first window to %q: %w", w.Name, err)
+			}
+		} else {
+			// Create subsequent windows.
+			args := []string{"-S", sock, "new-window", "-t", sessionName, "-n", w.Name}
+			if winPath != "" {
+				args = append(args, "-c", winPath)
+			}
+
+			if _, err := run(ctx, args...); err != nil {
+				return fmt.Errorf("creating window %q: %w", w.Name, err)
+			}
+		}
+
+		if len(w.Panes) == 0 {
+			continue
+		}
+
+		winTarget := fmt.Sprintf("%s:%d", sessionName, i)
+
+		initialPaneID, err := getPaneID(ctx, run, sock, winTarget)
+		if err != nil {
+			return fmt.Errorf("getting initial pane ID for window %d: %w", i, err)
+		}
+
+		leafPanes, err := layoutPanes(ctx, run, sock, w.Panes, initialPaneID, w.FlexDirection, winPath, cfg.PaneCmdDelay)
+		if err != nil {
+			return fmt.Errorf("laying out window %q: %w", w.Name, err)
+		}
+
+		// Apply focus then zoom (focus must come before zoom per spec).
+		for _, r := range leafPanes {
+			if r.pane.Focus {
+				if _, err := run(ctx, "-S", sock, "select-pane", "-t", r.paneID); err != nil {
+					return fmt.Errorf("select-pane %s: %w", r.paneID, err)
+				}
+			}
+		}
+
+		for _, r := range leafPanes {
+			if r.pane.Zoom {
+				if _, err := run(ctx, "-S", sock, "resize-pane", "-Z", "-t", r.paneID); err != nil {
+					return fmt.Errorf("resize-pane -Z %s: %w", r.paneID, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// layoutPanes recursively splits parentPaneID into len(panes) regions according
+// to each pane's flex weight, then applies content to leaf panes.
+// Returns all leaf pane results so the caller can apply focus/zoom.
+func layoutPanes(ctx context.Context, run RunFunc, sock string, panes []Pane, parentPaneID string, dir FlexDirection, parentPath string, paneCmdDelay int) ([]paneResult, error) {
+	if len(panes) == 0 {
+		return nil, nil
+	}
+
+	type allocation struct {
+		pane   Pane
+		paneID string
+	}
+
+	allocs := make([]allocation, 0, len(panes))
+	currentID := parentPaneID
+	remainingFlex := sumFlex(panes)
+
+	for i, p := range panes {
+		eFlex := p.effectiveFlex()
+		allocs = append(allocs, allocation{pane: p, paneID: currentID})
+		remainingFlex -= eFlex
+
+		if i < len(panes)-1 {
+			// split-window -p N: current pane keeps (100-N)%, new pane gets N%.
+			pct := splitPercent(eFlex, remainingFlex)
+			newID, err := run(ctx, buildSplitArgs(sock, pct, currentID, dir)...)
+			if err != nil {
+				return nil, fmt.Errorf("splitting pane %s: %w", currentID, err)
+			}
+
+			currentID = strings.TrimSpace(newID)
+		}
+	}
+
+	var results []paneResult
+
+	for _, a := range allocs {
+		effectivePath := resolvePath(a.pane.Path, parentPath)
+
+		if len(a.pane.Panes) > 0 {
+			children, err := layoutPanes(ctx, run, sock, a.pane.Panes, a.paneID, a.pane.FlexDirection, effectivePath, paneCmdDelay)
+			if err != nil {
+				return nil, err
+			}
+
+			results = append(results, children...)
+		} else {
+			if err := applyPaneContent(ctx, run, sock, a.pane, a.paneID, effectivePath, paneCmdDelay); err != nil {
+				return nil, err
+			}
+
+			results = append(results, paneResult{paneID: a.paneID, pane: a.pane})
+		}
+	}
+
+	return results, nil
+}
+
+func applyPaneContent(ctx context.Context, run RunFunc, sock string, p Pane, paneID, path string, paneCmdDelay int) error {
+	for k, v := range p.Env {
+		if err := sendKeys(ctx, run, sock, paneID, "export "+k+"="+v, paneCmdDelay); err != nil {
+			return fmt.Errorf("exporting env %s in pane %s: %w", k, paneID, err)
+		}
+	}
+
+	if p.Path != "" && path != "" {
+		if err := sendKeys(ctx, run, sock, paneID, "cd "+path, paneCmdDelay); err != nil {
+			return fmt.Errorf("cd %s in pane %s: %w", path, paneID, err)
+		}
+	}
+
+	for _, cmd := range p.Commands {
+		if err := sendKeys(ctx, run, sock, paneID, cmd, paneCmdDelay); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func sendKeys(ctx context.Context, run RunFunc, sock, paneID, cmd string, delayMs int) error {
+	if delayMs > 0 {
+		time.Sleep(time.Duration(delayMs) * time.Millisecond)
+	}
+
+	if _, err := run(ctx, "-S", sock, "send-keys", "-t", paneID, cmd, "Enter"); err != nil {
+		return fmt.Errorf("send-keys %q to pane %s: %w", cmd, paneID, err)
+	}
+
+	return nil
+}
+
+func getPaneID(ctx context.Context, run RunFunc, sock, target string) (string, error) {
+	id, err := run(ctx, "-S", sock, "display-message", "-t", target, "-p", "#{pane_id}")
+	if err != nil {
+		return "", fmt.Errorf("getting pane ID for %s: %w", target, err)
+	}
+
+	return strings.TrimSpace(id), nil
+}
+
+func buildSplitArgs(sock string, pct int, targetPaneID string, dir FlexDirection) []string {
+	args := []string{"-S", sock, "split-window", "-P", "-F", "#{pane_id}", "-p", strconv.Itoa(pct)}
+	if dir == FlexDirectionRow {
+		args = append(args, "-h")
+	}
+
+	return append(args, "-t", targetPaneID)
+}
+
+// resolvePath resolves path relative to basePath.
+// Absolute paths and ~ paths are returned as-is. Empty path → basePath.
+func resolvePath(path, basePath string) string {
+	if path == "" {
+		return basePath
+	}
+
+	if path[0] == '/' || path[0] == '~' {
+		return path
+	}
+
+	if basePath == "" {
+		return path
+	}
+
+	return basePath + "/" + path
+}
+
+func cmdString(c Command) string {
+	if len(c.Args) == 0 {
+		return c.Command
+	}
+
+	return c.Command + " " + strings.Join(c.Args, " ")
+}

--- a/plugins/session-tmux/internal/layout/apply.go
+++ b/plugins/session-tmux/internal/layout/apply.go
@@ -104,7 +104,10 @@ func Apply(ctx context.Context, run RunFunc, sock, sessionName string, cfg *Conf
 // layoutPanes recursively splits parentPaneID into len(panes) regions according
 // to each pane's flex weight, then applies content to leaf panes.
 // Returns all leaf pane results so the caller can apply focus/zoom.
-func layoutPanes(ctx context.Context, run RunFunc, sock string, panes []Pane, parentPaneID string, dir FlexDirection, parentPath string, paneCmdDelay int) ([]paneResult, error) {
+func layoutPanes(
+	ctx context.Context, run RunFunc, sock string, panes []Pane,
+	parentPaneID string, dir FlexDirection, parentPath string, paneCmdDelay int,
+) ([]paneResult, error) {
 	if len(panes) == 0 {
 		return nil, nil
 	}
@@ -126,8 +129,8 @@ func layoutPanes(ctx context.Context, run RunFunc, sock string, panes []Pane, pa
 		if i < len(panes)-1 {
 			// split-window -p N: current pane keeps (100-N)%, new pane gets N%.
 			pct := splitPercent(eFlex, remainingFlex)
-			nextPath := resolvePath(panes[i+1].Path, parentPath)
-			newID, err := run(ctx, buildSplitArgs(sock, pct, currentID, dir, nextPath)...)
+
+			newID, err := run(ctx, buildSplitArgs(sock, pct, currentID, dir, resolvePath(panes[i+1].Path, parentPath))...)
 			if err != nil {
 				return nil, fmt.Errorf("splitting pane %s: %w", currentID, err)
 			}
@@ -142,7 +145,9 @@ func layoutPanes(ctx context.Context, run RunFunc, sock string, panes []Pane, pa
 		effectivePath := resolvePath(a.pane.Path, parentPath)
 
 		if len(a.pane.Panes) > 0 {
-			children, err := layoutPanes(ctx, run, sock, a.pane.Panes, a.paneID, a.pane.FlexDirection, effectivePath, paneCmdDelay)
+			children, err := layoutPanes(
+				ctx, run, sock, a.pane.Panes, a.paneID, a.pane.FlexDirection, effectivePath, paneCmdDelay,
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -160,7 +165,9 @@ func layoutPanes(ctx context.Context, run RunFunc, sock string, panes []Pane, pa
 	return results, nil
 }
 
-func applyPaneContent(ctx context.Context, run RunFunc, sock string, p Pane, paneID, path string, paneCmdDelay int) error {
+func applyPaneContent(
+	ctx context.Context, run RunFunc, sock string, p Pane, paneID, path string, paneCmdDelay int,
+) error {
 	for k, v := range p.Env {
 		if err := sendKeys(ctx, run, sock, paneID, "export "+k+"="+v, paneCmdDelay); err != nil {
 			return fmt.Errorf("exporting env %s in pane %s: %w", k, paneID, err)

--- a/plugins/session-tmux/internal/layout/apply_test.go
+++ b/plugins/session-tmux/internal/layout/apply_test.go
@@ -1,0 +1,374 @@
+package layout_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/swm/plugins/session-tmux/internal/layout"
+)
+
+const (
+	testSock    = "/run/user/1000/swm/tmux/feat-x.sock"
+	testSession = "github•com/org/repo"
+)
+
+// recorder is a RunFunc that records calls and returns auto-incrementing pane IDs
+// for display-message and split-window calls.
+type recorder struct {
+	mu      sync.Mutex
+	calls   []string // each call as "arg1 arg2 ..."
+	paneSeq int
+}
+
+func (r *recorder) run(_ context.Context, args ...string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.calls = append(r.calls, strings.Join(args, " "))
+
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "display-message") || strings.Contains(joined, "split-window") {
+		id := "%" + string(rune('0'+r.paneSeq))
+		r.paneSeq++
+		return id, nil
+	}
+
+	return "", nil
+}
+
+func (r *recorder) hasCall(substr string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, c := range r.calls {
+		if strings.Contains(c, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *recorder) callCount(substr string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	n := 0
+
+	for _, c := range r.calls {
+		if strings.Contains(c, substr) {
+			n++
+		}
+	}
+
+	return n
+}
+
+func flex(n int) *int { return &n }
+
+func TestApply_SingleWindowNoPanes(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{Name: "editor"},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.True(t, rec.hasCall("rename-window"), "must rename default window")
+	require.True(t, rec.hasCall("editor"), "window name must appear in rename-window call")
+}
+
+func TestApply_TwoWindows(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{Name: "editor"},
+			{Name: "shell"},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.True(t, rec.hasCall("rename-window"), "first window must be renamed")
+	require.True(t, rec.hasCall("new-window"), "second window must be created with new-window")
+	require.True(t, rec.hasCall("shell"), "second window name must appear")
+}
+
+func TestApply_TwoPanesEqualFlex(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name: "main",
+				Panes: []layout.Pane{
+					{Commands: []string{"nvim ."}},
+					{Commands: []string{"bash"}},
+				},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.Equal(t, 1, rec.callCount("split-window"), "exactly one split for two panes")
+	require.True(t, rec.hasCall("-p 50"), "equal flex must produce 50% split")
+	require.True(t, rec.hasCall("nvim ."), "pane command must be sent")
+	require.True(t, rec.hasCall("bash"), "pane command must be sent")
+}
+
+func TestApply_ThreePanesEqualFlex(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name: "main",
+				Panes: []layout.Pane{
+					{Commands: []string{"cmd0"}},
+					{Commands: []string{"cmd1"}},
+					{Commands: []string{"cmd2"}},
+				},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.Equal(t, 2, rec.callCount("split-window"), "two splits for three panes")
+	require.True(t, rec.hasCall("-p 66"), "first split gives 66% to remaining (floor division)")
+	require.True(t, rec.hasCall("-p 50"), "second split halves the remainder")
+}
+
+func TestApply_WeightedFlex(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name: "main",
+				Panes: []layout.Pane{
+					{Flex: flex(2), Commands: []string{"big"}},
+					{Flex: flex(1), Commands: []string{"small"}},
+				},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.True(t, rec.hasCall("-p 33"), "2:1 flex ratio must produce 33% split for remaining")
+}
+
+func TestApply_RowDirectionUsesHorizontalFlag(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name:          "main",
+				FlexDirection: layout.FlexDirectionRow,
+				Panes: []layout.Pane{
+					{Commands: []string{"left"}},
+					{Commands: []string{"right"}},
+				},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.True(t, rec.hasCall("split-window"), "must call split-window")
+	require.True(t, rec.hasCall("-h"), "row direction must use -h flag")
+}
+
+func TestApply_NestedPanes(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name: "main",
+				Panes: []layout.Pane{
+					{Commands: []string{"editor"}},
+					{
+						Panes: []layout.Pane{
+							{Commands: []string{"tests"}},
+							{Commands: []string{"git"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	// 1 top-level split + 1 nested split = 2 total
+	require.Equal(t, 2, rec.callCount("split-window"))
+	require.True(t, rec.hasCall("editor"))
+	require.True(t, rec.hasCall("tests"))
+	require.True(t, rec.hasCall("git"))
+}
+
+func TestApply_FocusPaneSelected(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name: "main",
+				Panes: []layout.Pane{
+					{Commands: []string{"a"}},
+					{Commands: []string{"b"}, Focus: true},
+				},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.True(t, rec.hasCall("select-pane"), "focused pane must trigger select-pane")
+}
+
+func TestApply_ZoomAppliedAfterFocus(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name: "main",
+				Panes: []layout.Pane{
+					{Commands: []string{"a"}},
+					{Commands: []string{"b"}, Focus: true, Zoom: true},
+				},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+
+	// Verify select-pane comes before resize-pane -Z in call order.
+	selectIdx, zoomIdx := -1, -1
+	rec.mu.Lock()
+	for i, c := range rec.calls {
+		if strings.Contains(c, "select-pane") {
+			selectIdx = i
+		}
+		if strings.Contains(c, "resize-pane") && strings.Contains(c, "-Z") {
+			zoomIdx = i
+		}
+	}
+	rec.mu.Unlock()
+
+	require.Greater(t, selectIdx, -1, "select-pane must be called")
+	require.Greater(t, zoomIdx, -1, "resize-pane -Z must be called")
+	require.Less(t, selectIdx, zoomIdx, "select-pane must come before resize-pane -Z")
+}
+
+func TestApply_NoFocusOrZoomOnSwitchTo(t *testing.T) {
+	t.Parallel()
+
+	// Apply does not re-apply focus/zoom — that is the caller's responsibility.
+	// This test verifies Apply itself does not call select-pane when no pane has focus.
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name:  "main",
+				Panes: []layout.Pane{{Commands: []string{"a"}}},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.False(t, rec.hasCall("select-pane"), "select-pane must not be called when no pane has focus")
+	require.False(t, rec.hasCall("resize-pane"), "resize-pane must not be called when no pane has zoom")
+}
+
+func TestApply_StartupCommandsSentBeforeLayout(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Startup: []layout.Command{{Command: "mise install"}},
+		Windows: []layout.Window{
+			{
+				Name:  "main",
+				Panes: []layout.Pane{{Commands: []string{"nvim ."}}},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+
+	// "mise install" must appear before "nvim ." in the recorded calls.
+	startupIdx, layoutIdx := -1, -1
+	rec.mu.Lock()
+	for i, c := range rec.calls {
+		if strings.Contains(c, "mise install") {
+			startupIdx = i
+		}
+		if strings.Contains(c, "nvim .") {
+			layoutIdx = i
+		}
+	}
+	rec.mu.Unlock()
+
+	require.Greater(t, startupIdx, -1, "startup command must be sent")
+	require.Greater(t, layoutIdx, -1, "layout command must be sent")
+	require.Less(t, startupIdx, layoutIdx, "startup must precede layout commands")
+}
+
+func TestApply_SessionEnvSetBeforePanes(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Env: map[string]string{"EDITOR": "nvim"},
+		Windows: []layout.Window{
+			{Name: "main", Panes: []layout.Pane{{Commands: []string{"a"}}}},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+
+	envIdx, splitIdx := -1, -1
+	rec.mu.Lock()
+	for i, c := range rec.calls {
+		if strings.Contains(c, "setenv") && strings.Contains(c, "EDITOR") {
+			envIdx = i
+		}
+		if strings.Contains(c, "split-window") {
+			splitIdx = i
+		}
+	}
+	rec.mu.Unlock()
+
+	require.Greater(t, envIdx, -1, "setenv must be called")
+	// If there's a split, env must come before it.
+	if splitIdx >= 0 {
+		require.Less(t, envIdx, splitIdx, "setenv must precede split-window")
+	}
+}

--- a/plugins/session-tmux/internal/layout/apply_test.go
+++ b/plugins/session-tmux/internal/layout/apply_test.go
@@ -2,6 +2,7 @@ package layout_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -12,8 +13,10 @@ import (
 )
 
 const (
-	testSock    = "/run/user/1000/swm/tmux/feat-x.sock"
-	testSession = "github•com/org/repo"
+	testSock         = "/run/user/1000/swm/tmux/feat-x.sock"
+	testSession      = "github•com/org/repo"
+	testWindowMain   = "main"
+	testWindowEditor = "editor"
 )
 
 // recorder is a RunFunc that records calls and returns auto-incrementing pane IDs
@@ -22,35 +25,6 @@ type recorder struct {
 	mu      sync.Mutex
 	calls   []string // each call as "arg1 arg2 ..."
 	paneSeq int
-}
-
-func (r *recorder) run(_ context.Context, args ...string) (string, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.calls = append(r.calls, strings.Join(args, " "))
-
-	joined := strings.Join(args, " ")
-	if strings.Contains(joined, "display-message") || strings.Contains(joined, "split-window") {
-		id := "%" + string(rune('0'+r.paneSeq))
-		r.paneSeq++
-		return id, nil
-	}
-
-	return "", nil
-}
-
-func (r *recorder) hasCall(substr string) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	for _, c := range r.calls {
-		if strings.Contains(c, substr) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func (r *recorder) callCount(substr string) int {
@@ -68,7 +42,37 @@ func (r *recorder) callCount(substr string) int {
 	return n
 }
 
-func flex(n int) *int { return &n }
+func (r *recorder) hasCall(substr string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, c := range r.calls {
+		if strings.Contains(c, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *recorder) run(_ context.Context, args ...string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.calls = append(r.calls, strings.Join(args, " "))
+
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "display-message") || strings.Contains(joined, "split-window") {
+		id := fmt.Sprintf("%%%d", r.paneSeq)
+		r.paneSeq++
+
+		return id, nil
+	}
+
+	return "", nil
+}
+
+func flex(n int) *int { return &n } //nolint:modernize // address-of int literal not possible in Go
 
 func TestApply_SingleWindowNoPanes(t *testing.T) {
 	t.Parallel()
@@ -76,14 +80,14 @@ func TestApply_SingleWindowNoPanes(t *testing.T) {
 	rec := &recorder{}
 	cfg := &layout.Config{
 		Windows: []layout.Window{
-			{Name: "editor"},
+			{Name: testWindowEditor},
 		},
 	}
 
 	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
 	require.NoError(t, err)
 	require.True(t, rec.hasCall("rename-window"), "must rename default window")
-	require.True(t, rec.hasCall("editor"), "window name must appear in rename-window call")
+	require.True(t, rec.hasCall(testWindowEditor), "window name must appear in rename-window call")
 }
 
 func TestApply_TwoWindows(t *testing.T) {
@@ -92,7 +96,7 @@ func TestApply_TwoWindows(t *testing.T) {
 	rec := &recorder{}
 	cfg := &layout.Config{
 		Windows: []layout.Window{
-			{Name: "editor"},
+			{Name: testWindowEditor},
 			{Name: "shell"},
 		},
 	}
@@ -111,7 +115,7 @@ func TestApply_TwoPanesEqualFlex(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name: "main",
+				Name: testWindowMain,
 				Panes: []layout.Pane{
 					{Commands: []string{"nvim ."}},
 					{Commands: []string{"bash"}},
@@ -135,7 +139,7 @@ func TestApply_ThreePanesEqualFlex(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name: "main",
+				Name: testWindowMain,
 				Panes: []layout.Pane{
 					{Commands: []string{"cmd0"}},
 					{Commands: []string{"cmd1"}},
@@ -159,10 +163,10 @@ func TestApply_WeightedFlex(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name: "main",
+				Name: testWindowMain,
 				Panes: []layout.Pane{
-					{Flex: flex(2), Commands: []string{"big"}},
-					{Flex: flex(1), Commands: []string{"small"}},
+					{Flex: flex(2), Commands: []string{"big"}},   //nolint:modernize // address-of int literal not possible
+					{Flex: flex(1), Commands: []string{"small"}}, //nolint:modernize // address-of int literal not possible
 				},
 			},
 		},
@@ -180,7 +184,7 @@ func TestApply_RowDirectionUsesHorizontalFlag(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name:          "main",
+				Name:          testWindowMain,
 				FlexDirection: layout.FlexDirectionRow,
 				Panes: []layout.Pane{
 					{Commands: []string{"left"}},
@@ -203,9 +207,9 @@ func TestApply_NestedPanes(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name: "main",
+				Name: testWindowMain,
 				Panes: []layout.Pane{
-					{Commands: []string{"editor"}},
+					{Commands: []string{testWindowEditor}},
 					{
 						Panes: []layout.Pane{
 							{Commands: []string{"tests"}},
@@ -221,7 +225,7 @@ func TestApply_NestedPanes(t *testing.T) {
 	require.NoError(t, err)
 	// 1 top-level split + 1 nested split = 2 total
 	require.Equal(t, 2, rec.callCount("split-window"))
-	require.True(t, rec.hasCall("editor"))
+	require.True(t, rec.hasCall(testWindowEditor))
 	require.True(t, rec.hasCall("tests"))
 	require.True(t, rec.hasCall("git"))
 }
@@ -233,7 +237,7 @@ func TestApply_FocusPaneSelected(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name: "main",
+				Name: testWindowMain,
 				Panes: []layout.Pane{
 					{Commands: []string{"a"}},
 					{Commands: []string{"b"}, Focus: true},
@@ -254,7 +258,7 @@ func TestApply_ZoomAppliedAfterFocus(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name: "main",
+				Name: testWindowMain,
 				Panes: []layout.Pane{
 					{Commands: []string{"a"}},
 					{Commands: []string{"b"}, Focus: true, Zoom: true},
@@ -268,15 +272,19 @@ func TestApply_ZoomAppliedAfterFocus(t *testing.T) {
 
 	// Verify select-pane comes before resize-pane -Z in call order.
 	selectIdx, zoomIdx := -1, -1
+
 	rec.mu.Lock()
+
 	for i, c := range rec.calls {
 		if strings.Contains(c, "select-pane") {
 			selectIdx = i
 		}
+
 		if strings.Contains(c, "resize-pane") && strings.Contains(c, "-Z") {
 			zoomIdx = i
 		}
 	}
+
 	rec.mu.Unlock()
 
 	require.Greater(t, selectIdx, -1, "select-pane must be called")
@@ -293,7 +301,7 @@ func TestApply_NoFocusOrZoomOnSwitchTo(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name:  "main",
+				Name:  testWindowMain,
 				Panes: []layout.Pane{{Commands: []string{"a"}}},
 			},
 		},
@@ -313,7 +321,7 @@ func TestApply_StartupCommandsSentBeforeLayout(t *testing.T) {
 		Startup: []layout.Command{{Command: "mise install"}},
 		Windows: []layout.Window{
 			{
-				Name:  "main",
+				Name:  testWindowMain,
 				Panes: []layout.Pane{{Commands: []string{"nvim ."}}},
 			},
 		},
@@ -324,15 +332,19 @@ func TestApply_StartupCommandsSentBeforeLayout(t *testing.T) {
 
 	// "mise install" must appear before "nvim ." in the recorded calls.
 	startupIdx, layoutIdx := -1, -1
+
 	rec.mu.Lock()
+
 	for i, c := range rec.calls {
 		if strings.Contains(c, "mise install") {
 			startupIdx = i
 		}
+
 		if strings.Contains(c, "nvim .") {
 			layoutIdx = i
 		}
 	}
+
 	rec.mu.Unlock()
 
 	require.Greater(t, startupIdx, -1, "startup command must be sent")
@@ -347,7 +359,7 @@ func TestApply_SplitWindowUsesExplicitPanePath(t *testing.T) {
 	cfg := &layout.Config{
 		Windows: []layout.Window{
 			{
-				Name: "main",
+				Name: testWindowMain,
 				Panes: []layout.Pane{
 					{Commands: []string{"left"}},
 					{Path: "/explicit/path", Commands: []string{"right"}},
@@ -369,7 +381,7 @@ func TestApply_StartupCmdArgsQuoted(t *testing.T) {
 		Startup: []layout.Command{
 			{Command: "echo", Args: []string{"hello world", "simple"}},
 		},
-		Windows: []layout.Window{{Name: "main"}},
+		Windows: []layout.Window{{Name: testWindowMain}},
 	}
 
 	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
@@ -385,7 +397,7 @@ func TestApply_SessionEnvSetBeforePanes(t *testing.T) {
 	cfg := &layout.Config{
 		Env: map[string]string{"EDITOR": "nvim"},
 		Windows: []layout.Window{
-			{Name: "main", Panes: []layout.Pane{{Commands: []string{"a"}}}},
+			{Name: testWindowMain, Panes: []layout.Pane{{Commands: []string{"a"}}}},
 		},
 	}
 
@@ -393,15 +405,19 @@ func TestApply_SessionEnvSetBeforePanes(t *testing.T) {
 	require.NoError(t, err)
 
 	envIdx, splitIdx := -1, -1
+
 	rec.mu.Lock()
+
 	for i, c := range rec.calls {
 		if strings.Contains(c, "setenv") && strings.Contains(c, "EDITOR") {
 			envIdx = i
 		}
+
 		if strings.Contains(c, "split-window") {
 			splitIdx = i
 		}
 	}
+
 	rec.mu.Unlock()
 
 	require.Greater(t, envIdx, -1, "setenv must be called")

--- a/plugins/session-tmux/internal/layout/apply_test.go
+++ b/plugins/session-tmux/internal/layout/apply_test.go
@@ -340,6 +340,44 @@ func TestApply_StartupCommandsSentBeforeLayout(t *testing.T) {
 	require.Less(t, startupIdx, layoutIdx, "startup must precede layout commands")
 }
 
+func TestApply_SplitWindowUsesExplicitPanePath(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Windows: []layout.Window{
+			{
+				Name: "main",
+				Panes: []layout.Pane{
+					{Commands: []string{"left"}},
+					{Path: "/explicit/path", Commands: []string{"right"}},
+				},
+			},
+		},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.True(t, rec.hasCall("-c /explicit/path"), "split-window must pass -c for pane with explicit path")
+}
+
+func TestApply_StartupCmdArgsQuoted(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	cfg := &layout.Config{
+		Startup: []layout.Command{
+			{Command: "echo", Args: []string{"hello world", "simple"}},
+		},
+		Windows: []layout.Window{{Name: "main"}},
+	}
+
+	err := layout.Apply(context.Background(), rec.run, testSock, testSession, cfg)
+	require.NoError(t, err)
+	require.True(t, rec.hasCall("'hello world'"), "arg with space must be single-quoted")
+	require.True(t, rec.hasCall("simple"), "arg without special chars must be unquoted")
+}
+
 func TestApply_SessionEnvSetBeforePanes(t *testing.T) {
 	t.Parallel()
 

--- a/plugins/session-tmux/internal/layout/config.go
+++ b/plugins/session-tmux/internal/layout/config.go
@@ -1,0 +1,181 @@
+// Package layout loads and validates per-repo / global tmux layout configs.
+package layout
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/pelletier/go-toml/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// FlexDirection controls how sibling panes are split.
+type FlexDirection string
+
+const (
+	FlexDirectionColumn FlexDirection = "column" // vertical splits (default)
+	FlexDirectionRow    FlexDirection = "row"    // horizontal splits
+)
+
+// TemplateVars holds variables injected into config values before TOML parsing.
+type TemplateVars struct {
+	WorktreePath string
+	StoryName    string
+	TmuxSocket   string
+}
+
+// Command is an executable with optional arguments (used for startup commands).
+type Command struct {
+	Command string   `toml:"command"`
+	Args    []string `toml:"args"`
+}
+
+// Pane describes one tmux pane. Panes are recursive — a Pane may contain
+// child Panes forming a nested split tree.
+type Pane struct {
+	Flex          *int              `toml:"flex"`
+	FlexDirection FlexDirection     `toml:"flex_direction"`
+	Path          string            `toml:"path"`
+	Shell         string            `toml:"shell"`
+	Commands      []string          `toml:"commands"`
+	Env           map[string]string `toml:"env"`
+	Focus         bool              `toml:"focus"`
+	Zoom          bool              `toml:"zoom"`
+	Panes         []Pane            `toml:"panes"`
+}
+
+// effectiveFlex returns the pane's flex weight, defaulting to 1 when unset.
+func (p *Pane) effectiveFlex() int {
+	if p.Flex == nil {
+		return 1
+	}
+
+	return *p.Flex
+}
+
+// Window describes a named tmux window and its pane layout tree.
+type Window struct {
+	Name          string        `toml:"name"`
+	Path          string        `toml:"path"`
+	FlexDirection FlexDirection `toml:"flex_direction"`
+	Panes         []Pane        `toml:"panes"`
+}
+
+// Config is the parsed layout configuration.
+type Config struct {
+	Path         string            `toml:"path"`
+	Shell        string            `toml:"shell"`
+	PaneCmdDelay int               `toml:"pane_cmd_delay"`
+	Env          map[string]string `toml:"env"`
+	Startup      []Command         `toml:"startup"`
+	Windows      []Window          `toml:"windows"`
+}
+
+// LoadConfig resolves a layout config using a two-tier lookup (per-repo wins over global):
+//
+//  1. <worktreePath>/.swm/session-tmux.toml
+//  2. <xdgConfigHome>/swm/session-tmux.toml
+//
+// Returns nil, nil when no config file is found at either tier.
+func LoadConfig(worktreePath, xdgConfigHome string, vars TemplateVars) (*Config, error) {
+	candidates := []string{
+		filepath.Join(worktreePath, ".swm", "session-tmux.toml"),
+		filepath.Join(xdgConfigHome, "swm", "session-tmux.toml"),
+	}
+
+	for _, p := range candidates {
+		cfg, err := loadFile(p, vars)
+		if err != nil {
+			return nil, err
+		}
+
+		if cfg != nil {
+			return cfg, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func loadFile(path string, vars TemplateVars) (*Config, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // path is composed from trusted config directories
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("reading layout config %s: %w", path, err)
+	}
+
+	tmpl, err := template.New("layout").Parse(string(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parsing layout config template %s: %w", path, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, vars); err != nil {
+		return nil, fmt.Errorf("rendering layout config template %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := toml.Unmarshal(buf.Bytes(), &cfg); err != nil {
+		return nil, fmt.Errorf("parsing layout config TOML %s: %w", path, err)
+	}
+
+	if err := validateConfig(&cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func validateConfig(cfg *Config) error {
+	if len(cfg.Windows) == 0 {
+		return status.Errorf(codes.InvalidArgument, "layout config must define at least one window")
+	}
+
+	for i, w := range cfg.Windows {
+		if w.Name == "" {
+			return status.Errorf(codes.InvalidArgument, "layout: window[%d] must have a non-empty name", i)
+		}
+
+		var focusCount, zoomCount int
+		if err := validatePanes(w.Panes, fmt.Sprintf("window[%d](%q)", i, w.Name), &focusCount, &zoomCount); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validatePanes(panes []Pane, ctx string, focusCount, zoomCount *int) error {
+	for _, p := range panes {
+		if p.Flex != nil && *p.Flex < 1 {
+			return status.Errorf(codes.InvalidArgument, "layout: %s has a pane with flex=%d (must be ≥ 1)", ctx, *p.Flex)
+		}
+
+		if p.Focus {
+			*focusCount++
+			if *focusCount > 1 {
+				return status.Errorf(codes.InvalidArgument, "layout: %s has more than one pane with focus=true", ctx)
+			}
+		}
+
+		if p.Zoom {
+			*zoomCount++
+			if *zoomCount > 1 {
+				return status.Errorf(codes.InvalidArgument, "layout: %s has more than one pane with zoom=true", ctx)
+			}
+		}
+
+		if err := validatePanes(p.Panes, ctx, focusCount, zoomCount); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/plugins/session-tmux/internal/layout/config.go
+++ b/plugins/session-tmux/internal/layout/config.go
@@ -84,7 +84,9 @@ type Config struct {
 func LoadConfig(worktreePath, xdgConfigHome string, vars TemplateVars) (*Config, error) {
 	candidates := []string{
 		filepath.Join(worktreePath, ".swm", "session-tmux.toml"),
-		filepath.Join(xdgConfigHome, "swm", "session-tmux.toml"),
+	}
+	if xdgConfigHome != "" {
+		candidates = append(candidates, filepath.Join(xdgConfigHome, "swm", "session-tmux.toml"))
 	}
 
 	for _, p := range candidates {
@@ -143,6 +145,10 @@ func validateConfig(cfg *Config) error {
 			return status.Errorf(codes.InvalidArgument, "layout: window[%d] must have a non-empty name", i)
 		}
 
+		if err := validateFlexDirection(w.FlexDirection, fmt.Sprintf("window[%d](%q)", i, w.Name)); err != nil {
+			return err
+		}
+
 		var focusCount, zoomCount int
 		if err := validatePanes(w.Panes, fmt.Sprintf("window[%d](%q)", i, w.Name), &focusCount, &zoomCount); err != nil {
 			return err
@@ -150,6 +156,16 @@ func validateConfig(cfg *Config) error {
 	}
 
 	return nil
+}
+
+func validateFlexDirection(dir FlexDirection, ctx string) error {
+	switch dir {
+	case "", FlexDirectionColumn, FlexDirectionRow:
+		return nil
+	default:
+		return status.Errorf(codes.InvalidArgument,
+			"layout: %s has an invalid flex_direction %q (must be \"row\" or \"column\")", ctx, dir)
+	}
 }
 
 func validatePanes(panes []Pane, ctx string, focusCount, zoomCount *int) error {

--- a/plugins/session-tmux/internal/layout/config.go
+++ b/plugins/session-tmux/internal/layout/config.go
@@ -17,8 +17,10 @@ import (
 type FlexDirection string
 
 const (
-	FlexDirectionColumn FlexDirection = "column" // vertical splits (default)
-	FlexDirectionRow    FlexDirection = "row"    // horizontal splits
+	// FlexDirectionColumn splits panes vertically (top/bottom stacked). This is the default.
+	FlexDirectionColumn FlexDirection = "column"
+	// FlexDirectionRow splits panes horizontally (left/right side by side).
+	FlexDirectionRow FlexDirection = "row"
 )
 
 // TemplateVars holds variables injected into config values before TOML parsing.
@@ -100,14 +102,14 @@ func LoadConfig(worktreePath, xdgConfigHome string, vars TemplateVars) (*Config,
 		}
 	}
 
-	return nil, nil
+	return nil, nil //nolint:nilnil // nil Config means "no config file found" — not an error condition
 }
 
 func loadFile(path string, vars TemplateVars) (*Config, error) {
 	raw, err := os.ReadFile(path) //nolint:gosec // path is composed from trusted config directories
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil //nolint:nilnil // nil Config means "file not found" — not an error condition
 		}
 
 		return nil, fmt.Errorf("reading layout config %s: %w", path, err)
@@ -169,7 +171,13 @@ func validateFlexDirection(dir FlexDirection, ctx string) error {
 }
 
 func validatePanes(panes []Pane, ctx string, focusCount, zoomCount *int) error {
-	for _, p := range panes {
+	for i, p := range panes {
+		paneCtx := fmt.Sprintf("%s.panes[%d]", ctx, i)
+
+		if err := validateFlexDirection(p.FlexDirection, paneCtx); err != nil {
+			return err
+		}
+
 		if p.Flex != nil && *p.Flex < 1 {
 			return status.Errorf(codes.InvalidArgument, "layout: %s has a pane with flex=%d (must be ≥ 1)", ctx, *p.Flex)
 		}
@@ -188,7 +196,7 @@ func validatePanes(panes []Pane, ctx string, focusCount, zoomCount *int) error {
 			}
 		}
 
-		if err := validatePanes(p.Panes, ctx, focusCount, zoomCount); err != nil {
+		if err := validatePanes(p.Panes, paneCtx, focusCount, zoomCount); err != nil {
 			return err
 		}
 	}

--- a/plugins/session-tmux/internal/layout/config_test.go
+++ b/plugins/session-tmux/internal/layout/config_test.go
@@ -219,3 +219,29 @@ name = "main"
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
+
+func TestLoadConfig_EmptyXdgConfigHome(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir() // no per-repo config either
+	cfg, err := layout.LoadConfig(wt, "", layout.TemplateVars{})
+	require.NoError(t, err)
+	require.Nil(t, cfg, "empty xdgConfigHome with no per-repo config must return nil")
+}
+
+func TestLoadConfig_ValidationInvalidFlexDirection(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+[[windows]]
+name = "main"
+flex_direction = "diagonal"
+`)
+
+	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "flex_direction")
+}

--- a/plugins/session-tmux/internal/layout/config_test.go
+++ b/plugins/session-tmux/internal/layout/config_test.go
@@ -34,12 +34,13 @@ path = "{{.WorktreePath}}/src"
   commands = ["echo {{.StoryName}} {{.TmuxSocket}}"]
 `
 
-func writeConfig(t *testing.T, dir, name, content string) string {
+func writeConfig(t *testing.T, dir, content string) {
 	t.Helper()
-	p := filepath.Join(dir, name)
+
+	p := filepath.Join(dir, "session-tmux.toml")
+
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
 	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
-	return p
 }
 
 func TestLoadConfig_NoConfigAtEitherTier(t *testing.T) {
@@ -55,7 +56,7 @@ func TestLoadConfig_PerRepoConfigUsed(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", minimalConfig)
+	writeConfig(t, filepath.Join(wt, ".swm"), minimalConfig)
 
 	cfg, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
 	require.NoError(t, err)
@@ -69,7 +70,7 @@ func TestLoadConfig_GlobalConfigUsedWhenNoPerRepo(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(xdg, "swm"), "session-tmux.toml", twoWindowConfig)
+	writeConfig(t, filepath.Join(xdg, "swm"), twoWindowConfig)
 
 	cfg, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
 	require.NoError(t, err)
@@ -82,8 +83,8 @@ func TestLoadConfig_PerRepoWinsOverGlobal(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", minimalConfig)   // 1 window
-	writeConfig(t, filepath.Join(xdg, "swm"), "session-tmux.toml", twoWindowConfig) // 2 windows
+	writeConfig(t, filepath.Join(wt, ".swm"), minimalConfig)   // 1 window
+	writeConfig(t, filepath.Join(xdg, "swm"), twoWindowConfig) // 2 windows
 
 	cfg, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
 	require.NoError(t, err)
@@ -96,7 +97,7 @@ func TestLoadConfig_TemplateSubstitution(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", templateConfig)
+	writeConfig(t, filepath.Join(wt, ".swm"), templateConfig)
 
 	vars := layout.TemplateVars{
 		WorktreePath: "/home/user/code/stories/feat/github.com/org/repo",
@@ -116,7 +117,7 @@ func TestLoadConfig_ValidationNoWindows(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `# empty`)
+	writeConfig(t, filepath.Join(wt, ".swm"), `# empty`)
 
 	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
 	require.Error(t, err)
@@ -128,7 +129,7 @@ func TestLoadConfig_ValidationEmptyWindowName(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+	writeConfig(t, filepath.Join(wt, ".swm"), `
 [[windows]]
 name = ""
 `)
@@ -141,11 +142,9 @@ name = ""
 func TestLoadConfig_ValidationFlexZero(t *testing.T) {
 	t.Parallel()
 
-	flex := 0
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	_ = flex
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+	writeConfig(t, filepath.Join(wt, ".swm"), `
 [[windows]]
 name = "main"
 
@@ -163,7 +162,7 @@ func TestLoadConfig_ValidationTwoFocusPanes(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+	writeConfig(t, filepath.Join(wt, ".swm"), `
 [[windows]]
 name = "main"
 
@@ -185,7 +184,7 @@ func TestLoadConfig_ValidationTwoZoomPanes(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+	writeConfig(t, filepath.Join(wt, ".swm"), `
 [[windows]]
 name = "main"
 
@@ -207,7 +206,7 @@ func TestLoadConfig_ValidationFlexNegative(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+	writeConfig(t, filepath.Join(wt, ".swm"), `
 [[windows]]
 name = "main"
 
@@ -234,10 +233,32 @@ func TestLoadConfig_ValidationInvalidFlexDirection(t *testing.T) {
 
 	wt := t.TempDir()
 	xdg := t.TempDir()
-	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+	writeConfig(t, filepath.Join(wt, ".swm"), `
 [[windows]]
 name = "main"
 flex_direction = "diagonal"
+`)
+
+	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "flex_direction")
+}
+
+func TestLoadConfig_ValidationInvalidPaneFlexDirection(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), `
+[[windows]]
+name = "main"
+
+  [[windows.panes]]
+  flex_direction = "diagonal"
+
+    [[windows.panes.panes]]
+    commands = ["echo nested"]
 `)
 
 	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})

--- a/plugins/session-tmux/internal/layout/config_test.go
+++ b/plugins/session-tmux/internal/layout/config_test.go
@@ -1,0 +1,221 @@
+package layout_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/kalbasit/swm/plugins/session-tmux/internal/layout"
+)
+
+const minimalConfig = `
+[[windows]]
+name = "main"
+`
+
+const twoWindowConfig = `
+[[windows]]
+name = "editor"
+
+[[windows]]
+name = "shell"
+`
+
+const templateConfig = `
+[[windows]]
+name = "main"
+path = "{{.WorktreePath}}/src"
+
+  [[windows.panes]]
+  commands = ["echo {{.StoryName}} {{.TmuxSocket}}"]
+`
+
+func writeConfig(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+	return p
+}
+
+func TestLoadConfig_NoConfigAtEitherTier(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := layout.LoadConfig("/nonexistent/worktree", "/nonexistent/xdg", layout.TemplateVars{})
+	require.NoError(t, err)
+	require.Nil(t, cfg)
+}
+
+func TestLoadConfig_PerRepoConfigUsed(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", minimalConfig)
+
+	cfg, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Windows, 1)
+	require.Equal(t, "main", cfg.Windows[0].Name)
+}
+
+func TestLoadConfig_GlobalConfigUsedWhenNoPerRepo(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(xdg, "swm"), "session-tmux.toml", twoWindowConfig)
+
+	cfg, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Windows, 2)
+}
+
+func TestLoadConfig_PerRepoWinsOverGlobal(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", minimalConfig)   // 1 window
+	writeConfig(t, filepath.Join(xdg, "swm"), "session-tmux.toml", twoWindowConfig) // 2 windows
+
+	cfg, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Windows, 1, "per-repo config must win over global")
+}
+
+func TestLoadConfig_TemplateSubstitution(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", templateConfig)
+
+	vars := layout.TemplateVars{
+		WorktreePath: "/home/user/code/stories/feat/github.com/org/repo",
+		StoryName:    "feat-x",
+		TmuxSocket:   "/run/user/1000/swm/tmux/feat-x.sock",
+	}
+
+	cfg, err := layout.LoadConfig(wt, xdg, vars)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Equal(t, "/home/user/code/stories/feat/github.com/org/repo/src", cfg.Windows[0].Path)
+	require.Equal(t, "echo feat-x /run/user/1000/swm/tmux/feat-x.sock", cfg.Windows[0].Panes[0].Commands[0])
+}
+
+func TestLoadConfig_ValidationNoWindows(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `# empty`)
+
+	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestLoadConfig_ValidationEmptyWindowName(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+[[windows]]
+name = ""
+`)
+
+	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestLoadConfig_ValidationFlexZero(t *testing.T) {
+	t.Parallel()
+
+	flex := 0
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	_ = flex
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+[[windows]]
+name = "main"
+
+  [[windows.panes]]
+  flex = 0
+`)
+
+	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestLoadConfig_ValidationTwoFocusPanes(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+[[windows]]
+name = "main"
+
+  [[windows.panes]]
+  focus = true
+
+  [[windows.panes]]
+  focus = true
+`)
+
+	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "focus")
+}
+
+func TestLoadConfig_ValidationTwoZoomPanes(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+[[windows]]
+name = "main"
+
+  [[windows.panes]]
+  zoom = true
+
+  [[windows.panes]]
+  zoom = true
+`)
+
+	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "zoom")
+}
+
+func TestLoadConfig_ValidationFlexNegative(t *testing.T) {
+	t.Parallel()
+
+	wt := t.TempDir()
+	xdg := t.TempDir()
+	writeConfig(t, filepath.Join(wt, ".swm"), "session-tmux.toml", `
+[[windows]]
+name = "main"
+
+  [[windows.panes]]
+  flex = -1
+`)
+
+	_, err := layout.LoadConfig(wt, xdg, layout.TemplateVars{})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/plugins/session-tmux/internal/layout/split.go
+++ b/plugins/session-tmux/internal/layout/split.go
@@ -1,0 +1,35 @@
+package layout
+
+// splitPercent computes what percentage of a pane to give to the "remaining" siblings
+// so the current pane keeps currentFlex/(currentFlex+remainingFlex) of the space.
+//
+// With split-window -p N, the NEW pane receives N% and the target keeps (100-N)%.
+// Clamped to [1, 99] to avoid degenerate zero-size panes.
+func splitPercent(currentFlex, remainingFlex int) int {
+	total := currentFlex + remainingFlex
+	if total <= 0 {
+		return 50
+	}
+
+	pct := remainingFlex * 100 / total
+
+	if pct < 1 {
+		return 1
+	}
+
+	if pct > 99 {
+		return 99
+	}
+
+	return pct
+}
+
+// sumFlex returns the sum of effective flex weights for a slice of panes.
+func sumFlex(panes []Pane) int {
+	total := 0
+	for i := range panes {
+		total += panes[i].effectiveFlex()
+	}
+
+	return total
+}

--- a/plugins/session-tmux/internal/layout/split_test.go
+++ b/plugins/session-tmux/internal/layout/split_test.go
@@ -1,0 +1,75 @@
+package layout
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitPercent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		currentFlex   int
+		remainingFlex int
+		want          int
+	}{
+		{
+			name:          "equal pair gives 50",
+			currentFlex:   1,
+			remainingFlex: 1,
+			want:          50,
+		},
+		{
+			name:          "three equal panes first split",
+			currentFlex:   1,
+			remainingFlex: 2,
+			want:          66, // floor(200/3)
+		},
+		{
+			name:          "three equal panes second split",
+			currentFlex:   1,
+			remainingFlex: 1,
+			want:          50,
+		},
+		{
+			name:          "weighted 2:1 gives 33",
+			currentFlex:   2,
+			remainingFlex: 1,
+			want:          33,
+		},
+		{
+			name:          "weighted 1:2 gives 66",
+			currentFlex:   1,
+			remainingFlex: 2,
+			want:          66, // floor(200/3)
+		},
+		{
+			name:          "extreme ratio clamped to 99",
+			currentFlex:   1,
+			remainingFlex: 999,
+			want:          99,
+		},
+		{
+			name:          "extreme ratio clamped to 1",
+			currentFlex:   999,
+			remainingFlex: 1,
+			want:          1,
+		},
+		{
+			name:          "zero total returns 50",
+			currentFlex:   0,
+			remainingFlex: 0,
+			want:          50,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := splitPercent(tc.currentFlex, tc.remainingFlex)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/plugins/session-tmux/internal/layout/split_test.go
+++ b/plugins/session-tmux/internal/layout/split_test.go
@@ -1,4 +1,4 @@
-package layout
+package layout //nolint:testpackage // splitPercent is unexported; white-box test required
 
 import (
 	"testing"
@@ -68,6 +68,7 @@ func TestSplitPercent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			got := splitPercent(tc.currentFlex, tc.remainingFlex)
 			require.Equal(t, tc.want, got)
 		})

--- a/plugins/session-tmux/internal/session/testdata/faketmux/main.go
+++ b/plugins/session-tmux/internal/session/testdata/faketmux/main.go
@@ -67,6 +67,9 @@ func main() {
 			name = "test-session"
 		}
 		fmt.Println(name)
+	case "split-window":
+		// Return a fake pane ID so layout.Apply can reference the new pane.
+		fmt.Println("%1")
 	}
 }
 

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/kalbasit/swm/plugins/session-tmux/internal/layout"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 )
 
@@ -35,6 +37,7 @@ type tmuxConfig struct {
 type Tmux struct {
 	tmuxBin    string
 	socketDir  string
+	configHome string
 	hostClient pluginv1.HostClient
 	grpcConn   *grpc.ClientConn
 }
@@ -48,8 +51,9 @@ func New() (*Tmux, error) {
 	}
 
 	t := &Tmux{
-		tmuxBin:   bin,
-		socketDir: filepath.Join(xdg.RuntimeDir, "swm", "tmux"),
+		tmuxBin:    bin,
+		socketDir:  filepath.Join(xdg.RuntimeDir, "swm", "tmux"),
+		configHome: xdg.ConfigHome,
 	}
 
 	if sock := os.Getenv("SWM_HOST_SOCKET"); sock != "" {
@@ -70,13 +74,25 @@ func New() (*Tmux, error) {
 
 // NewWithBin returns a Tmux instance with an injected binary path and socket dir (for tests).
 func NewWithBin(tmuxBin, socketDir string) *Tmux {
-	return &Tmux{tmuxBin: tmuxBin, socketDir: socketDir}
+	return &Tmux{tmuxBin: tmuxBin, socketDir: socketDir, configHome: xdg.ConfigHome}
 }
 
 // NewWithBinAndClient returns a Tmux instance with an injected binary, socket dir,
 // and host client (for tests that exercise pane_group_command).
 func NewWithBinAndClient(tmuxBin, socketDir string, client pluginv1.HostClient) *Tmux {
-	return &Tmux{tmuxBin: tmuxBin, socketDir: socketDir, hostClient: client}
+	return &Tmux{tmuxBin: tmuxBin, socketDir: socketDir, configHome: xdg.ConfigHome, hostClient: client}
+}
+
+// NewWithBinAndConfigHome returns a Tmux instance with an injected binary, socket dir,
+// and XDG config home (for tests that exercise layout config resolution).
+func NewWithBinAndConfigHome(tmuxBin, socketDir, configHome string) *Tmux {
+	return &Tmux{tmuxBin: tmuxBin, socketDir: socketDir, configHome: configHome}
+}
+
+// NewWithBinClientAndConfigHome returns a Tmux instance with all dependencies injected
+// (for tests that exercise both pane_group_command and layout config).
+func NewWithBinClientAndConfigHome(tmuxBin, socketDir, configHome string, client pluginv1.HostClient) *Tmux {
+	return &Tmux{tmuxBin: tmuxBin, socketDir: socketDir, configHome: configHome, hostClient: client}
 }
 
 // Close releases the gRPC connection to the host service.
@@ -210,6 +226,14 @@ func (t *Tmux) OpenPaneGroup(ctx context.Context, req *pluginv1.OpenPaneGroupReq
 
 		if _, err := t.run(ctx, args...); err != nil {
 			return nil, err
+		}
+
+		if initialCmd == "" {
+			if err := t.applyLayout(ctx, sock, name, req); err != nil {
+				return nil, err
+			}
+		} else if t.layoutConfigExists(req.GetWorktreePath()) {
+			log.Printf("session-tmux: pane_group_command is set; ignoring layout config for %s", name)
 		}
 	}
 
@@ -378,6 +402,60 @@ func validateCommandBinary(cmd string) error {
 	}
 
 	return nil
+}
+
+// layoutConfigExists reports whether a layout config file exists at either tier
+// (per-repo .swm/session-tmux.toml or global $XDG_CONFIG_HOME/swm/session-tmux.toml).
+func (t *Tmux) layoutConfigExists(worktreePath string) bool {
+	candidates := []string{
+		filepath.Join(worktreePath, ".swm", "session-tmux.toml"),
+		filepath.Join(t.configHome, "swm", "session-tmux.toml"),
+	}
+
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// applyLayout resolves and applies the session-tmux layout for a newly created pane group.
+// Falls back to the built-in default layout (editor + shell) when no config file exists.
+func (t *Tmux) applyLayout(ctx context.Context, sock, sessionName string, req *pluginv1.OpenPaneGroupRequest) error {
+	storyName := strings.TrimSuffix(filepath.Base(req.GetWorkspaceId()), ".sock")
+	vars := layout.TemplateVars{
+		WorktreePath: req.GetWorktreePath(),
+		StoryName:    storyName,
+		TmuxSocket:   req.GetWorkspaceId(),
+	}
+
+	cfg, err := layout.LoadConfig(req.GetWorktreePath(), t.configHome, vars)
+	if err != nil {
+		return err
+	}
+
+	if cfg == nil {
+		cfg = defaultLayout()
+	}
+
+	return layout.Apply(ctx, t.run, sock, sessionName, cfg)
+}
+
+// defaultLayout returns the built-in two-window layout (editor + shell).
+func defaultLayout() *layout.Config {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vim"
+	}
+
+	return &layout.Config{
+		Windows: []layout.Window{
+			{Name: "editor", Panes: []layout.Pane{{Commands: []string{editor}}}},
+			{Name: "shell"},
+		},
+	}
 }
 
 func (t *Tmux) run(ctx context.Context, args ...string) (string, error) {

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -18,8 +18,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
-	"github.com/kalbasit/swm/plugins/session-tmux/internal/layout"
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+
+	"github.com/kalbasit/swm/plugins/session-tmux/internal/layout"
 )
 
 // buildVersion is set via -ldflags at build time.
@@ -314,6 +315,28 @@ func (t *Tmux) SwitchTo(ctx context.Context, req *pluginv1.SwitchToRequest) (*pl
 	return resp, nil
 }
 
+// applyLayout resolves and applies the session-tmux layout for a newly created pane group.
+// Falls back to the built-in default layout (editor + shell) when no config file exists.
+func (t *Tmux) applyLayout(ctx context.Context, sock, sessionName string, req *pluginv1.OpenPaneGroupRequest) error {
+	storyName := strings.TrimSuffix(filepath.Base(req.GetWorkspaceId()), ".sock")
+	vars := layout.TemplateVars{
+		WorktreePath: req.GetWorktreePath(),
+		StoryName:    storyName,
+		TmuxSocket:   req.GetWorkspaceId(),
+	}
+
+	cfg, err := layout.LoadConfig(req.GetWorktreePath(), t.configHome, vars)
+	if err != nil {
+		return err
+	}
+
+	if cfg == nil {
+		cfg = defaultLayout()
+	}
+
+	return layout.Apply(ctx, t.run, sock, sessionName, cfg)
+}
+
 // killOriginPane kills the specified pane in the origin workspace after a switch.
 // It is a no-op when either argument is empty.
 // "No such pane" errors from tmux are swallowed — the pane may have already closed.
@@ -349,6 +372,23 @@ func isKillPaneNotFound(err error) bool {
 	return strings.Contains(msg, "no such pane") ||
 		strings.Contains(msg, "can't find pane") ||
 		strings.Contains(msg, "no sessions")
+}
+
+// layoutConfigExists reports whether a layout config file exists at either tier
+// (per-repo .swm/session-tmux.toml or global $XDG_CONFIG_HOME/swm/session-tmux.toml).
+func (t *Tmux) layoutConfigExists(worktreePath string) bool {
+	candidates := []string{
+		filepath.Join(worktreePath, ".swm", "session-tmux.toml"),
+		filepath.Join(t.configHome, "swm", "session-tmux.toml"),
+	}
+
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 // paneGroupCommand returns the command string for a new pane group session, applying
@@ -402,45 +442,6 @@ func validateCommandBinary(cmd string) error {
 	}
 
 	return nil
-}
-
-// layoutConfigExists reports whether a layout config file exists at either tier
-// (per-repo .swm/session-tmux.toml or global $XDG_CONFIG_HOME/swm/session-tmux.toml).
-func (t *Tmux) layoutConfigExists(worktreePath string) bool {
-	candidates := []string{
-		filepath.Join(worktreePath, ".swm", "session-tmux.toml"),
-		filepath.Join(t.configHome, "swm", "session-tmux.toml"),
-	}
-
-	for _, p := range candidates {
-		if _, err := os.Stat(p); err == nil {
-			return true
-		}
-	}
-
-	return false
-}
-
-// applyLayout resolves and applies the session-tmux layout for a newly created pane group.
-// Falls back to the built-in default layout (editor + shell) when no config file exists.
-func (t *Tmux) applyLayout(ctx context.Context, sock, sessionName string, req *pluginv1.OpenPaneGroupRequest) error {
-	storyName := strings.TrimSuffix(filepath.Base(req.GetWorkspaceId()), ".sock")
-	vars := layout.TemplateVars{
-		WorktreePath: req.GetWorktreePath(),
-		StoryName:    storyName,
-		TmuxSocket:   req.GetWorkspaceId(),
-	}
-
-	cfg, err := layout.LoadConfig(req.GetWorktreePath(), t.configHome, vars)
-	if err != nil {
-		return err
-	}
-
-	if cfg == nil {
-		cfg = defaultLayout()
-	}
-
-	return layout.Apply(ctx, t.run, sock, sessionName, cfg)
 }
 
 // defaultLayout returns the built-in two-window layout (editor + shell).

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -1,7 +1,9 @@
 package session_test
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -55,6 +57,20 @@ func newTmux(t *testing.T) (*session.Tmux, string) {
 	socketDir := t.TempDir()
 
 	return session.NewWithBin(faketmuxBin, socketDir), socketDir
+}
+
+func newTmuxWithConfigHome(t *testing.T, configHome string) (*session.Tmux, string) {
+	t.Helper()
+	socketDir := t.TempDir()
+
+	return session.NewWithBinAndConfigHome(faketmuxBin, socketDir, configHome), socketDir
+}
+
+func writeLayoutConfig(t *testing.T, dir, content string) {
+	t.Helper()
+	p := filepath.Join(dir, "session-tmux.toml")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
 }
 
 func TestInfo(t *testing.T) {
@@ -750,6 +766,182 @@ func TestSwitchTo_NoKill_WhenOriginPaneIdEmpty(t *testing.T) {
 	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
 	require.NoError(t, err)
 	require.NotContains(t, string(logBytes), "kill-pane", "must not call kill-pane when origin pane id is empty")
+}
+
+func TestOpenPaneGroup_DefaultLayoutApplied(t *testing.T) {
+	// Cannot be parallel — sets env vars.
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+	t.Setenv("EDITOR", "test-editor")
+
+	worktree := t.TempDir() // no .swm/session-tmux.toml
+	tmux, socketDir := newTmuxWithConfigHome(t, t.TempDir())
+	sockPath := filepath.Join(socketDir, "feat-default.sock")
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: worktree,
+	})
+	require.NoError(t, err)
+
+	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+
+	tmuxLog := string(logBytes)
+	require.Contains(t, tmuxLog, "rename-window", "default layout must rename the first window")
+	require.Contains(t, tmuxLog, "editor", "default layout must include an 'editor' window")
+	require.Contains(t, tmuxLog, "new-window", "default layout must create a 'shell' window")
+	require.Contains(t, tmuxLog, "shell", "default layout must name the second window 'shell'")
+	require.Contains(t, tmuxLog, "test-editor", "default layout must send the EDITOR command")
+}
+
+func TestOpenPaneGroup_PerRepoLayoutApplied(t *testing.T) {
+	// Cannot be parallel — sets env vars.
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	worktree := t.TempDir()
+	writeLayoutConfig(t, filepath.Join(worktree, ".swm"), `
+[[windows]]
+name = "per-repo-window"
+
+  [[windows.panes]]
+  commands = ["per-repo-cmd"]
+`)
+
+	tmux, socketDir := newTmuxWithConfigHome(t, t.TempDir())
+	sockPath := filepath.Join(socketDir, "feat-per-repo.sock")
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: worktree,
+	})
+	require.NoError(t, err)
+
+	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+
+	tmuxLog := string(logBytes)
+	require.Contains(t, tmuxLog, "per-repo-window", "per-repo layout window name must be applied")
+	require.Contains(t, tmuxLog, "per-repo-cmd", "per-repo layout command must be sent")
+}
+
+func TestOpenPaneGroup_GlobalLayoutFallback(t *testing.T) {
+	// Cannot be parallel — sets env vars.
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	worktree := t.TempDir() // no per-repo config
+	configHome := t.TempDir()
+	writeLayoutConfig(t, filepath.Join(configHome, "swm"), `
+[[windows]]
+name = "global-window"
+
+  [[windows.panes]]
+  commands = ["global-cmd"]
+`)
+
+	tmux, socketDir := newTmuxWithConfigHome(t, configHome)
+	sockPath := filepath.Join(socketDir, "feat-global.sock")
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: worktree,
+	})
+	require.NoError(t, err)
+
+	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+
+	tmuxLog := string(logBytes)
+	require.Contains(t, tmuxLog, "global-window", "global layout must be applied when no per-repo config exists")
+	require.Contains(t, tmuxLog, "global-cmd", "global layout command must be sent")
+}
+
+func TestOpenPaneGroup_PerRepoLayoutWinsOverGlobal(t *testing.T) {
+	// Cannot be parallel — sets env vars.
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	worktree := t.TempDir()
+	writeLayoutConfig(t, filepath.Join(worktree, ".swm"), `
+[[windows]]
+name = "per-repo-wins"
+`)
+
+	configHome := t.TempDir()
+	writeLayoutConfig(t, filepath.Join(configHome, "swm"), `
+[[windows]]
+name = "global-loses"
+`)
+
+	tmux, socketDir := newTmuxWithConfigHome(t, configHome)
+	sockPath := filepath.Join(socketDir, "feat-resolution.sock")
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: worktree,
+	})
+	require.NoError(t, err)
+
+	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+
+	tmuxLog := string(logBytes)
+	require.Contains(t, tmuxLog, "per-repo-wins", "per-repo layout must take priority over global")
+	require.NotContains(t, tmuxLog, "global-loses", "global layout must be ignored when per-repo config exists")
+}
+
+func TestOpenPaneGroup_PaneGroupCommandWinsOverLayout(t *testing.T) {
+	// Cannot be parallel — sets env vars and redirects global log output.
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	worktree := t.TempDir()
+	configHome := t.TempDir()
+
+	// Create a per-repo layout config so the warning path is triggered.
+	writeLayoutConfig(t, filepath.Join(worktree, ".swm"), `
+[[windows]]
+name = "layout-window"
+`)
+
+	// Redirect log output to capture the warning.
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+
+	defer log.SetOutput(os.Stderr)
+
+	tomlConfig := `pane_group_command = "` + faketmuxBin + ` fake-cmd"`
+	client := &fakeHostClient{toml: []byte(tomlConfig)}
+	socketDir := t.TempDir()
+	tmux := session.NewWithBinClientAndConfigHome(faketmuxBin, socketDir, configHome, client)
+
+	sockPath := filepath.Join(socketDir, "feat-pgcmd.sock")
+	require.NoError(t, os.WriteFile(sockPath, nil, 0o600))
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: worktree,
+	})
+	require.NoError(t, err)
+
+	// pane_group_command must win — layout must not be applied.
+	tmuxLog, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+	require.NotContains(t, string(tmuxLog), "layout-window",
+		"layout must not be applied when pane_group_command is set")
+
+	// Warning must have been logged.
+	require.Contains(t, logBuf.String(), "pane_group_command",
+		"warning must mention pane_group_command")
+	require.Contains(t, logBuf.String(), "ignoring",
+		"warning must indicate the layout config is being ignored")
 }
 
 // fakeHostClient implements pluginv1.HostClient for tests.

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -68,6 +68,7 @@ func newTmuxWithConfigHome(t *testing.T, configHome string) (*session.Tmux, stri
 
 func writeLayoutConfig(t *testing.T, dir, content string) {
 	t.Helper()
+
 	p := filepath.Join(dir, "session-tmux.toml")
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))


### PR DESCRIPTION
## Summary

- Implements a two-tier TOML layout config system (`per-repo .swm/session-tmux.toml` > global `$XDG_CONFIG_HOME/swm/session-tmux.toml` > built-in default) that replaces the dependency on the external Laio binary
- New `plugins/session-tmux/internal/layout` package handles config loading, flex-split algorithm, and tmux command orchestration
- `pane_group_command` remains top priority; a warning is logged when both are present
- Existing behavior (editor + shell default) is preserved when no config file exists

## Test plan

- [x] Unit tests for `LoadConfig`: per-repo wins, global fallback, both absent, template substitution, all validation error cases
- [x] Unit tests for `splitPercent`: equal pairs, thirds, weighted ratios, extreme clamping, zero total
- [x] Unit tests for `Apply`: single window/pane, multi-window, nested panes, focus, zoom ordering, startup commands, env injection
- [x] Integration tests for `OpenPaneGroup`: default layout, per-repo layout, global fallback, per-repo wins over global, `pane_group_command` wins with warning
- [x] All existing tests still pass