### PR TITLE
feat: standardize pane_group_command on text/template

### DIFF
--- a/openspec/specs/session-tmux/spec.md
+++ b/openspec/specs/session-tmux/spec.md
@@ -55,10 +55,10 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 - **THEN** that socket is excluded from the streamed results
 
 ### Requirement: paneGroupCommand exposes template variables
-`session-tmux` SHALL substitute `{{.WorktreePath}}`, `{{.StoryName}}`, and `{{.TmuxSocket}}` in `pane_group_command` before executing it. `{{.TmuxSocket}}` expands to the absolute path of the story's tmux socket (the same value as `workspace_id` in the request).
+`session-tmux` SHALL substitute `{{worktree_path}}`, `{{story_name}}`, `{{project_id}}`, and `{{tmux_socket}}` in `pane_group_command` before executing it. `{{tmux_socket}}` expands to the absolute path of the story's tmux socket (the same value as `workspace_id` in the request).
 
 #### Scenario: Template variables are substituted
-- **WHEN** `config.toml` has `pane_group_command = "my-layout --socket '{{.TmuxSocket}}' --path '{{.WorktreePath}}'"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock` and `worktree_path = /home/user/code/stories/feat-x/github.com/org/repo`
+- **WHEN** `config.toml` has `pane_group_command = "my-layout --socket '{{tmux_socket}}' --path '{{worktree_path}}'"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock` and `worktree_path = /home/user/code/stories/feat-x/github.com/org/repo`
 - **THEN** the command runs as `my-layout --socket '/run/user/1000/swm/tmux/feat-x.sock' --path '/home/user/code/stories/feat-x/github.com/org/repo'`
 
 #### Scenario: Template substitution absent when no pane_group_command configured
@@ -82,8 +82,8 @@ When `pane_group_command` is configured, `session-tmux` SHALL validate that the 
 - **THEN** the tmux session is created with two windows: the first running `$EDITOR` (or `vim`), the second running a shell
 
 #### Scenario: Custom pane_group_command
-- **WHEN** `config.toml` has `pane_group_command = "my-layout --socket '{{.TmuxSocket}}' --path '{{.WorktreePath}}'"` and `OpenPaneGroup` is called
-- **THEN** the session's first window runs `my-layout` with both `{{.TmuxSocket}}` and `{{.WorktreePath}}` expanded to their respective values
+- **WHEN** `config.toml` has `pane_group_command = "my-layout --socket '{{tmux_socket}}' --path '{{worktree_path}}'"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `my-layout` with both `{{tmux_socket}}` and `{{worktree_path}}` expanded to their respective values
 
 #### Scenario: Per-repo layout config applied
 - **WHEN** `<worktree_path>/.swm/session-tmux.toml` exists and `pane_group_command` is not set

--- a/openspec/specs/session-tmux/spec.md
+++ b/openspec/specs/session-tmux/spec.md
@@ -55,10 +55,10 @@ The `session-tmux` plugin manages per-story tmux servers for swm. Each workspace
 - **THEN** that socket is excluded from the streamed results
 
 ### Requirement: paneGroupCommand exposes template variables
-`session-tmux` SHALL substitute `{{worktree_path}}`, `{{story_name}}`, `{{project_id}}`, and `{{tmux_socket}}` in `pane_group_command` before executing it. `{{tmux_socket}}` expands to the absolute path of the story's tmux socket (the same value as `workspace_id` in the request).
+`session-tmux` SHALL render `pane_group_command` through Go `text/template` with `{{.WorktreePath}}`, `{{.StoryName}}`, `{{.ProjectID}}`, and `{{.TmuxSocket}}` before executing it. `{{.TmuxSocket}}` expands to the absolute path of the story's tmux socket (the same value as `workspace_id` in the request).
 
 #### Scenario: Template variables are substituted
-- **WHEN** `config.toml` has `pane_group_command = "my-layout --socket '{{tmux_socket}}' --path '{{worktree_path}}'"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock` and `worktree_path = /home/user/code/stories/feat-x/github.com/org/repo`
+- **WHEN** `config.toml` has `pane_group_command = "my-layout --socket '{{.TmuxSocket}}' --path '{{.WorktreePath}}'"` and `OpenPaneGroup` is called with `workspace_id = /run/user/1000/swm/tmux/feat-x.sock` and `worktree_path = /home/user/code/stories/feat-x/github.com/org/repo`
 - **THEN** the command runs as `my-layout --socket '/run/user/1000/swm/tmux/feat-x.sock' --path '/home/user/code/stories/feat-x/github.com/org/repo'`
 
 #### Scenario: Template substitution absent when no pane_group_command configured
@@ -82,8 +82,8 @@ When `pane_group_command` is configured, `session-tmux` SHALL validate that the 
 - **THEN** the tmux session is created with two windows: the first running `$EDITOR` (or `vim`), the second running a shell
 
 #### Scenario: Custom pane_group_command
-- **WHEN** `config.toml` has `pane_group_command = "my-layout --socket '{{tmux_socket}}' --path '{{worktree_path}}'"` and `OpenPaneGroup` is called
-- **THEN** the session's first window runs `my-layout` with both `{{tmux_socket}}` and `{{worktree_path}}` expanded to their respective values
+- **WHEN** `config.toml` has `pane_group_command = "my-layout --socket '{{.TmuxSocket}}' --path '{{.WorktreePath}}'"` and `OpenPaneGroup` is called
+- **THEN** the session's first window runs `my-layout` with both `{{.TmuxSocket}}` and `{{.WorktreePath}}` expanded to their respective values
 
 #### Scenario: Per-repo layout config applied
 - **WHEN** `<worktree_path>/.swm/session-tmux.toml` exists and `pane_group_command` is not set

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -183,9 +183,9 @@ name = "code"
 
 The plugin itself needs no configuration for layout — the `session-tmux.toml` files (above) are sufficient. The following options can be set under `[plugins.config.session-tmux]` when needed:
 
-| Key                  | Type   | Default | Description                                                                                                                                                                                                    |
-| -------------------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pane_group_command` | string | `""`    | Shell command run when a pane group is first opened. Takes precedence over layout config when set. Supports `{{worktree_path}}`, `{{story_name}}`, `{{project_id}}`, and `{{tmux_socket}}` template variables. |
+| Key                  | Type   | Default | Description                                                                                                                                                                                                       |
+| -------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pane_group_command` | string | `""`    | Shell command run when a pane group is first opened. Takes precedence over layout config when set. Supports `{{.WorktreePath}}`, `{{.StoryName}}`, `{{.ProjectID}}`, and `{{.TmuxSocket}}` Go template variables. |
 
 ## Usage
 

--- a/plugins/session-tmux/README.md
+++ b/plugins/session-tmux/README.md
@@ -183,9 +183,9 @@ name = "code"
 
 The plugin itself needs no configuration for layout — the `session-tmux.toml` files (above) are sufficient. The following options can be set under `[plugins.config.session-tmux]` when needed:
 
-| Key                  | Type   | Default | Description                                                                                                                                                                                  |
-| -------------------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pane_group_command` | string | `""`    | Shell command run when a pane group is first opened. Takes precedence over layout config when set. Supports `{{.WorktreePath}}`, `{{.StoryName}}`, and `{{.TmuxSocket}}` template variables. |
+| Key                  | Type   | Default | Description                                                                                                                                                                                                    |
+| -------------------- | ------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pane_group_command` | string | `""`    | Shell command run when a pane group is first opened. Takes precedence over layout config when set. Supports `{{worktree_path}}`, `{{story_name}}`, `{{project_id}}`, and `{{tmux_socket}}` template variables. |
 
 ## Usage
 

--- a/plugins/session-tmux/internal/layout/config.go
+++ b/plugins/session-tmux/internal/layout/config.go
@@ -27,6 +27,7 @@ const (
 type TemplateVars struct {
 	WorktreePath string
 	StoryName    string
+	ProjectID    string
 	TmuxSocket   string
 }
 

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/adrg/xdg"
 	"github.com/pelletier/go-toml/v2"
@@ -409,20 +410,27 @@ func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroup
 		return ""
 	}
 
-	// Derive story name from the socket path basename.
 	storyName := strings.TrimSuffix(filepath.Base(req.GetWorkspaceId()), ".sock")
 
-	// Build project_id string: host/seg1/seg2/...
 	pid := req.GetProjectId()
-	projectID := pid.GetHost() + "/" + strings.Join(pid.GetSegments(), "/")
+	vars := layout.TemplateVars{
+		WorktreePath: req.GetWorktreePath(),
+		StoryName:    storyName,
+		ProjectID:    pid.GetHost() + "/" + strings.Join(pid.GetSegments(), "/"),
+		TmuxSocket:   req.GetWorkspaceId(),
+	}
 
-	cmd := cfg.PaneGroupCommand
-	cmd = strings.ReplaceAll(cmd, "{{worktree_path}}", req.GetWorktreePath())
-	cmd = strings.ReplaceAll(cmd, "{{story_name}}", storyName)
-	cmd = strings.ReplaceAll(cmd, "{{project_id}}", projectID)
-	cmd = strings.ReplaceAll(cmd, "{{tmux_socket}}", req.GetWorkspaceId())
+	tmpl, err := template.New("cmd").Parse(cfg.PaneGroupCommand)
+	if err != nil {
+		return ""
+	}
 
-	return cmd
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, vars); err != nil {
+		return ""
+	}
+
+	return buf.String()
 }
 
 // validateCommandBinary checks that the first token of cmd resolves to an

--- a/plugins/session-tmux/internal/session/tmux.go
+++ b/plugins/session-tmux/internal/session/tmux.go
@@ -211,7 +211,10 @@ func (t *Tmux) OpenPaneGroup(ctx context.Context, req *pluginv1.OpenPaneGroupReq
 	name := sessionName(pid.GetHost() + "/" + strings.Join(pid.GetSegments(), "/"))
 
 	// Determine the initial command for the session.
-	initialCmd := t.paneGroupCommand(ctx, req)
+	initialCmd, err := t.paneGroupCommand(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 
 	if initialCmd != "" {
 		if err := validateCommandBinary(initialCmd); err != nil {
@@ -320,9 +323,11 @@ func (t *Tmux) SwitchTo(ctx context.Context, req *pluginv1.SwitchToRequest) (*pl
 // Falls back to the built-in default layout (editor + shell) when no config file exists.
 func (t *Tmux) applyLayout(ctx context.Context, sock, sessionName string, req *pluginv1.OpenPaneGroupRequest) error {
 	storyName := strings.TrimSuffix(filepath.Base(req.GetWorkspaceId()), ".sock")
+	pid := req.GetProjectId()
 	vars := layout.TemplateVars{
 		WorktreePath: req.GetWorktreePath(),
 		StoryName:    storyName,
+		ProjectID:    pid.GetHost() + "/" + strings.Join(pid.GetSegments(), "/"),
 		TmuxSocket:   req.GetWorkspaceId(),
 	}
 
@@ -392,22 +397,26 @@ func (t *Tmux) layoutConfigExists(worktreePath string) bool {
 	return false
 }
 
-// paneGroupCommand returns the command string for a new pane group session, applying
-// template substitutions if pane_group_command is configured.
-// Returns empty string if no command is configured or if config cannot be fetched.
-func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroupRequest) string {
+// paneGroupCommand returns the rendered pane_group_command string, or ("", nil) when
+// no command is configured. Returns a non-nil error when the configured command's
+// template is invalid or references an unknown variable.
+func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroupRequest) (string, error) {
 	if t.hostClient == nil {
-		return ""
+		return "", nil
 	}
 
 	resp, err := t.hostClient.GetConfig(ctx, &pluginv1.GetConfigRequest{PluginName: "session-tmux"})
 	if err != nil {
-		return ""
+		return "", nil //nolint:nilerr // host RPC failure means no config available; not a user-facing error
 	}
 
 	var cfg tmuxConfig
-	if err := toml.Unmarshal(resp.GetToml(), &cfg); err != nil || cfg.PaneGroupCommand == "" {
-		return ""
+	if err := toml.Unmarshal(resp.GetToml(), &cfg); err != nil {
+		return "", nil //nolint:nilerr // malformed TOML treated as unconfigured; host validates config
+	}
+
+	if cfg.PaneGroupCommand == "" {
+		return "", nil
 	}
 
 	storyName := strings.TrimSuffix(filepath.Base(req.GetWorkspaceId()), ".sock")
@@ -420,17 +429,17 @@ func (t *Tmux) paneGroupCommand(ctx context.Context, req *pluginv1.OpenPaneGroup
 		TmuxSocket:   req.GetWorkspaceId(),
 	}
 
-	tmpl, err := template.New("cmd").Parse(cfg.PaneGroupCommand)
+	tmpl, err := template.New("cmd").Option("missingkey=error").Parse(cfg.PaneGroupCommand)
 	if err != nil {
-		return ""
+		return "", status.Errorf(codes.InvalidArgument, "pane_group_command template parse error: %v", err)
 	}
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, vars); err != nil {
-		return ""
+		return "", status.Errorf(codes.InvalidArgument, "pane_group_command template execute error: %v", err)
 	}
 
-	return buf.String()
+	return buf.String(), nil
 }
 
 // validateCommandBinary checks that the first token of cmd resolves to an

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -369,10 +369,9 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 	sockPath := filepath.Join(socketDir, "feat-x.sock")
 
 	// Use faketmuxBin (guaranteed to exist) so binary validation passes.
-	// testLaioPaneGroupCommandTOML references laio, which may not be installed.
 	toml := `pane_group_command = "` + faketmuxBin +
-		` start --file '{{worktree_path}}/.swm/laio.yaml'` +
-		` --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"`
+		` --path '{{.WorktreePath}}'` +
+		` --socket '{{.TmuxSocket}}'"`
 
 	client := &fakeHostClient{
 		toml: []byte(toml),
@@ -396,8 +395,8 @@ func TestOpenPaneGroup_WithPaneGroupCommand(t *testing.T) {
 	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
 	require.NoError(t, err)
 
-	wantCmd := faketmuxBin + " start --file '/tmp/stories/feat-x/github.com/kalbasit/swm/.swm/laio.yaml'" +
-		" --tmux-socket '" + sockPath + "' --replace-current-session --skip-attach"
+	wantCmd := faketmuxBin + " --path '/tmp/stories/feat-x/github.com/kalbasit/swm'" +
+		" --socket '" + sockPath + "'"
 
 	log := string(logBytes)
 	require.Contains(t, log, wantCmd, "expected substituted pane_group_command in tmux args")
@@ -413,8 +412,7 @@ func TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution(t *testing.T) {
 
 	// Use faketmuxBin (guaranteed to exist) so binary validation passes.
 	toml := `pane_group_command = "` + faketmuxBin +
-		` start --file '{{worktree_path}}/.swm/laio.yaml'` +
-		` --tmux-socket '{{tmux_socket}}' --replace-current-session --skip-attach"`
+		` --socket '{{.TmuxSocket}}'"`
 
 	client := &fakeHostClient{
 		toml: []byte(toml),
@@ -437,8 +435,8 @@ func TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution(t *testing.T) {
 	require.NoError(t, err)
 
 	log := string(logBytes)
-	require.Contains(t, log, "--tmux-socket '"+sockPath+"'",
-		"{{tmux_socket}} must be substituted with the workspace socket path")
+	require.Contains(t, log, "--socket '"+sockPath+"'",
+		"{{.TmuxSocket}} must be substituted with the workspace socket path")
 }
 
 func TestOpenPaneGroup_PaneGroupCommandWhitespaceOnly(t *testing.T) {

--- a/plugins/session-tmux/internal/session/tmux_test.go
+++ b/plugins/session-tmux/internal/session/tmux_test.go
@@ -943,6 +943,62 @@ name = "layout-window"
 		"warning must indicate the layout config is being ignored")
 }
 
+func TestOpenPaneGroup_LayoutProjectIDSubstitution(t *testing.T) {
+	// Cannot be parallel — sets env vars.
+	logFile := filepath.Join(t.TempDir(), "tmux.log")
+	t.Setenv("FAKETMUX_LOG", logFile)
+
+	worktree := t.TempDir()
+	writeLayoutConfig(t, filepath.Join(worktree, ".swm"), `
+[[windows]]
+name = "{{.ProjectID}}-window"
+
+  [[windows.panes]]
+  commands = ["echo {{.ProjectID}}"]
+`)
+
+	tmux, socketDir := newTmuxWithConfigHome(t, t.TempDir())
+	sockPath := filepath.Join(socketDir, "feat-projectid.sock")
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: worktree,
+	})
+	require.NoError(t, err)
+
+	logBytes, err := os.ReadFile(logFile) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, err)
+
+	tmuxLog := string(logBytes)
+	require.Contains(t, tmuxLog, testProject+"-window",
+		"{{.ProjectID}} must be substituted in layout window names")
+	require.Contains(t, tmuxLog, "echo "+testProject,
+		"{{.ProjectID}} must be substituted in layout pane commands")
+}
+
+func TestOpenPaneGroup_PaneGroupCommandTemplateError(t *testing.T) {
+	// Cannot be parallel — uses t.Setenv.
+	socketDir := t.TempDir()
+	t.Setenv("FAKETMUX_LOG", filepath.Join(t.TempDir(), "tmux.log"))
+
+	sockPath := filepath.Join(socketDir, "feat-tmpl-err.sock")
+	require.NoError(t, os.WriteFile(sockPath, nil, 0o600))
+
+	// Use an invalid template: unclosed action.
+	const badTemplateTOML = `pane_group_command = "` + "{{.UnknownKey}}" + `"`
+
+	client := &fakeHostClient{toml: []byte(badTemplateTOML)}
+	tmux := session.NewWithBinAndClient(faketmuxBin, socketDir, client)
+
+	_, err := tmux.OpenPaneGroup(context.Background(), &pluginv1.OpenPaneGroupRequest{
+		WorkspaceId:  sockPath,
+		ProjectId:    &pluginv1.ProjectID{Host: testHost, Segments: []string{testOrg, testRepo}},
+		WorktreePath: t.TempDir(),
+	})
+	require.Error(t, err, "pane_group_command with unknown template key must return an error")
+}
+
 // fakeHostClient implements pluginv1.HostClient for tests.
 type fakeHostClient struct {
 	toml []byte


### PR DESCRIPTION
## Summary

- Switch `pane_group_command` substitution from `strings.ReplaceAll`
  (old `{{worktree_path}}` snake_case format) to Go `text/template`
  with the same dot-notation PascalCase syntax used by `session-tmux.toml`
- Add `ProjectID string` to `layout.TemplateVars` so it is available in
  both layout configs and `pane_group_command`
- Supported variables are now:
  `{{.WorktreePath}}`, `{{.StoryName}}`, `{{.ProjectID}}`, `{{.TmuxSocket}}`
- Update README, spec, and tests to reflect the unified syntax

## Test plan

- [x] `TestOpenPaneGroup_WithPaneGroupCommand` — verifies full substitution
- [x] `TestOpenPaneGroup_WithPaneGroupCommand_SocketSubstitution` — verifies socket path
- [x] `task fmt` exits 0
- [x] `task lint` exits 0
- [x] `task test` exits 0