### PR TITLE
feat(workspace): add swm workspace close command

### DIFF
--- a/cmd/swm/internal/cli/root.go
+++ b/cmd/swm/internal/cli/root.go
@@ -78,6 +78,7 @@ func NewRootCmd(
 	wsGroup := &cobra.Command{Use: "workspace", Short: "Manage workspaces"}
 	wsGroup.AddCommand(workspace.NewOpenCmd(cfg, store, mgr, resolver, hooks, openOpts...))
 	wsGroup.AddCommand(workspace.NewListCmd(store, cfg.DefaultStory))
+	wsGroup.AddCommand(workspace.NewCloseCmd(store, mgr))
 	root.AddCommand(wsGroup)
 
 	prGroup := &cobra.Command{Use: "pr", Short: "Manage pull requests"}

--- a/cmd/swm/internal/cli/workspace/close.go
+++ b/cmd/swm/internal/cli/workspace/close.go
@@ -49,7 +49,7 @@ func NewCloseCmd(store coreStory.Store, mgr pluginManager) *cobra.Command {
 
 			sess, ok := raw.(pluginv1.SessionClient)
 			if !ok {
-				return errUnexpectedSessionPlugin
+				return fmt.Errorf("%w: expected pluginv1.SessionClient, got %T", errUnexpectedSessionPlugin, raw)
 			}
 
 			stream, err := sess.ListWorkspaces(ctx, &pluginv1.Empty{})
@@ -71,7 +71,7 @@ func NewCloseCmd(store coreStory.Store, mgr pluginManager) *cobra.Command {
 					if _, err := sess.CloseWorkspace(ctx, &pluginv1.CloseWorkspaceRequest{
 						WorkspaceId: ws.GetWorkspaceId(),
 					}); err != nil {
-						return fmt.Errorf("closing workspace: %w", err)
+						return fmt.Errorf("closing workspace %q for story %q: %w", ws.GetWorkspaceId(), name, err)
 					}
 
 					cmd.Printf("closed workspace for story %q\n", name)
@@ -95,9 +95,11 @@ func NewCloseCmd(store coreStory.Store, mgr pluginManager) *cobra.Command {
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		names := make([]string, len(stories))
-		for i, s := range stories {
-			names[i] = s.Name
+		names := make([]string, 0, len(stories))
+		for _, s := range stories {
+			if s != nil {
+				names = append(names, s.Name)
+			}
 		}
 
 		return names, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/swm/internal/cli/workspace/close.go
+++ b/cmd/swm/internal/cli/workspace/close.go
@@ -1,0 +1,107 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+)
+
+var (
+	errCloseNoStoryName        = errors.New("story name required: pass <name> or set $SWM_STORY")
+	errUnexpectedSessionPlugin = errors.New("unexpected session plugin type")
+)
+
+// NewCloseCmd returns the `swm workspace close` command.
+func NewCloseCmd(store coreStory.Store, mgr pluginManager) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "close [<name>]",
+		Short: "Close the active workspace for a story without removing the story",
+		Args:  cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			mgr.Warm(cmd.Context(), "session") //nolint:errcheck,gosec // Warm always returns nil; errors deferred to Get
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var name string
+			if len(args) == 1 {
+				name = args[0]
+			} else {
+				name = os.Getenv("SWM_STORY")
+			}
+
+			if name == "" {
+				return errCloseNoStoryName
+			}
+
+			ctx := cmd.Context()
+
+			raw, err := mgr.Get(ctx, "session")
+			if err != nil {
+				return fmt.Errorf("loading session plugin: %w", err)
+			}
+
+			sess, ok := raw.(pluginv1.SessionClient)
+			if !ok {
+				return errUnexpectedSessionPlugin
+			}
+
+			stream, err := sess.ListWorkspaces(ctx, &pluginv1.Empty{})
+			if err != nil {
+				return fmt.Errorf("listing workspaces: %w", err)
+			}
+
+			for {
+				ws, err := stream.Recv()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				if err != nil {
+					return fmt.Errorf("receiving workspace: %w", err)
+				}
+
+				if ws.GetStoryName() == name {
+					if _, err := sess.CloseWorkspace(ctx, &pluginv1.CloseWorkspaceRequest{
+						WorkspaceId: ws.GetWorkspaceId(),
+					}); err != nil {
+						return fmt.Errorf("closing workspace: %w", err)
+					}
+
+					cmd.Printf("closed workspace for story %q\n", name)
+
+					return nil
+				}
+			}
+
+			// No active workspace found — succeed (idempotent).
+			return nil
+		},
+	}
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		stories, err := store.List(cmd.Context())
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		names := make([]string, len(stories))
+		for i, s := range stories {
+			names[i] = s.Name
+		}
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	return cmd
+}

--- a/cmd/swm/internal/cli/workspace/close_test.go
+++ b/cmd/swm/internal/cli/workspace/close_test.go
@@ -1,0 +1,252 @@
+package workspace_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	coreStory "github.com/kalbasit/swm/cmd/swm/internal/core/story"
+	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
+
+	"github.com/kalbasit/swm/cmd/swm/internal/cli/workspace"
+)
+
+const testCloseWorkspaceID = "sock-feat-x"
+
+// stubCloseSession is a SessionClient for close command tests with configurable
+// ListWorkspaces and CloseWorkspace behavior.
+type stubCloseSession struct {
+	workspaces       []*pluginv1.Workspace
+	listErr          error
+	closeWorkspaceID string // set by CloseWorkspace call
+	closeErr         error
+}
+
+func (s *stubCloseSession) CloseWorkspace(
+	_ context.Context,
+	req *pluginv1.CloseWorkspaceRequest,
+	_ ...grpc.CallOption,
+) (*pluginv1.Empty, error) {
+	s.closeWorkspaceID = req.GetWorkspaceId()
+
+	return &pluginv1.Empty{}, s.closeErr
+}
+
+func (s *stubCloseSession) CurrentContext(
+	context.Context, *pluginv1.Empty, ...grpc.CallOption,
+) (*pluginv1.CurrentContextResponse, error) {
+	panic("stub")
+}
+
+func (s *stubCloseSession) Info(
+	context.Context, *pluginv1.Empty, ...grpc.CallOption,
+) (*pluginv1.SessionInfo, error) {
+	panic("stub")
+}
+
+func (s *stubCloseSession) IsInsideWorkspace(
+	context.Context, *pluginv1.Empty, ...grpc.CallOption,
+) (*pluginv1.BoolValue, error) {
+	panic("stub")
+}
+
+func (s *stubCloseSession) ListWorkspaces(
+	_ context.Context, _ *pluginv1.Empty, _ ...grpc.CallOption,
+) (grpc.ServerStreamingClient[pluginv1.Workspace], error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+
+	return &staticWorkspaceStream{workspaces: s.workspaces}, nil
+}
+
+func (s *stubCloseSession) OpenPaneGroup(
+	context.Context, *pluginv1.OpenPaneGroupRequest, ...grpc.CallOption,
+) (*pluginv1.PaneGroup, error) {
+	panic("stub")
+}
+
+func (s *stubCloseSession) OpenWorkspace(
+	context.Context, *pluginv1.OpenWorkspaceRequest, ...grpc.CallOption,
+) (*pluginv1.Workspace, error) {
+	panic("stub")
+}
+
+func (s *stubCloseSession) SwitchTo(
+	context.Context, *pluginv1.SwitchToRequest, ...grpc.CallOption,
+) (*pluginv1.SwitchToResponse, error) {
+	panic("stub")
+}
+
+var _ pluginv1.SessionClient = (*stubCloseSession)(nil)
+
+// staticWorkspaceStream streams a fixed slice of workspaces, then EOF.
+type staticWorkspaceStream struct {
+	workspaces []*pluginv1.Workspace
+	pos        int
+}
+
+func (s *staticWorkspaceStream) CloseSend() error             { return nil }
+func (s *staticWorkspaceStream) Context() context.Context     { return context.Background() }
+func (s *staticWorkspaceStream) Header() (metadata.MD, error) { panic("stub") }
+
+func (s *staticWorkspaceStream) Recv() (*pluginv1.Workspace, error) {
+	if s.pos >= len(s.workspaces) {
+		return nil, io.EOF
+	}
+
+	ws := s.workspaces[s.pos]
+	s.pos++
+
+	return ws, nil
+}
+
+func (s *staticWorkspaceStream) RecvMsg(any) error    { panic("stub") }
+func (s *staticWorkspaceStream) SendMsg(any) error    { panic("stub") }
+func (s *staticWorkspaceStream) Trailer() metadata.MD { panic("stub") }
+
+func TestCloseCmd_ClosesRunningWorkspace(t *testing.T) {
+	t.Parallel()
+
+	sess := &stubCloseSession{
+		workspaces: []*pluginv1.Workspace{
+			{WorkspaceId: testCloseWorkspaceID, StoryName: testStoryName},
+		},
+	}
+	mgr := &stubMgr{sess: sess}
+	store := &stubStore{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+	out := &strings.Builder{}
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, testCloseWorkspaceID, sess.closeWorkspaceID)
+	require.Contains(t, out.String(), `closed workspace for story "feat-x"`)
+}
+
+func TestCloseCmd_NoActiveWorkspace_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	sess := &stubCloseSession{workspaces: nil}
+	mgr := &stubMgr{sess: sess}
+	store := &stubStore{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.Empty(t, sess.closeWorkspaceID)
+}
+
+func TestCloseCmd_SWMStoryFallback(t *testing.T) {
+	t.Setenv("SWM_STORY", testStoryName)
+
+	sess := &stubCloseSession{
+		workspaces: []*pluginv1.Workspace{
+			{WorkspaceId: testCloseWorkspaceID, StoryName: testStoryName},
+		},
+	}
+	mgr := &stubMgr{sess: sess}
+	store := &stubStore{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+	cmd.SetArgs([]string{})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, testCloseWorkspaceID, sess.closeWorkspaceID)
+}
+
+func TestCloseCmd_NoArg_NoEnv_Error(t *testing.T) {
+	t.Setenv("SWM_STORY", "")
+
+	mgr := &stubMgr{}
+	store := &stubStore{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+	cmd.SetArgs([]string{})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCloseCmd_ArgOverridesEnv(t *testing.T) {
+	t.Setenv("SWM_STORY", "other-story")
+
+	sess := &stubCloseSession{
+		workspaces: []*pluginv1.Workspace{
+			{WorkspaceId: testCloseWorkspaceID, StoryName: testStoryName},
+		},
+	}
+	mgr := &stubMgr{sess: sess}
+	store := &stubStore{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.NoError(t, cmd.Execute())
+	require.Equal(t, testCloseWorkspaceID, sess.closeWorkspaceID)
+}
+
+func TestCloseCmd_SessionPluginAbsent(t *testing.T) {
+	t.Parallel()
+
+	mgr := &stubMgr{} // no sess → Get("session") returns errNoPlugin
+	store := &stubStore{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+	cmd.SetArgs([]string{testStoryName})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCloseCmd_ListWorkspacesError(t *testing.T) {
+	t.Parallel()
+
+	sess := &stubCloseSession{listErr: errNoPlugin}
+	mgr := &stubMgr{sess: sess}
+	store := &stubStore{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+	cmd.SetArgs([]string{testStoryName})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.ErrorIs(t, err, errNoPlugin)
+}
+
+func TestCloseCmd_ShellCompletion_ListsStories(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{
+		listStories: []*coreStory.Story{
+			{Name: "feat-a"},
+			{Name: "feat-b"},
+		},
+	}
+	mgr := &stubMgr{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	require.ElementsMatch(t, []string{"feat-a", "feat-b"}, completions)
+}
+
+func TestCloseCmd_ShellCompletion_NoCompletionAfterFirstArg(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+	mgr := &stubMgr{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+
+	_, directive := cmd.ValidArgsFunction(cmd, []string{"already-provided"}, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}

--- a/cmd/swm/internal/cli/workspace/close_test.go
+++ b/cmd/swm/internal/cli/workspace/close_test.go
@@ -17,7 +17,11 @@ import (
 	"github.com/kalbasit/swm/cmd/swm/internal/cli/workspace"
 )
 
-const testCloseWorkspaceID = "sock-feat-x"
+const (
+	testCloseWorkspaceID = "sock-feat-x"
+	testCompletionStoryA = "feat-a"
+	testCompletionStoryB = "feat-b"
+)
 
 // stubCloseSession is a SessionClient for close command tests with configurable
 // ListWorkspaces and CloseWorkspace behavior.
@@ -226,8 +230,8 @@ func TestCloseCmd_ShellCompletion_ListsStories(t *testing.T) {
 
 	store := &stubStore{
 		listStories: []*coreStory.Story{
-			{Name: "feat-a"},
-			{Name: "feat-b"},
+			{Name: testCompletionStoryA},
+			{Name: testCompletionStoryB},
 		},
 	}
 	mgr := &stubMgr{}
@@ -236,7 +240,7 @@ func TestCloseCmd_ShellCompletion_ListsStories(t *testing.T) {
 
 	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
 	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
-	require.ElementsMatch(t, []string{"feat-a", "feat-b"}, completions)
+	require.ElementsMatch(t, []string{testCompletionStoryA, testCompletionStoryB}, completions)
 }
 
 func TestCloseCmd_ShellCompletion_NoCompletionAfterFirstArg(t *testing.T) {
@@ -249,4 +253,65 @@ func TestCloseCmd_ShellCompletion_NoCompletionAfterFirstArg(t *testing.T) {
 
 	_, directive := cmd.ValidArgsFunction(cmd, []string{"already-provided"}, "")
 	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+// badTypeMgr returns a wrong type for the session plugin to exercise the type
+// assertion failure path in NewCloseCmd.
+type badTypeMgr struct{}
+
+func (b *badTypeMgr) Close() error                                 { return nil }
+func (b *badTypeMgr) Get(_ context.Context, _ string) (any, error) { return struct{}{}, nil }
+func (b *badTypeMgr) Warm(_ context.Context, _ ...string) error    { return nil }
+
+func TestCloseCmd_WrongSessionPluginType_ErrorIncludesType(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{}
+	cmd := workspace.NewCloseCmd(store, &badTypeMgr{})
+	cmd.SetArgs([]string{testStoryName})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "struct {}")
+}
+
+func TestCloseCmd_CloseWorkspaceError_ErrorIncludesContext(t *testing.T) {
+	t.Parallel()
+
+	sess := &stubCloseSession{
+		workspaces: []*pluginv1.Workspace{
+			{WorkspaceId: testCloseWorkspaceID, StoryName: testStoryName},
+		},
+		closeErr: errFakeClose,
+	}
+	mgr := &stubMgr{sess: sess}
+	store := &stubStore{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+	cmd.SetArgs([]string{testStoryName})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.ErrorIs(t, err, errFakeClose)
+	require.Contains(t, err.Error(), testCloseWorkspaceID)
+	require.Contains(t, err.Error(), testStoryName)
+}
+
+func TestCloseCmd_ShellCompletion_NilStoriesSkipped(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{
+		listStories: []*coreStory.Story{
+			{Name: testCompletionStoryA},
+			nil,
+			{Name: testCompletionStoryB},
+		},
+	}
+	mgr := &stubMgr{}
+
+	cmd := workspace.NewCloseCmd(store, mgr)
+
+	completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+	require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	require.ElementsMatch(t, []string{testCompletionStoryA, testCompletionStoryB}, completions)
 }

--- a/openspec/changes/archive/2026-05-27-swm-workspace-close/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-27-swm-workspace-close/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/archive/2026-05-27-swm-workspace-close/design.md
+++ b/openspec/changes/archive/2026-05-27-swm-workspace-close/design.md
@@ -1,0 +1,90 @@
+# Design: swm workspace close
+
+## Context
+
+`swm story remove` already contains a `closeStoryWorkspace` helper (unexported, in
+`cmd/swm/internal/cli/story/remove.go`) that: streams `ListWorkspaces`, matches by
+story name, then calls `CloseWorkspace`. That logic is exactly what the new command
+needs, but it is currently buried in the story package with best-effort semantics
+(errors are silently dropped).
+
+The session plugin proto already has `CloseWorkspace(CloseWorkspaceRequest)` and the
+`session-tmux` spec already requires idempotency (close on a missing workspace
+succeeds). No proto changes or plugin changes are needed.
+
+The workspace package (`cmd/swm/internal/cli/workspace/`) already owns `open.go` and
+`list.go`; `close.go` is the natural home for this command.
+
+## Goals / Non-Goals
+
+**Goals**
+- Add `swm workspace close [<name>]` that tears down the running multiplexer for a
+  story without touching the story record or worktrees.
+- Default to `$SWM_STORY` when no name is given; error when both are absent.
+- Succeed (idempotent) when no workspace is active for that story.
+- Shell-complete `<name>` from the story store.
+
+**Non-Goals**
+- Hooks (`pre-workspace-close` / `post-workspace-close`).
+- A `--all` flag or closing multiple workspaces.
+- Removing the story or its worktrees (that remains `swm story remove`).
+
+## Decisions
+
+### 1. Extract `closeStoryWorkspace` to the workspace package
+
+**Decision:** Move the close logic into `cmd/swm/internal/cli/workspace/close.go` and
+update `story/remove.go` to call it from there (or duplicate the small helper).
+
+**Why:** The workspace package is the domain owner; placing close logic there is
+consistent with how `open.go` and `list.go` are structured. Keeping it in the story
+package would mean the workspace command reaches into a sibling package, inverting the
+dependency direction.
+
+**Alternative considered:** Re-export from `story` package. Rejected — circular
+imports are not possible here but the logical ownership is wrong; story commands should
+not be a library for workspace commands.
+
+**Practical approach:** The helper is ~15 lines. Duplicate it in
+`cmd/swm/internal/cli/workspace/close.go` and keep `story/remove.go`'s private copy
+as-is. Both are internal packages; DRY across `internal/` siblings adds more coupling
+than it removes. Revisit if the logic grows.
+
+### 2. Error semantics: fatal vs. best-effort
+
+**Decision:** Errors from `ListWorkspaces` and `CloseWorkspace` are returned to the
+caller (fatal), unlike `story remove` which silently drops them.
+
+**Why:** `swm workspace close` is an explicit user action. When the user asks to close
+a workspace and it fails, they need to know. Best-effort silence is appropriate in
+`story remove` because workspace closure is a cleanup step subordinate to the primary
+goal of deleting the story.
+
+**Exception:** No active workspace (story not found in `ListWorkspaces`) is treated as
+success (idempotent), matching the session-tmux spec and `story remove` behavior.
+
+### 3. Workspace-ID resolution via `ListWorkspaces` (no new RPC)
+
+**Decision:** Resolve workspace_id by streaming `ListWorkspaces` and filtering by
+`story_name`, identical to how `story remove` does it.
+
+**Why:** The proto's `CloseWorkspaceRequest` requires a `workspace_id`, not a
+`story_name`. There is no `FindWorkspaceByStory` RPC and adding one would be over-
+engineering for this use case. `ListWorkspaces` is a stream and returns quickly (only
+active sockets).
+
+**Alternative considered:** Add a `CloseWorkspaceByStory` RPC to the proto. Rejected —
+the proto is stable and adding an RPC for a convenience mapping belongs at the host
+layer, not the plugin contract.
+
+## Risks / Trade-offs
+
+- [Race condition] A workspace could be closed between `ListWorkspaces` and
+  `CloseWorkspace`. → `CloseWorkspace` on a non-existent socket is idempotent
+  (session-tmux spec, scenario "Close non-existent workspace"), so this is safe.
+- [Session plugin absent] If no session plugin is configured, the command returns an
+  error. → Acceptable; the user can't close a workspace they can't open.
+
+## Open Questions
+
+_None. All design decisions are resolved._

--- a/openspec/changes/archive/2026-05-27-swm-workspace-close/proposal.md
+++ b/openspec/changes/archive/2026-05-27-swm-workspace-close/proposal.md
@@ -1,0 +1,48 @@
+# Proposal: swm workspace close
+
+## Why
+
+`swm story remove` is the only way to close an active workspace today, but it also
+deletes the story and all its worktrees. Users who want to stop the multiplexer
+session and reclaim resources without destroying their work have no supported path —
+they must kill the tmux server manually.
+
+## What Changes
+
+- Add `swm workspace close [<name>]` CLI command under the existing `swm workspace`
+  sub-command group.
+- The `<name>` argument is optional; when omitted the story name is resolved from
+  `$SWM_STORY`. Missing name with unset `$SWM_STORY` exits non-zero.
+- The command calls `session.ListWorkspaces`, finds the workspace matching the story
+  name, then calls `session.CloseWorkspace`. If no active workspace is found the
+  command succeeds (idempotent, workspace already closed).
+- Shell completion for `<name>` lists active story names.
+
+## Capabilities
+
+### New Capabilities
+
+_None._ The session plugin proto already exposes `CloseWorkspace`; no new RPC or
+plugin capability is needed.
+
+### Modified Capabilities
+
+- **workflow-commands** — adds the `swm workspace close` command requirement. The
+  existing `swm workspace open` requirement is unchanged.
+
+## Impact
+
+- `cmd/swm/internal/cli/workspace/` — new `close.go` file; `close` sub-command
+  registered on the workspace cobra group.
+- `cmd/swm/internal/cli/story/remove.go` — `closeStoryWorkspace` helper extracted
+  to a shared location so both `swm story remove` and `swm workspace close` can
+  reuse it without duplication.
+- No proto changes. No new plugin binary. No config changes.
+- Capability surface: **session** (read: ListWorkspaces; write: CloseWorkspace).
+
+## Non-goals
+
+- Closing all open workspaces at once (`--all` flag) — not in scope.
+- Hooks (`pre-workspace-close` / `post-workspace-close`) — can be added later.
+- Removing the story or its worktrees — that remains the exclusive domain of
+  `swm story remove`.

--- a/openspec/changes/archive/2026-05-27-swm-workspace-close/specs/workflow-commands/spec.md
+++ b/openspec/changes/archive/2026-05-27-swm-workspace-close/specs/workflow-commands/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: swm workspace close
+
+`swm workspace close [<name>]` SHALL close the active multiplexer workspace for a
+story without removing the story record or its worktrees. The `<name>` argument is
+optional. When omitted, the story name SHALL be resolved from the `$SWM_STORY`
+environment variable. If `<name>` is omitted and `$SWM_STORY` is unset or empty, the
+command SHALL exit non-zero with a descriptive error before performing any work. When
+`<name>` is supplied it always takes precedence over `$SWM_STORY`.
+
+The close sequence SHALL be:
+1. Call `session.ListWorkspaces` to find the workspace whose `story_name` matches.
+2. If no matching workspace is found, succeed with no output (idempotent).
+3. Call `session.CloseWorkspace` with the matched `workspace_id`.
+4. Print `closed workspace for story "<name>"` on success.
+
+Errors from `session.ListWorkspaces` or `session.CloseWorkspace` SHALL be returned as
+a non-zero exit. Unlike `swm story remove`, no best-effort cleanup is attempted — the
+command either fully succeeds or reports the error.
+
+The command SHALL NOT: remove the story JSON, remove worktrees, or run any hooks.
+When no session plugin is configured, the command SHALL exit non-zero with a
+descriptive error.
+
+Shell completion for `<name>` SHALL list all story names from the story store.
+
+#### Scenario: Close running workspace by explicit name
+
+- **WHEN** `swm workspace close feat-x` is run and a workspace for `feat-x` is active
+- **THEN** `session.ListWorkspaces` is called, the matching workspace_id is found, `session.CloseWorkspace` is called with that id, and the command prints `closed workspace for story "feat-x"` and exits zero
+
+#### Scenario: No active workspace — succeeds silently
+
+- **WHEN** `swm workspace close feat-x` is run and no workspace for `feat-x` exists
+- **THEN** `session.ListWorkspaces` returns results but none match `feat-x`, the command exits zero with no output
+
+#### Scenario: No arg with SWM_STORY set — closes current story workspace
+
+- **WHEN** `swm workspace close` is run with no argument and `$SWM_STORY=feat-x`
+- **THEN** the command behaves identically to `swm workspace close feat-x`
+
+#### Scenario: No arg and SWM_STORY unset — exits with error
+
+- **WHEN** `swm workspace close` is run with no argument and `$SWM_STORY` is unset
+- **THEN** the command exits non-zero with an error indicating a story name is required
+
+#### Scenario: Explicit arg overrides SWM_STORY
+
+- **WHEN** `swm workspace close other-story` is run with `$SWM_STORY=feat-x`
+- **THEN** the workspace for `other-story` is closed, not `feat-x`
+
+#### Scenario: Session plugin absent — exits with error
+
+- **WHEN** `swm workspace close feat-x` is run and no session plugin is configured
+- **THEN** the command exits non-zero with a descriptive error
+
+#### Scenario: ListWorkspaces error — exits with error
+
+- **WHEN** `swm workspace close feat-x` is run and `session.ListWorkspaces` returns an error
+- **THEN** the command exits non-zero and surfaces the error

--- a/openspec/changes/archive/2026-05-27-swm-workspace-close/tasks.md
+++ b/openspec/changes/archive/2026-05-27-swm-workspace-close/tasks.md
@@ -1,0 +1,19 @@
+## 1. Unit Tests (Red)
+
+- [x] 1.1 `cmd/swm`: Write failing unit tests in `cmd/swm/internal/cli/workspace/close_test.go` covering all spec scenarios: close running workspace by name, no active workspace (idempotent success), no arg + `$SWM_STORY` set, no arg + `$SWM_STORY` unset (error), explicit arg overrides env, session plugin absent (error), `ListWorkspaces` error
+
+## 2. Core Implementation (Green)
+
+- [x] 2.1 `cmd/swm`: Create `cmd/swm/internal/cli/workspace/close.go` with `NewCloseCmd` — define the `pluginManager` interface (same shape as in `open.go`), implement the `ListWorkspaces`→filter-by-story-name→`CloseWorkspace` sequence with fatal error semantics and idempotent "no workspace found" success path
+- [x] 2.2 `cmd/swm`: Add shell completion for `<name>` argument (list story names from store, matching pattern in `open.go` and `list.go`)
+- [x] 2.3 `cmd/swm`: Update `cmd/swm/internal/cli/workspace/export_test.go` (if it exists) to export any new unexported helpers needed by tests
+
+## 3. Wiring
+
+- [x] 3.1 `cmd/swm`: Register `NewCloseCmd` on the workspace cobra sub-command group (locate where `NewOpenCmd` and `NewListCmd` are added and add `close` alongside them)
+
+## 4. Verification
+
+- [x] 4.1 Run `task fmt` and fix any formatting issues
+- [x] 4.2 Run `task lint` and fix any lint issues
+- [x] 4.3 Run `task test` and confirm all tests pass

--- a/openspec/specs/workflow-commands/spec.md
+++ b/openspec/specs/workflow-commands/spec.md
@@ -330,6 +330,66 @@ Stories SHALL be sent to the picker sorted by `CreatedAt` descending (most recen
 - **WHEN** `swm workspace open feat-x --kill-pane` is run outside any tmux session and `SwitchTo` returns a non-empty `exec_argv`
 - **THEN** `SwitchToRequest` is built with origin fields set (if `$TMUX_PANE` and `CurrentContext()` succeed), and after `syscall.Exec` the plugin has already killed the origin pane before responding
 
+### Requirement: swm workspace close
+
+`swm workspace close [<name>]` SHALL close the active multiplexer workspace for a
+story without removing the story record or its worktrees. The `<name>` argument is
+optional. When omitted, the story name SHALL be resolved from the `$SWM_STORY`
+environment variable. If `<name>` is omitted and `$SWM_STORY` is unset or empty, the
+command SHALL exit non-zero with a descriptive error before performing any work. When
+`<name>` is supplied it always takes precedence over `$SWM_STORY`.
+
+The close sequence SHALL be:
+1. Call `session.ListWorkspaces` to find the workspace whose `story_name` matches.
+2. If no matching workspace is found, succeed with no output (idempotent).
+3. Call `session.CloseWorkspace` with the matched `workspace_id`.
+4. Print `closed workspace for story "<name>"` on success.
+
+Errors from `session.ListWorkspaces` or `session.CloseWorkspace` SHALL be returned as
+a non-zero exit. Unlike `swm story remove`, no best-effort cleanup is attempted — the
+command either fully succeeds or reports the error.
+
+The command SHALL NOT: remove the story JSON, remove worktrees, or run any hooks.
+When no session plugin is configured, the command SHALL exit non-zero with a
+descriptive error.
+
+Shell completion for `<name>` SHALL list all story names from the story store.
+
+#### Scenario: Close running workspace by explicit name
+
+- **WHEN** `swm workspace close feat-x` is run and a workspace for `feat-x` is active
+- **THEN** `session.ListWorkspaces` is called, the matching workspace_id is found, `session.CloseWorkspace` is called with that id, and the command prints `closed workspace for story "feat-x"` and exits zero
+
+#### Scenario: No active workspace — succeeds silently
+
+- **WHEN** `swm workspace close feat-x` is run and no workspace for `feat-x` exists
+- **THEN** `session.ListWorkspaces` returns results but none match `feat-x`, the command exits zero with no output
+
+#### Scenario: No arg with SWM_STORY set — closes current story workspace
+
+- **WHEN** `swm workspace close` is run with no argument and `$SWM_STORY=feat-x`
+- **THEN** the command behaves identically to `swm workspace close feat-x`
+
+#### Scenario: No arg and SWM_STORY unset — exits with error
+
+- **WHEN** `swm workspace close` is run with no argument and `$SWM_STORY` is unset
+- **THEN** the command exits non-zero with an error indicating a story name is required
+
+#### Scenario: Explicit arg overrides SWM_STORY
+
+- **WHEN** `swm workspace close other-story` is run with `$SWM_STORY=feat-x`
+- **THEN** the workspace for `other-story` is closed, not `feat-x`
+
+#### Scenario: Session plugin absent — exits with error
+
+- **WHEN** `swm workspace close feat-x` is run and no session plugin is configured
+- **THEN** the command exits non-zero with a descriptive error
+
+#### Scenario: ListWorkspaces error — exits with error
+
+- **WHEN** `swm workspace close feat-x` is run and `session.ListWorkspaces` returns an error
+- **THEN** the command exits non-zero and surfaces the error
+
 ### Requirement: swm workspace list
 `swm workspace list` SHALL print a tree of all workspaces and their attached projects to stdout. Workspaces are listed in lexicographic order by name; projects within each workspace are listed in lexicographic order by their canonical path (`host/segments...`). The `_default` story is excluded from output. The output uses box-drawing glyphs:
 ```


### PR DESCRIPTION
## Summary

- `swm story remove` was the only way to close an active workspace, but it also deletes the story and all its worktrees. Users who want to stop the multiplexer session and reclaim resources without destroying their work had no supported path.
- Add `swm workspace close [<name>]` to the `swm workspace` sub-command group
- Resolves story name from positional arg or `$SWM_STORY`; errors when both are absent
- Streams `session.ListWorkspaces`, finds the workspace matching the story name, calls `session.CloseWorkspace` — no workspace active succeeds silently (idempotent)
- Shell completion for `<name>` lists all story names from the story store
- No proto or plugin changes needed — `session.CloseWorkspace` RPC already existed

## Test plan

- [x] `task fmt` passes
- [x] `task lint` passes (workspace package)
- [x] `task test` passes — 23/23 packages, 9 new unit tests covering all spec scenarios

🤖 Generated with [Claude Code](https://claude.ai/claude-code)