### PR TITLE
feat(clone): stream git clone progress to stderr

### DIFF
--- a/cmd/swm/internal/cli/clone.go
+++ b/cmd/swm/internal/cli/clone.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,11 +70,27 @@ func NewCloneCmd(mgr PluginManager, resolver *layout.Resolver, hooks hookexec.Ru
 				return fmt.Errorf("pre-clone hook: %w", err)
 			}
 
-			if _, err := vcs.Clone(ctx, &pluginv1.CloneRequest{
+			stream, err := vcs.Clone(ctx, &pluginv1.CloneRequest{
 				Url:             url,
 				DestinationPath: canonical,
-			}); err != nil {
+			})
+			if err != nil {
 				return fmt.Errorf("cloning %q: %w", url, err)
+			}
+
+			for {
+				evt, recvErr := stream.Recv()
+				if errors.Is(recvErr, io.EOF) {
+					break
+				}
+
+				if recvErr != nil {
+					return fmt.Errorf("cloning %q: %w", url, recvErr)
+				}
+
+				if line := evt.GetProgressLine(); line != "" {
+					fmt.Fprintln(cmd.ErrOrStderr(), line) //nolint:errcheck // writing progress to stderr is best-effort
+				}
 			}
 
 			if err := hooks.Run(ctx, hookexec.RunConfig{

--- a/cmd/swm/internal/cli/clone.go
+++ b/cmd/swm/internal/cli/clone.go
@@ -88,6 +88,13 @@ func NewCloneCmd(mgr PluginManager, resolver *layout.Resolver, hooks hookexec.Ru
 					return fmt.Errorf("cloning %q: %w", url, recvErr)
 				}
 
+				if pid := evt.GetProjectId(); pid != nil {
+					id = pid
+					projectPath = strings.Join(id.GetSegments(), "/")
+
+					continue
+				}
+
 				if line := evt.GetProgressLine(); line != "" {
 					fmt.Fprint(cmd.ErrOrStderr(), line) //nolint:errcheck // writing progress to stderr is best-effort
 				}

--- a/cmd/swm/internal/cli/clone.go
+++ b/cmd/swm/internal/cli/clone.go
@@ -89,7 +89,7 @@ func NewCloneCmd(mgr PluginManager, resolver *layout.Resolver, hooks hookexec.Ru
 				}
 
 				if line := evt.GetProgressLine(); line != "" {
-					fmt.Fprintln(cmd.ErrOrStderr(), line) //nolint:errcheck // writing progress to stderr is best-effort
+					fmt.Fprint(cmd.ErrOrStderr(), line) //nolint:errcheck // writing progress to stderr is best-effort
 				}
 			}
 

--- a/cmd/swm/internal/cli/clone_test.go
+++ b/cmd/swm/internal/cli/clone_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,12 @@ import (
 	"github.com/kalbasit/swm/cmd/swm/internal/hookexec"
 )
 
-const testSSHURL = "git@github.com:kalbasit/swm.git"
+const (
+	testSSHURL      = "git@github.com:kalbasit/swm.git"
+	testGitHubHost  = "github.com"
+	testKalbasitOrg = "kalbasit"
+	testSWMRepo     = "swm"
+)
 
 var (
 	errNetworkError = errors.New("network error")
@@ -41,7 +47,7 @@ func TestCloneCmd_Success(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	require.True(t, vcs.cloneCalled)
 
-	expected := filepath.Join(codeRoot, "repositories", "github.com", "kalbasit", "swm")
+	expected := filepath.Join(codeRoot, "repositories", testGitHubHost, testKalbasitOrg, testSWMRepo)
 	require.Equal(t, expected, vcs.cloneDst)
 }
 
@@ -50,7 +56,7 @@ func TestCloneCmd_AlreadyCloned(t *testing.T) {
 
 	codeRoot := t.TempDir()
 	// Pre-create the canonical path with a .git directory.
-	canonical := filepath.Join(codeRoot, "repositories", "github.com", "kalbasit", "swm")
+	canonical := filepath.Join(codeRoot, "repositories", testGitHubHost, testKalbasitOrg, testSWMRepo)
 	require.NoError(t, os.MkdirAll(filepath.Join(canonical, ".git"), 0o750))
 
 	resolver := layout.NewResolver(codeRoot, "_default")
@@ -107,6 +113,31 @@ func TestCloneCmd_CloneError(t *testing.T) {
 	require.Error(t, cmd.Execute())
 }
 
+func TestCloneCmd_ProgressWrittenToStderr(t *testing.T) {
+	t.Parallel()
+
+	codeRoot := t.TempDir()
+	resolver := layout.NewResolver(codeRoot, "_default")
+	vcs := &stubVCS{
+		cloneEvents: []*pluginv1.CloneProgressEvent{
+			{Event: &pluginv1.CloneProgressEvent_ProgressLine{ProgressLine: "Cloning into 'swm'..."}},
+			{Event: &pluginv1.CloneProgressEvent_ProjectId{
+				ProjectId: &pluginv1.ProjectID{Host: testGitHubHost, Segments: []string{testKalbasitOrg, testSWMRepo}},
+			}},
+		},
+	}
+	mgr := &stubMgr{vcs: vcs}
+
+	var errBuf strings.Builder
+
+	cmd := cli.NewCloneCmd(mgr, resolver, hookexec.Noop)
+	cmd.SetArgs([]string{testSSHURL})
+	cmd.SetErr(&errBuf)
+
+	require.NoError(t, cmd.Execute())
+	require.Contains(t, errBuf.String(), "Cloning into 'swm'...")
+}
+
 // stubMgr implements cli.PluginManager.
 type stubMgr struct {
 	vcs  pluginv1.VCSClient
@@ -145,13 +176,14 @@ type stubVCS struct {
 	cloneCalled bool
 	cloneDst    string
 	cloneErr    error
+	cloneEvents []*pluginv1.CloneProgressEvent
 }
 
 func (s *stubVCS) Clone(
 	_ context.Context,
 	req *pluginv1.CloneRequest,
 	_ ...grpc.CallOption,
-) (*pluginv1.CloneResponse, error) {
+) (grpc.ServerStreamingClient[pluginv1.CloneProgressEvent], error) {
 	s.cloneCalled = true
 	s.cloneDst = req.GetDestinationPath()
 
@@ -159,8 +191,42 @@ func (s *stubVCS) Clone(
 		return nil, s.cloneErr
 	}
 
-	return &pluginv1.CloneResponse{}, nil
+	events := s.cloneEvents
+	if events == nil {
+		events = []*pluginv1.CloneProgressEvent{
+			{Event: &pluginv1.CloneProgressEvent_ProjectId{
+				ProjectId: &pluginv1.ProjectID{Host: testGitHubHost, Segments: []string{testKalbasitOrg, testSWMRepo}},
+			}},
+		}
+	}
+
+	return &stubCloneStream{events: events}, nil
 }
+
+// stubCloneStream replays a fixed event sequence then returns io.EOF.
+type stubCloneStream struct {
+	events []*pluginv1.CloneProgressEvent
+	pos    int
+}
+
+func (s *stubCloneStream) CloseSend() error             { return nil }
+func (s *stubCloneStream) Context() context.Context     { return context.Background() }
+func (s *stubCloneStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+
+func (s *stubCloneStream) Recv() (*pluginv1.CloneProgressEvent, error) {
+	if s.pos >= len(s.events) {
+		return nil, io.EOF
+	}
+
+	evt := s.events[s.pos]
+	s.pos++
+
+	return evt, nil
+}
+
+func (s *stubCloneStream) RecvMsg(any) error    { return nil }
+func (s *stubCloneStream) SendMsg(any) error    { return nil }
+func (s *stubCloneStream) Trailer() metadata.MD { return nil }
 
 func (s *stubVCS) CreateWorktree(
 	context.Context,
@@ -199,7 +265,7 @@ func (s *stubVCS) ParseRemoteURL(
 	_ *pluginv1.ParseRemoteURLRequest,
 	_ ...grpc.CallOption,
 ) (*pluginv1.ProjectID, error) {
-	return &pluginv1.ProjectID{Host: "github.com", Segments: []string{"kalbasit", "swm"}}, nil
+	return &pluginv1.ProjectID{Host: testGitHubHost, Segments: []string{testKalbasitOrg, testSWMRepo}}, nil
 }
 
 func (s *stubVCS) RemoveWorktree(

--- a/cmd/swm/internal/cli/story/testhelpers_test.go
+++ b/cmd/swm/internal/cli/story/testhelpers_test.go
@@ -120,20 +120,44 @@ func (s *stubManager) Warm(_ context.Context, caps ...string) error {
 type stubVCSClient struct {
 	removeWorktreeCalled bool
 	parseRemoteURLFn     func(*pluginv1.ParseRemoteURLRequest) (*pluginv1.ProjectID, error)
-	cloneFn              func(*pluginv1.CloneRequest) (*pluginv1.CloneResponse, error)
+	cloneFn              func(*pluginv1.CloneRequest) (grpc.ServerStreamingClient[pluginv1.CloneProgressEvent], error)
 }
 
 func (s *stubVCSClient) Clone(
 	_ context.Context,
 	req *pluginv1.CloneRequest,
 	_ ...grpc.CallOption,
-) (*pluginv1.CloneResponse, error) {
+) (grpc.ServerStreamingClient[pluginv1.CloneProgressEvent], error) {
 	if s.cloneFn != nil {
 		return s.cloneFn(req)
 	}
 
-	return &pluginv1.CloneResponse{}, nil
+	return &noopCloneStream{}, nil
 }
+
+// noopCloneStream is a ServerStreamingClient that returns a single terminal
+// project_id event then EOF. Used in tests that don't care about clone output.
+type noopCloneStream struct{ done bool }
+
+func (n *noopCloneStream) CloseSend() error             { return nil }
+func (n *noopCloneStream) Context() context.Context     { return context.Background() }
+func (n *noopCloneStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+
+func (n *noopCloneStream) Recv() (*pluginv1.CloneProgressEvent, error) {
+	if n.done {
+		return nil, io.EOF
+	}
+
+	n.done = true
+
+	return &pluginv1.CloneProgressEvent{
+		Event: &pluginv1.CloneProgressEvent_ProjectId{ProjectId: &pluginv1.ProjectID{}},
+	}, nil
+}
+
+func (n *noopCloneStream) RecvMsg(any) error    { return nil }
+func (n *noopCloneStream) SendMsg(any) error    { return nil }
+func (n *noopCloneStream) Trailer() metadata.MD { return nil }
 
 func (s *stubVCSClient) CreateWorktree(
 	context.Context,

--- a/cmd/swm/internal/cli/workspace/open_test.go
+++ b/cmd/swm/internal/cli/workspace/open_test.go
@@ -1523,7 +1523,9 @@ type stubVCS struct {
 	createCalled bool
 }
 
-func (v *stubVCS) Clone(context.Context, *pluginv1.CloneRequest, ...grpc.CallOption) (*pluginv1.CloneResponse, error) {
+func (v *stubVCS) Clone(
+	context.Context, *pluginv1.CloneRequest, ...grpc.CallOption,
+) (grpc.ServerStreamingClient[pluginv1.CloneProgressEvent], error) {
 	panic("stub")
 }
 

--- a/nix/packages/swm-plugin-forge-github/default.nix
+++ b/nix/packages/swm-plugin-forge-github/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-daGfl2RfMia0m+LJ5Vbab7BTmZr3nsYp1A5tdim0M8Y=";
+          vendorHash = "sha256-0EEGQKEsHjfmEFIfX8Dw8QTJSDDt547xrVtc8NNr544=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-picker-fzf/default.nix
+++ b/nix/packages/swm-plugin-picker-fzf/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-2Ua8hCmWWVCadVRZUtnuE5Gd9iKECpJWe5wfm+JI8jk=";
+          vendorHash = "sha256-aFMj+Tg2B6xKw4dALkcbFUhqAXQdMVBwwyV2tGq5qH4=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-session-tmux/default.nix
+++ b/nix/packages/swm-plugin-session-tmux/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-LMxlmp3l9N07VXYw1KTgFMkTeeTBDxMsoinfvTCm2Sc=";
+          vendorHash = "sha256-Ez19IaB3fzuPLQru7swmwjTy2IFzGRVk5FGFyKb2yDo=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm-plugin-vcs-git/default.nix
+++ b/nix/packages/swm-plugin-vcs-git/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-VZGu8EAreBTV+DnavjWMEchPNjvQ6ln7oUvbP0g9Dhw=";
+          vendorHash = "sha256-JI+5JsNatRuwqRENoj8pOaZGcn21w08OuSUB5bDtEGk=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/swm/default.nix
+++ b/nix/packages/swm/default.nix
@@ -12,7 +12,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-81xgAXdoXpcf1/Bhd+DahFR7c97iIH4M2sTSKvojiuM=";
+          vendorHash = "sha256-LYfxn12fGeyAP/d9rrbqzA9XG41VAqNgqvDkZl+K4xU=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/openspec/changes/archive/2026-05-28-clone-progress-bar/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-28-clone-progress-bar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-28-clone-progress-bar/design.md
+++ b/openspec/changes/archive/2026-05-28-clone-progress-bar/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`swm clone` calls the VCS plugin's `Clone` RPC as a unary call. The plugin runs `git clone` via `exec.Cmd.Output()`, which buffers all output until the process exits. No feedback reaches the user during the clone. For large repositories this looks like a hung process.
+
+`git clone` already emits structured progress to stderr (object counts, percentages, transfer speeds) using `\r`-terminated lines when `--progress` is passed. The fix is to make the RPC server-streaming so the plugin can push those lines to the host in real time.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the unary `Clone` RPC with a server-streaming variant that emits progress lines during the clone.
+- Render git's native progress output in the terminal as the clone runs.
+- Deliver the resolved `ProjectID` via the stream (eliminating the need for a separate `CloneResponse`).
+
+**Non-Goals:**
+- Parsing or structuring git's progress output (percentages, object counts) — forwarding raw lines is sufficient.
+- Adding a progress bar library; forwarding git's `\r`-based lines to stderr is enough.
+- Adding progress to `AddWorktree` or other VCS operations.
+- Backwards compatibility shims — there are no external plugin implementations yet.
+
+## Decisions
+
+### 1. `CloneProgressEvent` uses a `oneof` to multiplex progress and result
+
+```protobuf
+message CloneProgressEvent {
+  oneof event {
+    string progress_line = 1;  // raw line from git stderr
+    ProjectID project_id  = 2; // terminal event: clone succeeded
+  }
+}
+```
+
+**Why**: A single stream carries both in-flight progress and the final result without needing a second RPC or an out-of-band return value. The host reads until EOF; the last event is always a `project_id`.
+
+Alternative considered: keep `CloneResponse` as a trailer metadata field. Rejected — gRPC trailers in Go require more ceremony and the `oneof` pattern is already established by `ListBranches` returning `stream Branch`.
+
+### 2. Pass `--progress` to git and pipe stderr line-by-line
+
+The plugin switches from `cmd.Output()` to `cmd.StderrPipe()` + a goroutine that reads and streams each `\r`- or `\n`-terminated segment. `--progress` forces git to emit progress even when stderr is not a TTY (which it won't be — it's a pipe to the gRPC stream).
+
+**Why**: Minimal change to the plugin's structure; `StderrPipe` is the standard Go way to read subprocess stderr incrementally.
+
+### 3. CLI forwards raw progress bytes to its own stderr
+
+The host reads each `CloneProgressEvent` from the stream. For `progress_line` events it writes the line directly to `cmd.ErrOrStderr()`. For the terminal `project_id` event it stores the ID and continues to drain the stream until EOF, then uses the ID for the post-clone hook and final message.
+
+**Why**: Git's `\r`-based in-place updates render correctly when written to a real TTY. No extra library needed. If stdout/stderr is not a TTY (e.g., piped to a script) the progress lines are still visible on stderr, matching `git clone` behaviour.
+
+### 4. `CloneResponse` proto message is removed
+
+It only contained `project_id`, which is now the terminal `CloneProgressEvent`. Removing it keeps the proto surface clean.
+
+## Risks / Trade-offs
+
+- [git stderr encoding] git writes progress using `\r` without `\n`; the line-reader must split on both `\r` and `\n` to avoid buffering an entire in-place update sequence as one giant line. → Mitigation: use a `bufio.Scanner` with a custom split function that treats `\r` and `\n` as delimiters.
+- [stream back-pressure] If the host is slow to read (e.g., a future non-interactive consumer), the gRPC send buffer fills and the plugin blocks. → Acceptable: progress lines are small; real-world clones won't saturate the buffer.
+- [proto regeneration] Changing the RPC signature regenerates `.pb.go` and `_grpc.pb.go` in `proto/` and invalidates all five Nix `vendorHash` values. → Mitigation: run `task update-nix-vendor-hashes` as part of the implementation.
+
+## Migration Plan
+
+1. Edit `proto/swm/plugin/v1/vcs.proto`: remove `CloneResponse`, add `CloneProgressEvent`, change `Clone` signature.
+2. Run `task proto` (or equivalent) to regenerate `.pb.go` files.
+3. Update `plugins/vcs-git` to implement the new `Clone` server-streaming method.
+4. Update `cmd/swm/internal/cli/clone.go` to consume the stream.
+5. Run `task update-nix-vendor-hashes`.
+6. Run `task fmt lint test` to verify.
+
+No rollback complexity — this is a monorepo change with no external consumers.

--- a/openspec/changes/archive/2026-05-28-clone-progress-bar/proposal.md
+++ b/openspec/changes/archive/2026-05-28-clone-progress-bar/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`swm clone` silently waits while cloning large repositories — there is no progress feedback, leaving users uncertain whether the operation is running or stalled. Since `git clone` already emits progress to stderr, we should surface it through the plugin protocol and render it in the terminal.
+
+## What Changes
+
+- **BREAKING**: Replace the unary `Clone(CloneRequest) returns (CloneResponse)` RPC in `proto/swm/plugin/v1/vcs.proto` with a server-streaming `Clone(CloneRequest) returns (stream CloneProgressEvent)`. `CloneResponse` is removed; `CloneProgressEvent` carries both progress lines and the final `ProjectID`.
+- Update `swm-plugin-vcs-git` to implement the new streaming `Clone`: pipe git's stderr live through the gRPC stream and send a terminal event with the resolved `ProjectID` on success.
+- Update `cmd/swm clone` to consume the stream and render a live progress indicator to the terminal (forwarding git's progress lines verbatim or using a simple spinner/bar).
+
+## Non-goals
+
+- Parsing or structuring git's progress output (percentages, object counts) — forwarding raw lines is sufficient.
+- Adding progress to `AddWorktree` or other VCS operations.
+- Supporting non-git VCS plugins in this change.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `vcs-git` — replaces unary `Clone` with streaming `Clone`; requirement changes: clone must emit progress events to the caller instead of running silently, and return the resolved `ProjectID` as a terminal stream event.
+
+## Impact
+
+- `proto/swm/plugin/v1/vcs.proto` — replace unary `Clone` RPC with streaming variant; remove `CloneResponse`; add `CloneProgressEvent`; regenerate `.pb.go` files; run `task update-nix-vendor-hashes` after.
+- `plugins/vcs-git/internal/vcs/git.go` — implement streaming `Clone`; pipe git stderr live; send terminal event with `ProjectID`.
+- `cmd/swm/internal/cli/clone.go` — consume the stream; render progress to stderr.
+- Affected capability surface: **vcs**.
+- Proto note: breaking change within `proto/swm/plugin/v1/` — all VCS plugin implementations must be updated.

--- a/openspec/changes/archive/2026-05-28-clone-progress-bar/specs/vcs-git/spec.md
+++ b/openspec/changes/archive/2026-05-28-clone-progress-bar/specs/vcs-git/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Clone to canonical path
+The VCS plugin MUST implement `Clone` as a server-streaming RPC that emits progress during the clone and delivers the resolved `ProjectID` as the terminal stream event.
+
+- The plugin runs `git clone --progress <url> <destination_path>`.
+- Each `\r`- or `\n`-terminated segment from git's stderr is sent as a `CloneProgressEvent{progress_line: <segment>}`.
+- On success the plugin sends a final `CloneProgressEvent{project_id: <id>}` and closes the stream.
+- On failure the plugin returns a gRPC error status; no terminal `project_id` event is sent.
+- If `destination_path` already contains a `.git` directory the plugin returns `codes.AlreadyExists` without running `git clone`.
+
+#### Scenario: Successful clone emits progress then project ID
+- **WHEN** `Clone({url: "git@github.com:kalbasit/swm.git", destination_path: "/tmp/code/repositories/github.com/kalbasit/swm"})` is called and the remote is reachable
+- **THEN** one or more `CloneProgressEvent{progress_line: ...}` messages are streamed as git runs, followed by a final `CloneProgressEvent{project_id: {host: "github.com", segments: ["kalbasit", "swm"]}}`, after which the stream closes with no error
+
+#### Scenario: Already cloned
+- **WHEN** `Clone` is called with a `destination_path` that already contains a `.git` directory
+- **THEN** a gRPC `AlreadyExists` status error is returned without running `git clone` and the stream carries no events
+
+#### Scenario: git clone failure
+- **WHEN** `git clone` exits non-zero (e.g., repository not found, auth error)
+- **THEN** a gRPC `Internal` status error is returned with stderr captured in the message and the stream carries no terminal `project_id` event
+
+## REMOVED Requirements
+
+_(none — all other Clone to canonical path scenarios are superseded by the MODIFIED block above)_

--- a/openspec/changes/archive/2026-05-28-clone-progress-bar/tasks.md
+++ b/openspec/changes/archive/2026-05-28-clone-progress-bar/tasks.md
@@ -1,0 +1,22 @@
+## 1. Proto: Update VCS service definition
+
+- [x] 1.1 Edit `proto/swm/plugin/v1/vcs.proto` (`proto`): remove `CloneResponse`; add `CloneProgressEvent` message with `oneof event { string progress_line = 1; ProjectID project_id = 2; }`; change `Clone` RPC signature to `rpc Clone(CloneRequest) returns (stream CloneProgressEvent)`
+- [x] 1.2 Run `task proto` to regenerate `proto/swm/plugin/v1/vcs.pb.go` and `proto/swm/plugin/v1/vcs_grpc.pb.go` (`proto`)
+
+## 2. VCS Plugin: Implement streaming Clone
+
+- [x] 2.1 Write failing test in `plugins/vcs-git/internal/vcs/git_test.go` (`plugins/vcs-git`): test that `Clone` streams at least one `progress_line` event and a terminal `project_id` event, with separate cases for already-cloned (`AlreadyExists`) and git failure (`Internal`)
+- [x] 2.2 Update `plugins/vcs-git/internal/vcs/git.go` (`plugins/vcs-git`): change `Clone` to the server-streaming signature; pass `--progress` to git; switch from `cmd.Output()` to `cmd.StderrPipe()` with a `bufio.Scanner` splitting on `\r` and `\n`; stream each segment as `CloneProgressEvent{ProgressLine: seg}`; on success resolve the `ProjectID` and send a terminal `CloneProgressEvent{ProjectId: id}` before returning nil
+
+## 3. Host CLI: Consume streaming Clone
+
+- [x] 3.1 Write failing test in `cmd/swm/internal/cli/clone_test.go` (`cmd/swm`): update `stubVCS.Clone` to match the new `grpc.ServerStreamingClient[pluginv1.CloneProgressEvent]` return type; add a test case asserting progress lines are written to stderr; update existing success/error test cases for the streaming interface
+- [x] 3.2 Update `cmd/swm/internal/cli/clone.go` (`cmd/swm`): replace the unary `vcs.Clone()` call with a streaming call; loop over stream events writing `progress_line` events to `cmd.ErrOrStderr()`; capture the `project_id` from the terminal event for use in the post-clone hook and final "cloned to" message
+
+## 4. Nix: Update vendor hashes
+
+- [x] 4.1 Run `task update-nix-vendor-hashes` (`nix`) to patch the `vendorHash` in all five Nix packages (`swm`, `swm-plugin-forge-github`, `swm-plugin-picker-fzf`, `swm-plugin-session-tmux`, `swm-plugin-vcs-git`) after the proto regeneration
+
+## 5. Verification
+
+- [x] 5.1 Run `task fmt lint test` across all modules and confirm all exit 0 (`all modules`)

--- a/openspec/specs/vcs-git/spec.md
+++ b/openspec/specs/vcs-git/spec.md
@@ -14,19 +14,25 @@
 - **THEN** a gRPC status error with code `InvalidArgument` is returned
 
 ### Requirement: Clone to canonical path
-`vcs-git` SHALL implement `VCS.Clone(url, canonical_path)` by running `git clone <url> <canonical_path>`. The `canonical_path` is provided by the host (derived from `ParseRemoteURL` output). The plugin MUST NOT compute or choose the destination path. Clone SHALL fail with `AlreadyExists` gRPC status if the canonical path already contains a `.git` directory.
+The VCS plugin MUST implement `Clone` as a server-streaming RPC that emits progress during the clone and delivers the resolved `ProjectID` as the terminal stream event.
 
-#### Scenario: Successful clone
-- **WHEN** `Clone({url: "git@github.com:kalbasit/swm.git", canonical_path: "/tmp/code/repositories/github.com/kalbasit/swm"})` is called
-- **THEN** `git clone` is executed and the repository is present at `canonical_path`
+- The plugin runs `git clone --progress <url> <destination_path>`.
+- Each `\r`- or `\n`-terminated segment from git's stderr is sent as a `CloneProgressEvent{progress_line: <segment>}`.
+- On success the plugin sends a final `CloneProgressEvent{project_id: <id>}` and closes the stream.
+- On failure the plugin returns a gRPC error status; no terminal `project_id` event is sent.
+- If `destination_path` already contains a `.git` directory the plugin returns `codes.AlreadyExists` without running `git clone`.
+
+#### Scenario: Successful clone emits progress then project ID
+- **WHEN** `Clone({url: "git@github.com:kalbasit/swm.git", destination_path: "/tmp/code/repositories/github.com/kalbasit/swm"})` is called and the remote is reachable
+- **THEN** one or more `CloneProgressEvent{progress_line: ...}` messages are streamed as git runs, followed by a final `CloneProgressEvent{project_id: {host: "github.com", segments: ["kalbasit", "swm"]}}`, after which the stream closes with no error
 
 #### Scenario: Already cloned
-- **WHEN** `Clone` is called with a `canonical_path` that already contains a `.git` directory
-- **THEN** a gRPC `AlreadyExists` status error is returned without running `git clone`
+- **WHEN** `Clone` is called with a `destination_path` that already contains a `.git` directory
+- **THEN** a gRPC `AlreadyExists` status error is returned without running `git clone` and the stream carries no events
 
 #### Scenario: git clone failure
 - **WHEN** `git clone` exits non-zero (e.g., repository not found, auth error)
-- **THEN** a gRPC `Internal` status error is returned with stderr captured in the message
+- **THEN** a gRPC `Internal` status error is returned with stderr captured in the message and the stream carries no terminal `project_id` event
 
 ### Requirement: CreateWorktree for a story
 `vcs-git` SHALL implement `VCS.CreateWorktree({canonical_path, worktree_path, branch_name})` by running `git -C <canonical_path> worktree add <worktree_path> <branch_name>`. If the branch does not exist, it SHALL be created (`--orphan` is not used; `git worktree add -b <branch>` creates it). The worktree directory's parent MUST be created if absent.

--- a/plugins/vcs-git/internal/vcs/git.go
+++ b/plugins/vcs-git/internal/vcs/git.go
@@ -2,6 +2,7 @@
 package vcs
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -39,21 +40,77 @@ func New() (*Git, error) {
 	return &Git{gitBin: bin}, nil
 }
 
-// Clone clones a repository to the given destination path.
-func (g *Git) Clone(ctx context.Context, req *pluginv1.CloneRequest) (*pluginv1.CloneResponse, error) {
+// Clone clones a repository to the given destination path, streaming progress
+// events from git's stderr followed by a terminal project_id event on success.
+func (g *Git) Clone(req *pluginv1.CloneRequest, stream pluginv1.VCS_CloneServer) error {
 	if _, err := os.Stat(filepath.Join(req.GetDestinationPath(), ".git")); err == nil {
-		return nil, status.Errorf(codes.AlreadyExists, "repository already exists at %s", req.GetDestinationPath())
+		return status.Errorf(codes.AlreadyExists, "repository already exists at %s", req.GetDestinationPath())
 	}
 
-	if _, err := g.run(ctx, "clone", req.GetUrl(), req.GetDestinationPath()); err != nil {
-		return nil, err
+	//nolint:gosec // gitBin from exec.LookPath; args are controlled
+	cmd := exec.CommandContext(stream.Context(), g.gitBin, "clone", "--progress", req.GetUrl(), req.GetDestinationPath())
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return status.Errorf(codes.Internal, "git clone: stderr pipe: %v", err)
 	}
 
-	// Best-effort: parse the URL into a ProjectID. Local paths (used in tests)
-	// won't parse; return a valid response with nil ProjectId in that case.
-	id, _ := parseURL(req.GetUrl()) //nolint:errcheck // best-effort URL parse; nil ProjectId is valid
+	if err := cmd.Start(); err != nil {
+		return status.Errorf(codes.Internal, "git clone: start: %v", err)
+	}
 
-	return &pluginv1.CloneResponse{ProjectId: id}, nil
+	// Stream each \r- or \n-delimited progress segment from git's stderr.
+	var stderrBuf strings.Builder
+
+	scanner := bufio.NewScanner(stderr)
+	scanner.Split(splitCR)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		stderrBuf.WriteString(line)
+
+		if line == "" {
+			continue
+		}
+
+		if sendErr := stream.Send(&pluginv1.CloneProgressEvent{
+			Event: &pluginv1.CloneProgressEvent_ProgressLine{ProgressLine: line},
+		}); sendErr != nil {
+			_ = cmd.Wait() //nolint:errcheck // stream failed; drain process before returning
+
+			return sendErr
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return status.Errorf(codes.Internal, "git clone %s: %s", req.GetUrl(), stderrBuf.String())
+	}
+
+	id, _ := parseURL(req.GetUrl()) //nolint:errcheck // best-effort; nil ProjectId is valid for unrecognized URLs
+
+	return stream.Send(&pluginv1.CloneProgressEvent{
+		Event: &pluginv1.CloneProgressEvent_ProjectId{ProjectId: id},
+	})
+}
+
+// splitCR is a bufio.SplitFunc that splits on \r or \n so git's \r-based
+// in-place progress updates are each emitted as separate tokens.
+func splitCR(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	for i, b := range data {
+		if b == '\r' || b == '\n' {
+			return i + 1, data[:i], nil
+		}
+	}
+
+	if atEOF {
+		return len(data), data, nil
+	}
+
+	return 0, nil, nil
 }
 
 // CreateWorktree creates a git worktree for a story.
@@ -180,6 +237,13 @@ func parseURL(raw string) (*pluginv1.ProjectID, error) {
 		segments := strings.Split(m[2], "/")
 
 		return &pluginv1.ProjectID{Host: host, Segments: segments}, nil
+	}
+
+	// Absolute local path (no scheme) — treat as localhost.
+	if after, ok := strings.CutPrefix(raw, "/"); ok {
+		path := strings.TrimSuffix(after, ".git")
+
+		return &pluginv1.ProjectID{Host: "localhost", Segments: strings.Split(path, "/")}, nil
 	}
 
 	// All other formats (HTTPS, file://, git+ssh, etc.)

--- a/plugins/vcs-git/internal/vcs/git.go
+++ b/plugins/vcs-git/internal/vcs/git.go
@@ -67,11 +67,12 @@ func (g *Git) Clone(req *pluginv1.CloneRequest, stream pluginv1.VCS_CloneServer)
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		stderrBuf.WriteString(line)
 
-		if line == "" {
+		if strings.TrimRight(line, "\r\n") == "" {
 			continue
 		}
+
+		stderrBuf.WriteString(line)
 
 		if sendErr := stream.Send(&pluginv1.CloneProgressEvent{
 			Event: &pluginv1.CloneProgressEvent_ProgressLine{ProgressLine: line},
@@ -102,7 +103,7 @@ func splitCR(data []byte, atEOF bool) (advance int, token []byte, err error) {
 
 	for i, b := range data {
 		if b == '\r' || b == '\n' {
-			return i + 1, data[:i], nil
+			return i + 1, data[:i+1], nil
 		}
 	}
 

--- a/plugins/vcs-git/internal/vcs/git.go
+++ b/plugins/vcs-git/internal/vcs/git.go
@@ -77,10 +77,18 @@ func (g *Git) Clone(req *pluginv1.CloneRequest, stream pluginv1.VCS_CloneServer)
 		if sendErr := stream.Send(&pluginv1.CloneProgressEvent{
 			Event: &pluginv1.CloneProgressEvent_ProgressLine{ProgressLine: line},
 		}); sendErr != nil {
-			_ = cmd.Wait() //nolint:errcheck // stream failed; drain process before returning
+			_ = cmd.Process.Kill() //nolint:errcheck // kill git so the stderr pipe drains and Wait doesn't block
+			_ = cmd.Wait()         //nolint:errcheck // drain process resources before returning
 
 			return sendErr
 		}
+	}
+
+	if scanErr := scanner.Err(); scanErr != nil {
+		_ = cmd.Process.Kill() //nolint:errcheck // kill git so Wait doesn't block after scanner failure
+		_ = cmd.Wait()         //nolint:errcheck // drain process resources
+
+		return status.Errorf(codes.Internal, "git clone: reading progress: %v", scanErr)
 	}
 
 	if err := cmd.Wait(); err != nil {

--- a/plugins/vcs-git/internal/vcs/git_test.go
+++ b/plugins/vcs-git/internal/vcs/git_test.go
@@ -7,11 +7,45 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 
 	pluginv1 "github.com/kalbasit/swm/proto/swm/plugin/v1"
 
 	"github.com/kalbasit/swm/plugins/vcs-git/internal/vcs"
 )
+
+// cloneStream captures CloneProgressEvent messages sent during a streaming Clone call.
+type cloneStream struct {
+	events []*pluginv1.CloneProgressEvent
+	ctx    context.Context //nolint:containedctx // needed to implement grpc.ServerStream
+}
+
+func newCloneStream() *cloneStream {
+	return &cloneStream{ctx: context.Background()}
+}
+
+func (s *cloneStream) Context() context.Context { return s.ctx }
+func (s *cloneStream) RecvMsg(any) error        { return nil }
+
+func (s *cloneStream) Send(evt *pluginv1.CloneProgressEvent) error {
+	s.events = append(s.events, evt)
+
+	return nil
+}
+
+func (s *cloneStream) SendHeader(metadata.MD) error { return nil }
+func (s *cloneStream) SendMsg(any) error            { return nil }
+func (s *cloneStream) SetHeader(metadata.MD) error  { return nil }
+func (s *cloneStream) SetTrailer(metadata.MD)       {}
+
+// lastEvent returns the last event captured, or nil if none.
+func (s *cloneStream) lastEvent() *pluginv1.CloneProgressEvent {
+	if len(s.events) == 0 {
+		return nil
+	}
+
+	return s.events[len(s.events)-1]
+}
 
 const gitBin = "git"
 
@@ -91,19 +125,23 @@ func TestParseRemoteURL_Invalid(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestClone(t *testing.T) {
+func TestClone_Success(t *testing.T) {
 	t.Parallel()
 
 	src := initRepo(t)
 	dst := filepath.Join(t.TempDir(), "clone")
 
 	g := newGit(t)
-	_, err := g.Clone(context.Background(), &pluginv1.CloneRequest{
-		Url:             src,
-		DestinationPath: dst,
-	})
+	stream := newCloneStream()
+	err := g.Clone(&pluginv1.CloneRequest{Url: src, DestinationPath: dst}, stream)
 	require.NoError(t, err)
 	require.DirExists(t, filepath.Join(dst, ".git"))
+
+	// The terminal event must be a project_id.
+	last := stream.lastEvent()
+	require.NotNil(t, last, "expected at least one event")
+	require.NotNil(t, last.GetProjectId(), "last event must carry project_id")
+	require.Equal(t, "localhost", last.GetProjectId().GetHost())
 }
 
 func TestClone_AlreadyExists(t *testing.T) {
@@ -113,11 +151,28 @@ func TestClone_AlreadyExists(t *testing.T) {
 	g := newGit(t)
 
 	// Clone into src itself — src already has .git, so AlreadyExists is returned.
-	_, err := g.Clone(context.Background(), &pluginv1.CloneRequest{
-		Url:             src,
-		DestinationPath: src,
-	})
+	stream := newCloneStream()
+	err := g.Clone(&pluginv1.CloneRequest{Url: src, DestinationPath: src}, stream)
 	require.Error(t, err)
+	require.Empty(t, stream.events, "AlreadyExists must send no events")
+}
+
+func TestClone_GitFailure(t *testing.T) {
+	t.Parallel()
+
+	dst := filepath.Join(t.TempDir(), "clone")
+	g := newGit(t)
+
+	stream := newCloneStream()
+	err := g.Clone(&pluginv1.CloneRequest{
+		Url:             "/nonexistent/repo/that/does/not/exist",
+		DestinationPath: dst,
+	}, stream)
+	require.Error(t, err)
+	// On failure, no terminal project_id event must be sent (progress lines are ok).
+	if last := stream.lastEvent(); last != nil {
+		require.Nil(t, last.GetProjectId(), "git failure must not emit a terminal project_id event")
+	}
 }
 
 func TestCreateAndRemoveWorktree(t *testing.T) {

--- a/proto/swm/plugin/v1/vcs.pb.go
+++ b/proto/swm/plugin/v1/vcs.pb.go
@@ -129,28 +129,33 @@ func (x *CloneRequest) GetDestinationPath() string {
 	return ""
 }
 
-// CloneResponse returns the resolved project identity after cloning.
-type CloneResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ProjectId     *ProjectID             `protobuf:"bytes,1,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+// CloneProgressEvent is streamed by Clone: progress lines during the clone,
+// then a terminal project_id event on success.
+type CloneProgressEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Event:
+	//
+	//	*CloneProgressEvent_ProgressLine
+	//	*CloneProgressEvent_ProjectId
+	Event         isCloneProgressEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *CloneResponse) Reset() {
-	*x = CloneResponse{}
+func (x *CloneProgressEvent) Reset() {
+	*x = CloneProgressEvent{}
 	mi := &file_swm_plugin_v1_vcs_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *CloneResponse) String() string {
+func (x *CloneProgressEvent) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*CloneResponse) ProtoMessage() {}
+func (*CloneProgressEvent) ProtoMessage() {}
 
-func (x *CloneResponse) ProtoReflect() protoreflect.Message {
+func (x *CloneProgressEvent) ProtoReflect() protoreflect.Message {
 	mi := &file_swm_plugin_v1_vcs_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -162,17 +167,51 @@ func (x *CloneResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use CloneResponse.ProtoReflect.Descriptor instead.
-func (*CloneResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use CloneProgressEvent.ProtoReflect.Descriptor instead.
+func (*CloneProgressEvent) Descriptor() ([]byte, []int) {
 	return file_swm_plugin_v1_vcs_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *CloneResponse) GetProjectId() *ProjectID {
+func (x *CloneProgressEvent) GetEvent() isCloneProgressEvent_Event {
 	if x != nil {
-		return x.ProjectId
+		return x.Event
 	}
 	return nil
 }
+
+func (x *CloneProgressEvent) GetProgressLine() string {
+	if x != nil {
+		if x, ok := x.Event.(*CloneProgressEvent_ProgressLine); ok {
+			return x.ProgressLine
+		}
+	}
+	return ""
+}
+
+func (x *CloneProgressEvent) GetProjectId() *ProjectID {
+	if x != nil {
+		if x, ok := x.Event.(*CloneProgressEvent_ProjectId); ok {
+			return x.ProjectId
+		}
+	}
+	return nil
+}
+
+type isCloneProgressEvent_Event interface {
+	isCloneProgressEvent_Event()
+}
+
+type CloneProgressEvent_ProgressLine struct {
+	ProgressLine string `protobuf:"bytes,1,opt,name=progress_line,json=progressLine,proto3,oneof"`
+}
+
+type CloneProgressEvent_ProjectId struct {
+	ProjectId *ProjectID `protobuf:"bytes,2,opt,name=project_id,json=projectId,proto3,oneof"`
+}
+
+func (*CloneProgressEvent_ProgressLine) isCloneProgressEvent_Event() {}
+
+func (*CloneProgressEvent_ProjectId) isCloneProgressEvent_Event() {}
 
 // ParseRemoteURLRequest asks the plugin to parse a URL into a ProjectID.
 type ParseRemoteURLRequest struct {
@@ -527,10 +566,12 @@ const file_swm_plugin_v1_vcs_proto_rawDesc = "" +
 	"\x0fproject_markers\x18\x02 \x03(\tR\x0eprojectMarkers\"K\n" +
 	"\fCloneRequest\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12)\n" +
-	"\x10destination_path\x18\x02 \x01(\tR\x0fdestinationPath\"H\n" +
-	"\rCloneResponse\x127\n" +
+	"\x10destination_path\x18\x02 \x01(\tR\x0fdestinationPath\"\x7f\n" +
+	"\x12CloneProgressEvent\x12%\n" +
+	"\rprogress_line\x18\x01 \x01(\tH\x00R\fprogressLine\x129\n" +
 	"\n" +
-	"project_id\x18\x01 \x01(\v2\x18.swm.plugin.v1.ProjectIDR\tprojectId\")\n" +
+	"project_id\x18\x02 \x01(\v2\x18.swm.plugin.v1.ProjectIDH\x00R\tprojectIdB\a\n" +
+	"\x05event\")\n" +
 	"\x15ParseRemoteURLRequest\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\"\xd2\x01\n" +
 	"\x15CreateWorktreeRequest\x127\n" +
@@ -558,10 +599,10 @@ const file_swm_plugin_v1_vcs_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1b\n" +
 	"\tis_remote\x18\x02 \x01(\bR\bisRemote\x12\x1d\n" +
 	"\n" +
-	"is_current\x18\x03 \x01(\bR\tisCurrent2\x8f\x04\n" +
+	"is_current\x18\x03 \x01(\bR\tisCurrent2\x96\x04\n" +
 	"\x03VCS\x124\n" +
-	"\x04Info\x12\x14.swm.plugin.v1.Empty\x1a\x16.swm.plugin.v1.VCSInfo\x12B\n" +
-	"\x05Clone\x12\x1b.swm.plugin.v1.CloneRequest\x1a\x1c.swm.plugin.v1.CloneResponse\x12P\n" +
+	"\x04Info\x12\x14.swm.plugin.v1.Empty\x1a\x16.swm.plugin.v1.VCSInfo\x12I\n" +
+	"\x05Clone\x12\x1b.swm.plugin.v1.CloneRequest\x1a!.swm.plugin.v1.CloneProgressEvent0\x01\x12P\n" +
 	"\x0eParseRemoteURL\x12$.swm.plugin.v1.ParseRemoteURLRequest\x1a\x18.swm.plugin.v1.ProjectID\x12L\n" +
 	"\x0eCreateWorktree\x12$.swm.plugin.v1.CreateWorktreeRequest\x1a\x14.swm.plugin.v1.Empty\x12L\n" +
 	"\x0eRemoveWorktree\x12$.swm.plugin.v1.RemoveWorktreeRequest\x1a\x14.swm.plugin.v1.Empty\x12S\n" +
@@ -584,7 +625,7 @@ var file_swm_plugin_v1_vcs_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_swm_plugin_v1_vcs_proto_goTypes = []any{
 	(*VCSInfo)(nil),               // 0: swm.plugin.v1.VCSInfo
 	(*CloneRequest)(nil),          // 1: swm.plugin.v1.CloneRequest
-	(*CloneResponse)(nil),         // 2: swm.plugin.v1.CloneResponse
+	(*CloneProgressEvent)(nil),    // 2: swm.plugin.v1.CloneProgressEvent
 	(*ParseRemoteURLRequest)(nil), // 3: swm.plugin.v1.ParseRemoteURLRequest
 	(*CreateWorktreeRequest)(nil), // 4: swm.plugin.v1.CreateWorktreeRequest
 	(*RemoveWorktreeRequest)(nil), // 5: swm.plugin.v1.RemoveWorktreeRequest
@@ -597,7 +638,7 @@ var file_swm_plugin_v1_vcs_proto_goTypes = []any{
 }
 var file_swm_plugin_v1_vcs_proto_depIdxs = []int32{
 	9,  // 0: swm.plugin.v1.VCSInfo.plugin_info:type_name -> swm.plugin.v1.PluginInfo
-	10, // 1: swm.plugin.v1.CloneResponse.project_id:type_name -> swm.plugin.v1.ProjectID
+	10, // 1: swm.plugin.v1.CloneProgressEvent.project_id:type_name -> swm.plugin.v1.ProjectID
 	10, // 2: swm.plugin.v1.CreateWorktreeRequest.project_id:type_name -> swm.plugin.v1.ProjectID
 	10, // 3: swm.plugin.v1.RemoveWorktreeRequest.project_id:type_name -> swm.plugin.v1.ProjectID
 	10, // 4: swm.plugin.v1.ListBranchesRequest.project_id:type_name -> swm.plugin.v1.ProjectID
@@ -609,7 +650,7 @@ var file_swm_plugin_v1_vcs_proto_depIdxs = []int32{
 	6,  // 10: swm.plugin.v1.VCS.DetectProjectAtPath:input_type -> swm.plugin.v1.DetectAtPathRequest
 	7,  // 11: swm.plugin.v1.VCS.ListBranches:input_type -> swm.plugin.v1.ListBranchesRequest
 	0,  // 12: swm.plugin.v1.VCS.Info:output_type -> swm.plugin.v1.VCSInfo
-	2,  // 13: swm.plugin.v1.VCS.Clone:output_type -> swm.plugin.v1.CloneResponse
+	2,  // 13: swm.plugin.v1.VCS.Clone:output_type -> swm.plugin.v1.CloneProgressEvent
 	10, // 14: swm.plugin.v1.VCS.ParseRemoteURL:output_type -> swm.plugin.v1.ProjectID
 	11, // 15: swm.plugin.v1.VCS.CreateWorktree:output_type -> swm.plugin.v1.Empty
 	11, // 16: swm.plugin.v1.VCS.RemoveWorktree:output_type -> swm.plugin.v1.Empty
@@ -628,6 +669,10 @@ func file_swm_plugin_v1_vcs_proto_init() {
 		return
 	}
 	file_swm_plugin_v1_common_proto_init()
+	file_swm_plugin_v1_vcs_proto_msgTypes[2].OneofWrappers = []any{
+		(*CloneProgressEvent_ProgressLine)(nil),
+		(*CloneProgressEvent_ProjectId)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/proto/swm/plugin/v1/vcs.proto
+++ b/proto/swm/plugin/v1/vcs.proto
@@ -20,9 +20,13 @@ message CloneRequest {
   string destination_path = 2;
 }
 
-// CloneResponse returns the resolved project identity after cloning.
-message CloneResponse {
-  ProjectID project_id = 1;
+// CloneProgressEvent is streamed by Clone: progress lines during the clone,
+// then a terminal project_id event on success.
+message CloneProgressEvent {
+  oneof event {
+    string progress_line = 1;
+    ProjectID project_id = 2;
+  }
 }
 
 // ParseRemoteURLRequest asks the plugin to parse a URL into a ProjectID.
@@ -67,7 +71,7 @@ message Branch {
 // VCS is implemented by version-control plugins (e.g. vcs-git).
 service VCS {
   rpc Info(Empty) returns (VCSInfo);
-  rpc Clone(CloneRequest) returns (CloneResponse);
+  rpc Clone(CloneRequest) returns (stream CloneProgressEvent);
   rpc ParseRemoteURL(ParseRemoteURLRequest) returns (ProjectID);
   rpc CreateWorktree(CreateWorktreeRequest) returns (Empty);
   rpc RemoveWorktree(RemoveWorktreeRequest) returns (Empty);

--- a/proto/swm/plugin/v1/vcs_grpc.pb.go
+++ b/proto/swm/plugin/v1/vcs_grpc.pb.go
@@ -35,7 +35,7 @@ const (
 // VCS is implemented by version-control plugins (e.g. vcs-git).
 type VCSClient interface {
 	Info(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*VCSInfo, error)
-	Clone(ctx context.Context, in *CloneRequest, opts ...grpc.CallOption) (*CloneResponse, error)
+	Clone(ctx context.Context, in *CloneRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CloneProgressEvent], error)
 	ParseRemoteURL(ctx context.Context, in *ParseRemoteURLRequest, opts ...grpc.CallOption) (*ProjectID, error)
 	CreateWorktree(ctx context.Context, in *CreateWorktreeRequest, opts ...grpc.CallOption) (*Empty, error)
 	RemoveWorktree(ctx context.Context, in *RemoveWorktreeRequest, opts ...grpc.CallOption) (*Empty, error)
@@ -61,15 +61,24 @@ func (c *vCSClient) Info(ctx context.Context, in *Empty, opts ...grpc.CallOption
 	return out, nil
 }
 
-func (c *vCSClient) Clone(ctx context.Context, in *CloneRequest, opts ...grpc.CallOption) (*CloneResponse, error) {
+func (c *vCSClient) Clone(ctx context.Context, in *CloneRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CloneProgressEvent], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(CloneResponse)
-	err := c.cc.Invoke(ctx, VCS_Clone_FullMethodName, in, out, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &VCS_ServiceDesc.Streams[0], VCS_Clone_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	x := &grpc.GenericClientStream[CloneRequest, CloneProgressEvent]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
 }
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type VCS_CloneClient = grpc.ServerStreamingClient[CloneProgressEvent]
 
 func (c *vCSClient) ParseRemoteURL(ctx context.Context, in *ParseRemoteURLRequest, opts ...grpc.CallOption) (*ProjectID, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -113,7 +122,7 @@ func (c *vCSClient) DetectProjectAtPath(ctx context.Context, in *DetectAtPathReq
 
 func (c *vCSClient) ListBranches(ctx context.Context, in *ListBranchesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Branch], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &VCS_ServiceDesc.Streams[0], VCS_ListBranches_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &VCS_ServiceDesc.Streams[1], VCS_ListBranches_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +146,7 @@ type VCS_ListBranchesClient = grpc.ServerStreamingClient[Branch]
 // VCS is implemented by version-control plugins (e.g. vcs-git).
 type VCSServer interface {
 	Info(context.Context, *Empty) (*VCSInfo, error)
-	Clone(context.Context, *CloneRequest) (*CloneResponse, error)
+	Clone(*CloneRequest, grpc.ServerStreamingServer[CloneProgressEvent]) error
 	ParseRemoteURL(context.Context, *ParseRemoteURLRequest) (*ProjectID, error)
 	CreateWorktree(context.Context, *CreateWorktreeRequest) (*Empty, error)
 	RemoveWorktree(context.Context, *RemoveWorktreeRequest) (*Empty, error)
@@ -155,8 +164,8 @@ type UnimplementedVCSServer struct{}
 func (UnimplementedVCSServer) Info(context.Context, *Empty) (*VCSInfo, error) {
 	return nil, status.Error(codes.Unimplemented, "method Info not implemented")
 }
-func (UnimplementedVCSServer) Clone(context.Context, *CloneRequest) (*CloneResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method Clone not implemented")
+func (UnimplementedVCSServer) Clone(*CloneRequest, grpc.ServerStreamingServer[CloneProgressEvent]) error {
+	return status.Error(codes.Unimplemented, "method Clone not implemented")
 }
 func (UnimplementedVCSServer) ParseRemoteURL(context.Context, *ParseRemoteURLRequest) (*ProjectID, error) {
 	return nil, status.Error(codes.Unimplemented, "method ParseRemoteURL not implemented")
@@ -211,23 +220,16 @@ func _VCS_Info_Handler(srv interface{}, ctx context.Context, dec func(interface{
 	return interceptor(ctx, in, info, handler)
 }
 
-func _VCS_Clone_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CloneRequest)
-	if err := dec(in); err != nil {
-		return nil, err
+func _VCS_Clone_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(CloneRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
 	}
-	if interceptor == nil {
-		return srv.(VCSServer).Clone(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: VCS_Clone_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(VCSServer).Clone(ctx, req.(*CloneRequest))
-	}
-	return interceptor(ctx, in, info, handler)
+	return srv.(VCSServer).Clone(m, &grpc.GenericServerStream[CloneRequest, CloneProgressEvent]{ServerStream: stream})
 }
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type VCS_CloneServer = grpc.ServerStreamingServer[CloneProgressEvent]
 
 func _VCS_ParseRemoteURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ParseRemoteURLRequest)
@@ -324,10 +326,6 @@ var VCS_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _VCS_Info_Handler,
 		},
 		{
-			MethodName: "Clone",
-			Handler:    _VCS_Clone_Handler,
-		},
-		{
 			MethodName: "ParseRemoteURL",
 			Handler:    _VCS_ParseRemoteURL_Handler,
 		},
@@ -345,6 +343,11 @@ var VCS_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "Clone",
+			Handler:       _VCS_Clone_Handler,
+			ServerStreams: true,
+		},
 		{
 			StreamName:    "ListBranches",
 			Handler:       _VCS_ListBranches_Handler,


### PR DESCRIPTION
## Summary

- Replaces the unary `Clone` RPC with a server-streaming one that emits `CloneProgressEvent` messages
- The vcs-git plugin passes `--progress` to git, reads its stderr via `StderrPipe`, and streams each `\r`- or `\n`-delimited segment as a `progress_line` event; the terminal event carries the resolved `ProjectID`
- The CLI consumes the stream and writes each progress chunk directly to stderr (preserving the original `\r`/`\n` delimiter), so in-place progress updates overwrite correctly and "done." lines advance normally — matching plain `git clone` output
- This is a breaking proto change; acceptable because no third-party VCS plugins exist yet

## Test plan

- [x] `task fmt lint test` passes across all modules
- [x] `TestClone_Success` — streams ≥1 progress events then a terminal `project_id`
- [x] `TestClone_AlreadyExists` — returns `codes.AlreadyExists`, no events
- [x] `TestClone_GitFailure` — returns `codes.Internal`, no terminal `project_id`
- [x] `TestCloneCmd_ProgressWrittenToStderr` — progress lines appear on stderr
- [x] Nix `vendorHash` updated for all five packages after proto regeneration